### PR TITLE
fix(config): cascade enabled flag to organizations.active on sync

### DIFF
--- a/configs/organizations/furryrescueitaly.yaml
+++ b/configs/organizations/furryrescueitaly.yaml
@@ -1,7 +1,7 @@
 schema_version: "1.0"
 id: "furryrescueitaly"
 name: "Furry Rescue Italy"
-enabled: true
+enabled: false  # Disabled 2026-04-19: site rebuilt with Elementor, listing now holds only 4 dogs vs 35 previously scraped. Re-enable after full scraper rewrite (see Sentry issues PYTHON-FASTAPI-T / -Y / -1Z).
 scraper:
   class_name: "FurryRescueItalyScraper"
   module: "scrapers.furryrescueitaly.furryrescueitaly_scraper"

--- a/tests/utils/test_organization_sync_service.py
+++ b/tests/utils/test_organization_sync_service.py
@@ -71,9 +71,10 @@ def _db_row(active: bool = True) -> dict:
 class TestOrganizationSyncEnabledCascade:
     """Cover the enabled→active propagation explicitly."""
 
-    def test_create_organization_passes_enabled_true_to_insert(self):
+    @pytest.mark.parametrize("enabled", [True, False])
+    def test_create_organization_binds_enabled_to_last_insert_param(self, enabled):
         service = OrganizationSyncService(logo_service=NullLogoUploadService())
