### PR TITLE
fix(frontend): cap SSG to top 500 prioritized dogs to unblock prod builds

### DIFF
--- a/frontend/src/app/dogs/[slug]/__tests__/prioritizeDogsForStaticParams.test.ts
+++ b/frontend/src/app/dogs/[slug]/__tests__/prioritizeDogsForStaticParams.test.ts
@@ -1,0 +1,112 @@
+import { prioritizeDogsForStaticParams } from "../prioritizeDogsForStaticParams";
+import type { Dog } from "../../../../types/dog";
+
+const NOW = new Date("2026-04-28T00:00:00Z");
+const RECENT_DATE = new Date("2026-04-15T00:00:00Z").toISOString();
+const OLD_DATE = new Date("2025-12-01T00:00:00Z").toISOString();
+
+const buildDog = (overrides: Partial<Dog>): Dog =>
+  ({
+    id: 1,
+    slug: "default-slug",
+    name: "Default",
+    organization_id: 1,
+    status: "available",
+    ...overrides,
+  }) as Dog;
+
+describe("prioritizeDogsForStaticParams", () => {
+  it("drops dogs without a slug", () => {
+    const dogs = [
+      buildDog({ slug: "a-1", primary_image_url: "x" }),
+      buildDog({ slug: "", primary_image_url: "x" }),
+      buildDog({ slug: undefined as unknown as string, primary_image_url: "x" }),
+    ];
+    expect(prioritizeDogsForStaticParams(dogs, 10, NOW)).toEqual([{ slug: "a-1" }]);
+  });
+
+  it("sorts by score: LLM content (10) > image (5) > recent (3)", () => {
+    const dogs = [
+      buildDog({ slug: "no-signals" }),
+      buildDog({ slug: "recent-only", created_at: RECENT_DATE }),
+      buildDog({ slug: "image-only", primary_image_url: "x" }),
+      buildDog({ slug: "llm-only", llm_description: "blurb" }),
+      buildDog({
+        slug: "all-signals",
+        llm_description: "blurb",
+        primary_image_url: "x",
+        created_at: RECENT_DATE,
+      }),
+    ];
+
+    const result = prioritizeDogsForStaticParams(dogs, 10, NOW);
+
+    expect(result.map((d) => d.slug)).toEqual([
+      "all-signals",
+      "llm-only",
+      "image-only",
+      "recent-only",
+      "no-signals",
+    ]);
+  });
+
+  it("treats dog_profiler_data.description as LLM content", () => {
+    const dogs = [
+      buildDog({ slug: "plain" }),
+      buildDog({
+        slug: "profiler",
+        dog_profiler_data: { description: "Friendly", tagline: "" } as Dog["dog_profiler_data"],
+      }),
+    ];
+
+    const result = prioritizeDogsForStaticParams(dogs, 10, NOW);
+    expect(result[0].slug).toBe("profiler");
+  });
+
+  it("treats dogs older than 30 days as not recent", () => {
+    const dogs = [
+      buildDog({ slug: "old", created_at: OLD_DATE }),
+      buildDog({ slug: "recent", created_at: RECENT_DATE }),
+    ];
+
+    const result = prioritizeDogsForStaticParams(dogs, 10, NOW);
+    expect(result[0].slug).toBe("recent");
+  });
+
+  it("limits the result to the requested size", () => {
+    const dogs = Array.from({ length: 1500 }, (_, i) =>
+      buildDog({ slug: `dog-${i}`, primary_image_url: i % 2 === 0 ? "x" : undefined }),
+    );
+
+    const result = prioritizeDogsForStaticParams(dogs, 500, NOW);
+    expect(result).toHaveLength(500);
+  });
+
+  it("returns objects with only a slug field (Next.js generateStaticParams contract)", () => {
+    const dogs = [
+      buildDog({
+        slug: "a-1",
+        llm_description: "x",
+        primary_image_url: "x",
+        created_at: RECENT_DATE,
+      }),
+    ];
+
+    const result = prioritizeDogsForStaticParams(dogs, 10, NOW);
+    expect(result).toEqual([{ slug: "a-1" }]);
+    expect(Object.keys(result[0])).toEqual(["slug"]);
+  });
+
+  it("handles malformed created_at gracefully", () => {
+    const dogs = [
+      buildDog({ slug: "bad-date", created_at: "not-a-date", primary_image_url: "x" }),
+    ];
+
+    const result = prioritizeDogsForStaticParams(dogs, 10, NOW);
+    expect(result).toEqual([{ slug: "bad-date" }]);
+  });
+
+  it("returns empty array when given empty input", () => {
+    expect(prioritizeDogsForStaticParams([], 500, NOW)).toEqual([]);
+  });
+});

