### PR TITLE
perf(sentry): reduce sampling to cut excessive span volume

### DIFF
--- a/api/monitoring/__init__.py
+++ b/api/monitoring/__init__.py
@@ -84,26 +84,23 @@ def init_sentry(app_environment: str) -> None:
             StarletteIntegration(
                 transaction_style="endpoint",
                 failed_request_status_codes={401, 403, 429, *range(500, 600)},
-                middleware_spans=True,
+                middleware_spans=False,
             ),
             FastApiIntegration(
                 transaction_style="endpoint",
                 failed_request_status_codes={401, 403, 429, *range(500, 600)},
-                middleware_spans=True,
+                middleware_spans=False,
             ),
             LoggingIntegration(level=logging.INFO, event_level=logging.ERROR),
         ],
-        traces_sample_rate=1.0,  # 100% sampling in production (low traffic)
-        profiles_sample_rate=1.0,  # 100% CPU profiling in production
-        profile_lifecycle="trace",
+        traces_sample_rate=0.1,  # 10% sampling to reduce span volume
         attach_stacktrace=True,
         send_default_pii=False,
         before_send=scrub_sensitive_data,
-        before_send_transaction=filter_transactions,  # Filter noisy transactions
+        before_send_transaction=filter_transactions,
         release=os.getenv("SENTRY_RELEASE", "unknown"),
         server_name=os.getenv("SERVER_NAME", "api"),
         max_breadcrumbs=50,
-        enable_tracing=True,
     )
 
     sentry_sdk.set_tag("service", "backend-api")

--- a/api/routes/sentry_test.py
+++ b/api/routes/sentry_test.py
@@ -39,7 +39,6 @@ async def sentry_health():
             "environment": sentry_sdk.get_client().options.get("environment"),
             "dsn_configured": bool(sentry_sdk.get_client().options.get("dsn")),
             "traces_sample_rate": sentry_sdk.get_client().options.get("traces_sample_rate"),
-            "profiles_sample_rate": sentry_sdk.get_client().options.get("profiles_sample_rate"),
         },
     )
 

--- a/frontend/sentry.edge.config.ts
+++ b/frontend/sentry.edge.config.ts
@@ -21,8 +21,8 @@ if (isProduction) {
     // Release tracking
     release: process.env.SENTRY_RELEASE || process.env.VERCEL_GIT_COMMIT_SHA || "unknown",
 
-    // Performance monitoring - 100% sampling for low-traffic site (15 visitors/day)
-    tracesSampleRate: 1.0,
+    // Performance monitoring - 10% sampling to reduce span volume
+    tracesSampleRate: 0.1,
 
     // Session replay not applicable on edge - explicitly set to 0
     replaysSessionSampleRate: 0,

--- a/frontend/sentry.server.config.ts
+++ b/frontend/sentry.server.config.ts
@@ -20,8 +20,8 @@ if (isProduction) {
     // Release tracking
     release: process.env.SENTRY_RELEASE || process.env.VERCEL_GIT_COMMIT_SHA || "unknown",
 
-    // Performance monitoring - 100% sampling for low-traffic site (15 visitors/day)
-    tracesSampleRate: 1.0,
+    // Performance monitoring - 10% sampling to reduce span volume
+    tracesSampleRate: 0.1,
 
     // Session replay not applicable on server - explicitly set to 0
     replaysSessionSampleRate: 0,

--- a/frontend/src/instrumentation-client.ts
+++ b/frontend/src/instrumentation-client.ts
@@ -51,8 +51,12 @@ if (
       process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ||
       "unknown",
 
-    // Performance monitoring - 100% sampling for low-traffic site (15 visitors/day)
-    tracesSampleRate: 1.0,
+    // Performance sampling: 100% pageloads (web vitals), 10% everything else
+    tracesSampler: (samplingContext) => {
+      const op = samplingContext.attributes?.["sentry.op"];
+      if (op === "pageload") return 1.0;
+      return 0.1;
+    },
 
     // Enable distributed tracing to backend API
     tracePropagationTargets: [
@@ -61,8 +65,8 @@ if (
       /^https:\/\/api\.rescuedogs\.me/,
     ],
 
-    // Session Replay - Disabled in development to avoid conflicts, 100% in production for better debugging
-    replaysSessionSampleRate: isProduction ? 1.0 : 0,
+    // Session Replay - 10% baseline, 100% on errors
+    replaysSessionSampleRate: isProduction ? 0.1 : 0,
     replaysOnErrorSampleRate: isProduction ? 1.0 : 0,
 
     // Integrations

--- a/tests/test_sentry_integration.py
+++ b/tests/test_sentry_integration.py
@@ -56,8 +56,7 @@ class TestSentryConfiguration:
                 mock_init.assert_called_once()
                 call_kwargs = mock_init.call_args.kwargs
 
-                assert call_kwargs["traces_sample_rate"] == 1.0
-                assert call_kwargs["profiles_sample_rate"] == 1.0
+                assert call_kwargs["traces_sample_rate"] == 0.1
 
     def test_sentry_dsn_from_environment(self) -> None:
         from api.monitoring import init_sentry


### PR DESCRIPTION
## Summary
- **Traces**: 100% → 10% across server, edge, and backend runtimes. Client uses `tracesSampler` to keep 100% pageloads (web vitals) while sampling everything else at 10%
- **Session replay**: 100% → 10% baseline (100% on errors preserved)
- **CPU profiling**: removed entirely (`profiles_sample_rate`, `profile_lifecycle`)
- **Middleware spans**: disabled on backend Starlette/FastAPI integrations
- **Redundant config**: removed `enable_tracing=True` (implied by `traces_sample_rate`)

## Why
Sentry was recording 100% of all spans, replays, and CPU profiles across every runtime — eating shared org budget despite ~20 daily users.

## What's preserved
- 100% error capture (errors are never sampled)
- 100% web vitals (pageload transactions)
- 100% replay-on-error
- All error filtering, data scrubbing, breadcrumb logic unchanged

## Test plan
- [ ] Backend tests pass (`test_sentry_integration.py` updated for new rate)
- [ ] Frontend type check passes
- [ ] CI green