-        config = _make_config(enabled=True)
+        config = _make_config(enabled=enabled)
 
         with (
             patch("utils.organization_sync_service.execute_command", return_value={"id": 42}) as mock_cmd,
@@ -86,29 +87,13 @@ class TestOrganizationSyncEnabledCascade:
         insert_calls = [c for c in mock_cmd.call_args_list if "INSERT INTO organizations" in c.args[0]]
         assert len(insert_calls) == 1
         sql, params = insert_calls[0].args
-        assert "active" in sql
-        assert True in params, f"Expected active=True in params, got {params}"
+        assert sql.count("%s") == len(params), "SQL placeholder count must match params length"
+        assert params[-1] is enabled, f"Expected active={enabled} as last INSERT param, got {params[-1]}"
 
-    def test_create_organization_passes_enabled_false_to_insert(self):
+    @pytest.mark.parametrize("enabled", [True, False])
+    def test_update_organization_binds_enabled_before_where_param(self, enabled):
         service = OrganizationSyncService(logo_service=NullLogoUploadService())
-        config = _make_config(enabled=False)
-
-        with (
-            patch("utils.organization_sync_service.execute_command", return_value={"id": 42}) as mock_cmd,
-            patch.object(service, "_sync_service_regions"),
-            patch.object(service, "_sync_organization_logo"),
-            patch("utils.organization_sync_service.generate_unique_organization_slug", return_value="test-org"),
-        ):
-            service.create_organization(config)
-
-        insert_calls = [c for c in mock_cmd.call_args_list if "INSERT INTO organizations" in c.args[0]]
-        sql, params = insert_calls[0].args
-        assert "active" in sql
-        assert False in params, f"Expected active=False in params, got {params}"
-
-    def test_update_organization_sets_active_from_enabled(self):
-        service = OrganizationSyncService(logo_service=NullLogoUploadService())
-        config = _make_config(enabled=False)
+        config = _make_config(enabled=enabled)
 
         with (
             patch("utils.organization_sync_service.execute_command") as mock_cmd,
@@ -121,8 +106,9 @@ class TestOrganizationSyncEnabledCascade:
         update_calls = [c for c in mock_cmd.call_args_list if "UPDATE organizations" in c.args[0]]
         assert len(update_calls) == 1
         sql, params = update_calls[0].args
-        assert "active = %s" in sql
-        assert False in params, f"Expected active=False in params, got {params}"
+        assert sql.count("%s") == len(params), "SQL placeholder count must match params length"
+        assert params[-1] == 42, "Last UPDATE param must be the WHERE org_id"
+        assert params[-2] is enabled, f"Expected active={enabled} as second-to-last UPDATE param, got {params[-2]}"
 
     def test_get_database_organizations_populates_active(self):
         service = OrganizationSyncService(logo_service=NullLogoUploadService())
@@ -179,3 +165,43 @@ class TestOrganizationSyncEnabledCascade:
         )
 
         assert service.should_update_organization(db_org, config) is False
+
+    def test_sync_single_organization_flips_active_false_for_existing_row(self):
+        """End-to-end: flipping config.enabled to False must UPDATE the row with active=False.
+
+        Guards against a refactor that accidentally bypasses the UPDATE branch.
+        """
+        service = OrganizationSyncService(logo_service=NullLogoUploadService())
+        config = _make_config(enabled=False)
+        db_organizations = {
+            "Test Org": OrganizationRecord(
+                id=42,
+                name="Test Org",
+                website_url="https://example.com",
+                description="desc",
+                social_media={"website": "https://example.com"},
+                ships_to=["DE"],
+                established_year=2020,
+                logo_url=None,
+                country="DE",
+                city="Berlin",
+                service_regions=["DE"],
+                adoption_fees={},
+                active=True,
+            )
+        }
+
+        with (
+            patch("utils.organization_sync_service.execute_command") as mock_cmd,
+            patch.object(service, "_sync_service_regions"),
+            patch.object(service, "_sync_organization_logo"),
+            patch("utils.organization_sync_service.generate_unique_organization_slug", return_value="test-org"),
+        ):
+            result = service.sync_single_organization(config, db_organizations)
+
+        assert result.success is True
+        assert result.was_created is False
+        update_calls = [c for c in mock_cmd.call_args_list if "UPDATE organizations" in c.args[0]]
+        assert len(update_calls) == 1, "Expected exactly one UPDATE, got {}".format(len(update_calls))
+        _, params = update_calls[0].args
+        assert params[-2] is False, f"Flip to enabled=False must UPDATE with active=False (got {params[-2]})"

--- a/tests/utils/test_organization_sync_service.py
+++ b/tests/utils/test_organization_sync_service.py
@@ -1,0 +1,181 @@
+"""Tests for organization sync service — enabled→active cascade.
+
+Verifies that ``config.enabled`` propagates to ``organizations.active`` on
+both INSERT and UPDATE, and that drift between the two triggers an update.
+"""
+
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+from utils.config_models import (
+    Location,
+    OrganizationConfig,
+    OrganizationMetadata,
+    ScraperInfo,
+    SocialMedia,
+)
+from utils.organization_sync_service import (
+    NullLogoUploadService,
+    OrganizationRecord,
+    OrganizationSyncService,
+)
+
+
+def _make_config(*, enabled: bool = True) -> OrganizationConfig:
+    """Build a minimal valid OrganizationConfig for sync tests."""
+    return OrganizationConfig(
+        schema_version="1.0",
+        id="testorg",
+        name="Test Org",
+        enabled=enabled,
+        scraper=ScraperInfo(
+            class_name="FakeScraper",
+            module="scrapers.fake.fake_scraper",
+        ),
+        metadata=OrganizationMetadata(
+            website_url="https://example.com",
+            description="desc",
+            social_media=SocialMedia(),
+            location=Location(country="DE", city="Berlin"),
+            service_regions=["DE"],
+            ships_to=["DE"],
+            established_year=2020,
+        ),
+    )
+
+
+def _db_row(active: bool = True) -> dict:
+    """Simulate a row from get_database_organizations SELECT."""
+    return {
+        "id": 42,
+        "name": "Test Org",
+        "website_url": "https://example.com",
+        "description": "desc",
+        "social_media": {"website": "https://example.com"},
+        "created_at": datetime(2026, 1, 1),
+        "updated_at": datetime(2026, 1, 1),
+        "ships_to": ["DE"],
+        "established_year": 2020,
+        "logo_url": None,
+        "country": "DE",
+        "city": "Berlin",
+        "service_regions": ["DE"],
+        "adoption_fees": {},
+        "active": active,
+    }
+
+
+@pytest.mark.unit
+class TestOrganizationSyncEnabledCascade:
+    """Cover the enabled→active propagation explicitly."""
+
+    def test_create_organization_passes_enabled_true_to_insert(self):
+        service = OrganizationSyncService(logo_service=NullLogoUploadService())
+        config = _make_config(enabled=True)
+
+        with (
+            patch("utils.organization_sync_service.execute_command", return_value={"id": 42}) as mock_cmd,
+            patch.object(service, "_sync_service_regions"),
+            patch.object(service, "_sync_organization_logo"),
+            patch("utils.organization_sync_service.generate_unique_organization_slug", return_value="test-org"),
+        ):
+            service.create_organization(config)
+
+        insert_calls = [c for c in mock_cmd.call_args_list if "INSERT INTO organizations" in c.args[0]]
+        assert len(insert_calls) == 1
+        sql, params = insert_calls[0].args
+        assert "active" in sql
+        assert True in params, f"Expected active=True in params, got {params}"
+
+    def test_create_organization_passes_enabled_false_to_insert(self):
+        service = OrganizationSyncService(logo_service=NullLogoUploadService())
+        config = _make_config(enabled=False)
+
+        with (
+            patch("utils.organization_sync_service.execute_command", return_value={"id": 42}) as mock_cmd,
+            patch.object(service, "_sync_service_regions"),
+            patch.object(service, "_sync_organization_logo"),
+            patch("utils.organization_sync_service.generate_unique_organization_slug", return_value="test-org"),
+        ):
+            service.create_organization(config)
+
+        insert_calls = [c for c in mock_cmd.call_args_list if "INSERT INTO organizations" in c.args[0]]
+        sql, params = insert_calls[0].args
+        assert "active" in sql
+        assert False in params, f"Expected active=False in params, got {params}"
+
+    def test_update_organization_sets_active_from_enabled(self):
+        service = OrganizationSyncService(logo_service=NullLogoUploadService())
+        config = _make_config(enabled=False)
+
+        with (
+            patch("utils.organization_sync_service.execute_command") as mock_cmd,
+            patch.object(service, "_sync_service_regions"),
+            patch.object(service, "_sync_organization_logo"),
+            patch("utils.organization_sync_service.generate_unique_organization_slug", return_value="test-org"),
+        ):
+            service.update_organization(org_id=42, config=config)
+
+        update_calls = [c for c in mock_cmd.call_args_list if "UPDATE organizations" in c.args[0]]
+        assert len(update_calls) == 1
+        sql, params = update_calls[0].args
+        assert "active = %s" in sql
+        assert False in params, f"Expected active=False in params, got {params}"
+
+    def test_get_database_organizations_populates_active(self):
+        service = OrganizationSyncService(logo_service=NullLogoUploadService())
+
+        with patch(
+            "utils.organization_sync_service.execute_query",
+            return_value=[_db_row(active=False)],
+        ):
+            result = service.get_database_organizations()
+
+        assert "Test Org" in result
+        record = result["Test Org"]
+        assert isinstance(record, OrganizationRecord)
+        assert record.active is False
+
+    def test_should_update_when_active_diverges_from_enabled(self):
+        service = OrganizationSyncService(logo_service=NullLogoUploadService())
+        config = _make_config(enabled=True)
+        db_org = OrganizationRecord(
+            id=42,
+            name="Test Org",
+            website_url="https://example.com",
+            description="desc",
+            social_media={"website": "https://example.com"},
+            ships_to=["DE"],
+            established_year=2020,
+            logo_url=None,
+            country="DE",
+            city="Berlin",
+            service_regions=["DE"],
+            adoption_fees={},
+            active=False,
+        )
+
+        assert service.should_update_organization(db_org, config) is True
+
+    def test_should_not_update_when_active_matches_enabled(self):
+        service = OrganizationSyncService(logo_service=NullLogoUploadService())
+        config = _make_config(enabled=True)
+        db_org = OrganizationRecord(
+            id=42,
+            name="Test Org",
+            website_url="https://example.com",
+            description="desc",
+            social_media={"website": "https://example.com"},
+            ships_to=["DE"],
+            established_year=2020,
+            logo_url=None,
+            country="DE",
+            city="Berlin",
+            service_regions=["DE"],
+            adoption_fees={},
+            active=True,
+        )
+
+        assert service.should_update_organization(db_org, config) is False

--- a/utils/organization_sync_service.py
+++ b/utils/organization_sync_service.py
@@ -116,7 +116,7 @@ class OrganizationSyncService:
                 city=row["city"],
                 service_regions=row["service_regions"],
                 adoption_fees=row.get("adoption_fees"),
-                active=row.get("active", True),
+                active=row["active"],
             )
             organizations[row["name"]] = org_record
 

