### PR TITLE
chore(ci): bump pnpm/action-setup v5 -> v6, pin pnpm 10

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -103,9 +103,9 @@ jobs:
           node-version: "20"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
         with:
-          version: 9
+          version: 10
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -117,7 +117,7 @@ jobs:
         run: pnpm lint
 
       - name: Run tests
-        run: pnpm test -- --coverage --watchAll=false --maxWorkers=2
+        run: pnpm test --coverage --watchAll=false --maxWorkers=2
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -43,9 +43,9 @@ jobs:
           node-version: "20"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
         with:
-          version: 9
+          version: 10
 
       - name: Install frontend dependencies
         working-directory: ./frontend

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -61,4 +61,4 @@ jobs:
 
       - name: Unit tests
         working-directory: ./frontend
-        run: pnpm test -- --passWithNoTests --watchAll=false
+        run: pnpm test --passWithNoTests --watchAll=false

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -176,9 +176,9 @@ jobs:
           node-version: "20"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
         with:
-          version: 9
+          version: 10
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -190,7 +190,7 @@ jobs:
         run: pnpm lint
 
       - name: Run comprehensive tests
-        run: pnpm test -- --coverage --watchAll=false --maxWorkers=2 --verbose
+        run: pnpm test --coverage --watchAll=false --maxWorkers=2 --verbose
 
       - name: Build validation
         run: pnpm build


### PR DESCRIPTION
## Summary
- Replaces dependabot PR #184. That branch failed CI with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` because action-setup v6 ships pnpm 11 in its bootstrap and pnpm 11 enforces strict overrides validation against a lockfile generated by pnpm 10.
- Pins the action's \`version\` input to \`10\`, matching local dev (pnpm 10.33.0) and our current \`pnpm-lock.yaml\`.
- Same change applied to all three workflows: \`ci-pr.yml\`, \`ci-push.yml\`, \`pre-merge.yml\`.

## Test plan
- [x] \`pnpm install --frozen-lockfile\` succeeds locally with pnpm 10.33.0.
- [ ] CI green on this PR (Quick Check, Frontend Tests, Backend tests).