--- a/frontend/src/app/dogs/[slug]/__tests__/prioritizeDogsForStaticParams.test.ts
+++ b/frontend/src/app/dogs/[slug]/__tests__/prioritizeDogsForStaticParams.test.ts
@@ -73,6 +73,28 @@ describe("prioritizeDogsForStaticParams", () => {
     expect(result[0].slug).toBe("recent");
   });
 
+  it("treats a dog at exactly the 30-day boundary as not recent", () => {
+    const exactlyThirtyDaysAgo = new Date(NOW);
+    exactlyThirtyDaysAgo.setDate(exactlyThirtyDaysAgo.getDate() - 30);
+
+    const dogs = [
+      buildDog({ slug: "boundary", created_at: exactlyThirtyDaysAgo.toISOString() }),
+      buildDog({ slug: "no-signals" }),
+    ];
+
+    const result = prioritizeDogsForStaticParams(dogs, 10, NOW);
+    expect(result.map((d) => d.slug)).toEqual(["boundary", "no-signals"]);
+  });
+
+  it("preserves input order for dogs at the same score (stable sort)", () => {
+    const dogs = Array.from({ length: 6 }, (_, i) =>
+      buildDog({ slug: `tied-${i}`, primary_image_url: "x" }),
+    );
+
+    const result = prioritizeDogsForStaticParams(dogs, 3, NOW);
+    expect(result.map((d) => d.slug)).toEqual(["tied-0", "tied-1", "tied-2"]);
+  });
+
   it("limits the result to the requested size", () => {
     const dogs = Array.from({ length: 1500 }, (_, i) =>
       buildDog({ slug: `dog-${i}`, primary_image_url: i % 2 === 0 ? "x" : undefined }),

--- a/frontend/src/app/dogs/[slug]/page.tsx
+++ b/frontend/src/app/dogs/[slug]/page.tsx
@@ -14,6 +14,9 @@ import DogDetailClient from "./DogDetailClient";
 import DogDetailSkeleton from "../../../components/ui/DogDetailSkeleton";
 import ImagePreload from "../../../components/seo/ImagePreload";
 import Layout from "../../../components/layout/Layout";
+import { prioritizeDogsForStaticParams } from "./prioritizeDogsForStaticParams";
+
+const STATIC_PARAMS_LIMIT = 500;
 
 async function fetchAnimalBySlug(slug: string): Promise<DogWithLlm | null> {
   if (process.env.NODE_ENV === "test" && process.env.JEST_WORKER_ID) {
@@ -219,9 +222,7 @@ export async function generateStaticParams(): Promise<Array<{ slug: string }>> {
     const { getAllAnimalsForSitemap } = await import("../../../services/animalsService");
     const dogs = await getAllAnimalsForSitemap();
 
-    return dogs
-      .filter((dog): dog is typeof dog & { slug: string } => typeof dog.slug === "string" && dog.slug !== "")
-      .map((dog) => ({ slug: dog.slug }));
+    return prioritizeDogsForStaticParams(dogs, STATIC_PARAMS_LIMIT);
 
   } catch (error) {
     reportError(error, { context: "DogDetailPage.generateStaticParams" });

--- a/frontend/src/app/dogs/[slug]/prioritizeDogsForStaticParams.ts
+++ b/frontend/src/app/dogs/[slug]/prioritizeDogsForStaticParams.ts
@@ -1,0 +1,38 @@
+import type { Dog } from "../../../types/dog";
+
+const RECENT_WINDOW_DAYS = 30;
+const SCORE_HAS_LLM_CONTENT = 10;
+const SCORE_HAS_IMAGE = 5;
+const SCORE_RECENT = 3;
+
+const isRecent = (dateStr: string | null | undefined, now: Date = new Date()): boolean => {
+  if (!dateStr) return false;
+  const date = new Date(dateStr);
+  if (Number.isNaN(date.getTime())) return false;
+  const cutoff = new Date(now);
+  cutoff.setDate(cutoff.getDate() - RECENT_WINDOW_DAYS);
+  return date > cutoff;
+};
+
+const scoreDog = (dog: Dog, now: Date): number => {
+  const hasLLMContent = !!(dog.llm_description || dog.dog_profiler_data?.description);
+  const hasImage = !!dog.primary_image_url;
+  return (
+    (hasLLMContent ? SCORE_HAS_LLM_CONTENT : 0) +
+    (hasImage ? SCORE_HAS_IMAGE : 0) +
+    (isRecent(dog.created_at, now) ? SCORE_RECENT : 0)
+  );
+};
+
+export function prioritizeDogsForStaticParams(
+  dogs: Dog[],
+  limit: number,
+  now: Date = new Date(),
+): Array<{ slug: string }> {
+  return dogs
+    .filter((dog): dog is Dog & { slug: string } => typeof dog.slug === "string" && dog.slug !== "")
+    .map((dog) => ({ slug: dog.slug, priority: scoreDog(dog, now) }))
+    .sort((a, b) => b.priority - a.priority)
+    .slice(0, limit)
+    .map(({ slug }) => ({ slug }));
+}


### PR DESCRIPTION
## Summary
Production Vercel builds have been failing for ~7 days. The build SSGs all 1,544+ dog pages via \`generateStaticParams\`, and a handful (e.g. \`kelly-mixed-breed-1502\`, \`kareela-mixed-breed-1501\`, \`kendo-mixed-breed-1499\`, \`dora-staffordshire-bull-terrier-mix-6664\`) consistently exceed Next.js's 60s static-page timeout. After 3 retries on a single slow page the entire build aborts. All 3 production deploys in the last 13h failed this way; the most recent successful prod deploy is 7 days old.

This restores the prioritized top-500 strategy that #149 removed:
- Score each dog: LLM content (+10), image (+5), recent <30 days (+3)
- Sort desc, take top 500 → pre-rendered at build time
- Remaining ~1,000 long-tail dogs render on demand and are cached by the existing \`revalidate = 3600\` ISR

Prioritization was extracted to a pure function (\`prioritizeDogsForStaticParams\`) so it's unit-testable (the original branch was gated behind \`NODE_ENV !== "test"\` inside \`generateStaticParams\`, which made it untestable under jest).

## Why not just bump \`staticPageGenerationTimeout\`?
Papers over the symptom. The slow dogs already retry 3× — so a single bad backend response still kills the build, and every subsequent deploy gets slower. The right long-term fix is to investigate why those specific dogs take >60s on the backend (left as a follow-up).

## Test plan
- [x] 8 new unit tests for \`prioritizeDogsForStaticParams\` (sorting, slug filter, score weights, malformed dates, limit, output shape).
- [x] Full frontend suite: 3525 passed / 20 skipped.
- [x] \`pnpm tsc --noEmit\`, \`pnpm lint\`, \`pnpm build\` all green locally.
- [ ] Vercel preview deploys successfully.
- [ ] After merge: production deploy on main goes green again.