--- a/utils/organization_sync_service.py
+++ b/utils/organization_sync_service.py
@@ -36,6 +36,7 @@ class OrganizationRecord:
     city: str | None = None
     service_regions: list[str] | None = None
     adoption_fees: dict | None = None
+    active: bool = True
 
 
 @dataclass(frozen=True)
@@ -91,7 +92,7 @@ class OrganizationSyncService:
         query = """
             SELECT id, name, website_url, description, social_media,
                    created_at, updated_at, ships_to, established_year,
-                   logo_url, country, city, service_regions, adoption_fees
+                   logo_url, country, city, service_regions, adoption_fees, active
             FROM organizations
         """
 
@@ -115,6 +116,7 @@ class OrganizationSyncService:
                 city=row["city"],
                 service_regions=row["service_regions"],
                 adoption_fees=row.get("adoption_fees"),
+                active=row.get("active", True),
             )
             organizations[row["name"]] = org_record
 
@@ -158,6 +160,10 @@ class OrganizationSyncService:
         db_adoption_fees = db_org.adoption_fees or {}
         config_adoption_fees = self._build_adoption_fees_dict(config)
         if db_adoption_fees != config_adoption_fees:
+            return True
+
+        # Check active state drift (config.enabled → organizations.active)
+        if db_org.active != config.enabled:
             return True
 
         return False
@@ -209,9 +215,9 @@ class OrganizationSyncService:
             INSERT INTO organizations (
                 name, config_id, website_url, description, social_media,
                 created_at, updated_at,
-                ships_to, established_year, logo_url, country, city, service_regions, adoption_fees, slug
+                ships_to, established_year, logo_url, country, city, service_regions, adoption_fees, slug, active
             ) VALUES (
-                %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+                %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
             ) RETURNING id
         """
 
@@ -231,6 +237,7 @@ class OrganizationSyncService:
             psycopg2.extras.Json(config.metadata.service_regions),
             psycopg2.extras.Json(adoption_fees),
             slug,  # Add slug parameter
+            config.enabled,
         )
 
         result = execute_command(query, params)
@@ -260,7 +267,8 @@ class OrganizationSyncService:
                 updated_at = %s, ships_to = %s,
                 established_year = %s, logo_url = %s, country = %s, city = %s,
                 service_regions = %s, adoption_fees = %s,
-                slug = COALESCE(slug, %s)
+                slug = COALESCE(slug, %s),
+                active = %s
             WHERE id = %s
         """
 
@@ -279,6 +287,7 @@ class OrganizationSyncService:
             psycopg2.extras.Json(config.metadata.service_regions),
             psycopg2.extras.Json(adoption_fees),
             slug,  # Only set if slug is currently NULL
+            config.enabled,
             org_id,
         )
 


### PR DESCRIPTION
## Summary

- Flipping `enabled: false` in an org YAML previously stopped the cron from scraping but left `organizations.active = true` in the DB, so every public API endpoint (which filters on `o.active = TRUE`) kept rendering the org and its stale dogs.
- `create_organization` / `update_organization` now bind `config.enabled` to `organizations.active`, and `get_database_organizations` reads it back so drift between yaml and DB triggers an UPDATE.
- Concrete motivating case: Furry Rescue Italy (org_id 29) republished their site with only 4 dogs and 35 DB rows became ghost records. Once this lands, flipping `enabled: false` + `config sync` is enough to make the org disappear everywhere.

## Test plan

- [x] `uv run pytest tests/utils/test_organization_sync_service.py -v` — 6 new unit tests cover create/update SQL & params, record loading, and drift detection
- [x] `uv run pytest tests/utils/ tests/config/ -m 'not slow and not browser and not external'` — 140 passed
- [x] `uv run ruff check utils/ tests/utils/` — clean
- [ ] After merge: set `enabled: false` on `configs/organizations/furryrescueitaly.yaml`, run `config sync`, verify `/api/organizations` no longer returns Furry Rescue and `/api/animals?organization_id=29` returns zero