### PR TITLE
fix(scrapers): retry Dogs Trust listing page load on Playwright timeout

### DIFF
--- a/scrapers/dogstrust/dogstrust_scraper.py
+++ b/scrapers/dogstrust/dogstrust_scraper.py
@@ -18,6 +18,7 @@ USE_PLAYWRIGHT = os.environ.get("USE_PLAYWRIGHT", "false").lower() == "true"
 
 # Imports are unconditional so tests can exercise both paths regardless of
 # the env var; USE_PLAYWRIGHT only routes runtime behaviour.
+from playwright.async_api import TimeoutError as PlaywrightTimeoutError  # noqa: E402
 from selenium.webdriver.common.by import By  # noqa: E402
 from selenium.webdriver.support import expected_conditions as EC  # noqa: E402
 from selenium.webdriver.support.wait import WebDriverWait  # noqa: E402
@@ -184,31 +185,20 @@ class DogsTrustScraper(BaseScraper):
     def collect_data(self, max_pages_to_scrape: int = None) -> list[dict[str, Any]]:
         """Collect all available dog data from listing pages.
 
-        This method implements the BaseScraper template method pattern with
-        enhanced parallel processing following the Many Tears Rescue pattern.
-
-        It extracts dogs from all listing pages using Selenium with pagination,
-        filters existing animals if configured, then scrapes detailed information
-        for each dog using parallel HTTP requests.
-
-        Returns:
-            List of dog data dictionaries for database storage
+        Exceptions propagate to BaseScraper._run_with_connection, which routes
+        them through capture_scraper_error (real Sentry exception with stack
+        trace) and handle_scraper_failure (status="error" in scrape_logs).
+        Catching here would re-introduce the silent-failure pathology this
+        scraper had: return [] -> animals_found == 0 -> misleading
+        alert_zero_dogs_found Sentry alert with no actionable trace.
         """
-        try:
-            # Phase 1: Get and filter animals
-            animals = self._get_filtered_animals(max_pages_to_scrape=max_pages_to_scrape)
-            if not animals:
-                return []
-
-            # Phase 2: Process animals in parallel with HTTP requests
-            all_dogs_data = self._process_animals_parallel(animals)
-
-            self.logger.info(f"Total unique dogs collected: {len(all_dogs_data)}")
-            return all_dogs_data
-
-        except Exception as e:
-            self.logger.error(f"Error collecting data from Dogs Trust: {e}")
+        animals = self._get_filtered_animals(max_pages_to_scrape=max_pages_to_scrape)
+        if not animals:
             return []
+
+        all_dogs_data = self._process_animals_parallel(animals)
+        self.logger.info(f"Total unique dogs collected: {len(all_dogs_data)}")
+        return all_dogs_data
 
     def get_animal_list(self, max_pages_to_scrape: int = None) -> list[dict[str, Any]]:
         """Fetch list of available dogs using browser automation with pagination.
@@ -593,19 +583,19 @@ class DogsTrustScraper(BaseScraper):
                     self.logger.debug(f"Overlay removal error (non-critical): {e}")
 
                 # Wait for dog cards to appear. Remote Browserless under
-                # stealth_mode intermittently fails to render within 15s
-                # (production: ~50% of cron runs since 2026-04-20). Retry once
-                # via a reload, then raise so the failure surfaces as a real
-                # error in logs/Sentry instead of a misleading zero-dogs alert.
+                # stealth_mode intermittently fails to render the initial page;
+                # retry once via reload, then raise so the failure surfaces as
+                # a real Sentry exception with a stack trace instead of a
+                # misleading zero-dogs alert.
                 dog_card_selector = 'a[href*="/rehoming/dogs/"]'
                 try:
                     await page.wait_for_selector(dog_card_selector, timeout=45000, state="attached")
                     self.logger.info("Initial page loaded successfully")
-                except Exception as first_err:
+                except PlaywrightTimeoutError as first_err:
                     self.logger.warning(f"Initial page load timed out (attempt 1/2): {first_err}; reloading and retrying...")
                     await page.reload(wait_until="domcontentloaded")
                     await asyncio.sleep(1.0)
-                    # Re-remove OneTrust overlays after reload — they re-render.
+                    # OneTrust overlays can re-render after the reload.
                     try:
                         await page.evaluate(
                             """
@@ -615,12 +605,12 @@ class DogsTrustScraper(BaseScraper):
                             })()
                         """
                         )
-                    except Exception:
-                        pass
+                    except Exception as overlay_err:
+                        self.logger.debug(f"Post-reload overlay removal error (non-critical): {overlay_err}")
                     try:
                         await page.wait_for_selector(dog_card_selector, timeout=45000, state="attached")
                         self.logger.info("Initial page loaded successfully after retry")
-                    except Exception as retry_err:
+                    except PlaywrightTimeoutError as retry_err:
                         self.logger.error(f"Initial page load failed after retry: {retry_err}")
                         raise
 

--- a/scrapers/dogstrust/dogstrust_scraper.py
+++ b/scrapers/dogstrust/dogstrust_scraper.py
@@ -16,16 +16,14 @@ from scrapers.base_scraper import BaseScraper
 
 USE_PLAYWRIGHT = os.environ.get("USE_PLAYWRIGHT", "false").lower() == "true"
 
-if USE_PLAYWRIGHT:
-    from services.playwright_browser_service import (
-        PlaywrightOptions,
-    )
-else:
-    from selenium.webdriver.common.by import By
-    from selenium.webdriver.support import expected_conditions as EC
-    from selenium.webdriver.support.wait import WebDriverWait
+# Imports are unconditional so tests can exercise both paths regardless of
+# the env var; USE_PLAYWRIGHT only routes runtime behaviour.
+from selenium.webdriver.common.by import By  # noqa: E402
+from selenium.webdriver.support import expected_conditions as EC  # noqa: E402
+from selenium.webdriver.support.wait import WebDriverWait  # noqa: E402
 
-    from services.browser_service import BrowserOptions, get_browser_service
+from services.browser_service import BrowserOptions, get_browser_service  # noqa: E402
+from services.playwright_browser_service import PlaywrightOptions  # noqa: E402
 
 
 class DogsTrustScraper(BaseScraper):
@@ -61,7 +59,16 @@ class DogsTrustScraper(BaseScraper):
         # Use config-driven URLs instead of hardcoded values
         website_url = getattr(self.org_config.metadata, "website_url", "https://www.dogstrust.org.uk")
         self.base_url = str(website_url).rstrip("/") if website_url else "https://www.dogstrust.org.uk"
-        self.listing_url = f"{self.base_url}/rehoming/dogs"
+        # Navigate directly to the canonical parameterized URL the site
+        # redirects to. Skipping the redirect removes one anti-bot interception
+        # point and a race where wait_for_selector can fire on the pre-redirect
+        # page.
+        self.listing_url = (
+            f"{self.base_url}/rehoming/dogs"
+            "?page=0&sort=NEW&liveWithCats=false&liveWithDogs=false"
+            "&liveWithPreschool=false&liveWithPrimary=false&liveWithSecondary=false"
+            "&noReserved=false&isUnderdog=false&currentDistance=1000"
+        )
         self.organization_name = self.org_config.name
 
     def _get_filtered_animals(self, max_pages_to_scrape: int = None) -> list[dict[str, Any]]:
@@ -585,12 +592,37 @@ class DogsTrustScraper(BaseScraper):
                 except Exception as e:
                     self.logger.debug(f"Overlay removal error (non-critical): {e}")
 
-                # Wait for dog cards to appear
+                # Wait for dog cards to appear. Remote Browserless under
+                # stealth_mode intermittently fails to render within 15s
+                # (production: ~50% of cron runs since 2026-04-20). Retry once
+                # via a reload, then raise so the failure surfaces as a real
+                # error in logs/Sentry instead of a misleading zero-dogs alert.
+                dog_card_selector = 'a[href*="/rehoming/dogs/"]'
                 try:
-                    await page.wait_for_selector('a[href*="/rehoming/dogs/"]', timeout=15000)
+                    await page.wait_for_selector(dog_card_selector, timeout=45000, state="attached")
                     self.logger.info("Initial page loaded successfully")
-                except Exception as e:
-                    self.logger.warning(f"Timeout waiting for initial page load: {e}")
+                except Exception as first_err:
+                    self.logger.warning(f"Initial page load timed out (attempt 1/2): {first_err}; reloading and retrying...")
+                    await page.reload(wait_until="domcontentloaded")
+                    await asyncio.sleep(1.0)
+                    # Re-remove OneTrust overlays after reload — they re-render.
+                    try:
+                        await page.evaluate(
+                            """
+                            (() => {
+                                document.querySelector('#onetrust-consent-sdk')?.remove();
+                                document.querySelector('.onetrust-pc-dark-filter')?.remove();
+                            })()
+                        """
+                        )
+                    except Exception:
+                        pass
+                    try:
+                        await page.wait_for_selector(dog_card_selector, timeout=45000, state="attached")
+                        self.logger.info("Initial page loaded successfully after retry")
+                    except Exception as retry_err:
+                        self.logger.error(f"Initial page load failed after retry: {retry_err}")
+                        raise
 
                 # Apply filter to hide reserved dogs
                 try:
@@ -767,6 +799,10 @@ class DogsTrustScraper(BaseScraper):
 
             except Exception as e:
                 self.logger.error(f"Error during Playwright pagination scraping: {e}")
+                # Propagate so collect_data() can record a real failure instead
+                # of silently returning [] and triggering the misleading
+                # zero-dogs Sentry alert.
+                raise
 
         self.logger.info(f"Total dogs collected across all pages: {len(all_dogs)}")
         return all_dogs

--- a/tests/scrapers/test_dogstrust_scraper.py
+++ b/tests/scrapers/test_dogstrust_scraper.py
@@ -9,6 +9,7 @@ from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
+from playwright.async_api import TimeoutError as PlaywrightTimeoutError
 
 from scrapers.base_scraper import BaseScraper
 from scrapers.dogstrust.dogstrust_scraper import DogsTrustScraper
@@ -66,9 +67,11 @@ class TestDogsTrustScraper(ScraperTestBase):
 
         result = scraper.get_animal_list()
 
-        # Verify the initial page load call
-        expected_first_url = "https://www.dogstrust.org.uk/rehoming/dogs"
-        mock_driver.get.assert_any_call(expected_first_url)
+        # Initial page load uses the canonical parameterized URL.
+        assert mock_driver.get.called
+        loaded_url = mock_driver.get.call_args.args[0]
+        assert loaded_url.startswith("https://www.dogstrust.org.uk/rehoming/dogs")
+        assert "page=0" in loaded_url
         # Verify attempts to find filter elements were made
         assert mock_driver.find_element.called
         assert isinstance(result, list)
@@ -160,19 +163,11 @@ class TestDogsTrustUnifiedStandardization:
             assert processed["breed_category"] == "Unknown"
 
 
-# --- Playwright listing-page resilience tests ---
-#
-# Production data (organization_id=28) shows ~50% of cron runs since 2026-04-20
-# finish in ~22s with zero dogs, every failure preceded by:
-#   "Timeout waiting for initial page load: Page.wait_for_selector: Timeout 15000ms exceeded"
-# Successful runs of the same scraper return 393-442 dogs. The site itself is
-# fine; the issue is intermittent remote-Browserless page load slowness.
-#
-# These tests lock in:
-#   1. Canonical parameterized listing URL (avoids the /rehoming/dogs redirect).
-#   2. One retry on initial wait_for_selector timeout.
-#   3. Hard-fail (raise) if both attempts time out, so Sentry/Railway logs show
-#      a real error instead of swallowing it into a misleading zero-dogs alert.
+# Listing-page resilience: remote Browserless under stealth_mode
+# intermittently fails to render the initial page within the timeout. The
+# tests below lock in: canonical URL, retry-once on timeout, raise on
+# repeated timeout, propagation to collect_data so the failure surfaces as
+# a real Sentry exception (not a misleading zero-dogs alert).
 
 
 def _build_listing_page_mock(wait_for_selector_side_effect, content_html=""):
@@ -226,8 +221,6 @@ _VALID_LISTING_HTML = """
 class TestDogsTrustListingUrl:
     def test_listing_url_uses_canonical_parameterized_path(self):
         scraper = DogsTrustScraper()
-        # Skipping the bare /rehoming/dogs redirect removes one anti-bot
-        # interception point during the page load.
         assert "page=0" in scraper.listing_url
         assert "currentDistance=1000" in scraper.listing_url
 
@@ -239,16 +232,20 @@ class TestDogsTrustPlaywrightResilience:
         """First wait_for_selector times out, reload + second wait succeeds."""
         scraper = DogsTrustScraper()
         page = _build_listing_page_mock(
-            wait_for_selector_side_effect=[TimeoutError("initial timeout"), None],
+            wait_for_selector_side_effect=[PlaywrightTimeoutError("initial timeout"), None],
             content_html=_VALID_LISTING_HTML,
         )
         _patch_browser_retry(scraper, page)
 
+        evaluate_count_before = page.evaluate.await_count
         result = await scraper._get_animal_list_playwright(max_pages_to_scrape=1)
 
-        page.reload.assert_awaited_once()
+        page.reload.assert_awaited_once_with(wait_until="domcontentloaded")
         assert page.wait_for_selector.await_count == 2
-        assert len(result) == 2  # both dogs from the listing HTML
+        # OneTrust overlays can re-render after reload, so the retry path
+        # must re-strip them before the second wait.
+        assert page.evaluate.await_count > evaluate_count_before + 1
+        assert len(result) == 2
 
     @pytest.mark.asyncio
     async def test_raises_when_both_wait_attempts_timeout(self):
@@ -256,17 +253,17 @@ class TestDogsTrustPlaywrightResilience:
         scraper = DogsTrustScraper()
         page = _build_listing_page_mock(
             wait_for_selector_side_effect=[
-                TimeoutError("first timeout"),
-                TimeoutError("retry timeout"),
+                PlaywrightTimeoutError("first timeout"),
+                PlaywrightTimeoutError("retry timeout"),
             ],
             content_html="",
         )
         _patch_browser_retry(scraper, page)
 
-        with pytest.raises(Exception):  # noqa: B017 — any exception type counts
+        with pytest.raises(PlaywrightTimeoutError):
             await scraper._get_animal_list_playwright(max_pages_to_scrape=1)
 
-        page.reload.assert_awaited_once()
+        page.reload.assert_awaited_once_with(wait_until="domcontentloaded")
         assert page.wait_for_selector.await_count == 2
 
     @pytest.mark.asyncio
@@ -284,3 +281,33 @@ class TestDogsTrustPlaywrightResilience:
         page.reload.assert_not_called()
         assert page.wait_for_selector.await_count == 1
         assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_collect_data_propagates_listing_failure(self):
+        """collect_data must not swallow listing-page exceptions.
+
+        Verifies the end-to-end contract: a Playwright timeout during listing
+        discovery propagates out of collect_data so BaseScraper._run_with_connection
+        can capture a real Sentry exception (with stack trace) instead of
+        silently returning [] and firing alert_zero_dogs_found.
+        """
+        scraper = DogsTrustScraper()
+        page = _build_listing_page_mock(
+            wait_for_selector_side_effect=[
+                PlaywrightTimeoutError("first timeout"),
+                PlaywrightTimeoutError("retry timeout"),
+            ],
+            content_html="",
+        )
+        _patch_browser_retry(scraper, page)
+
+        with pytest.raises(PlaywrightTimeoutError):
+            await scraper._get_animal_list_playwright(max_pages_to_scrape=1)
+        # collect_data is sync and calls into the same get_animal_list, so the
+        # async exception path proved above is sufficient — the missing
+        # try/except is what we're asserting against. Belt and braces: grep
+        # the source for the swallow pattern we removed.
+        import inspect
+
+        source = inspect.getsource(scraper.collect_data)
+        assert "except Exception" not in source, "collect_data must not catch and return [] — that re-introduces the silent-failure bug this PR fixes"

--- a/tests/scrapers/test_dogstrust_scraper.py
+++ b/tests/scrapers/test_dogstrust_scraper.py
@@ -5,7 +5,8 @@ Tests cover the hybrid approach (Selenium for listings, HTTP for details)
 and reserved dog filtering requirements.
 """
 
-from unittest.mock import Mock, patch
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -157,3 +158,129 @@ class TestDogsTrustUnifiedStandardization:
             # Should handle missing breed gracefully
             assert "breed" in processed
             assert processed["breed_category"] == "Unknown"
+
+
+# --- Playwright listing-page resilience tests ---
+#
+# Production data (organization_id=28) shows ~50% of cron runs since 2026-04-20
+# finish in ~22s with zero dogs, every failure preceded by:
+#   "Timeout waiting for initial page load: Page.wait_for_selector: Timeout 15000ms exceeded"
+# Successful runs of the same scraper return 393-442 dogs. The site itself is
+# fine; the issue is intermittent remote-Browserless page load slowness.
+#
+# These tests lock in:
+#   1. Canonical parameterized listing URL (avoids the /rehoming/dogs redirect).
+#   2. One retry on initial wait_for_selector timeout.
+#   3. Hard-fail (raise) if both attempts time out, so Sentry/Railway logs show
+#      a real error instead of swallowing it into a misleading zero-dogs alert.
+
+
+def _build_listing_page_mock(wait_for_selector_side_effect, content_html=""):
+    """Build a mock Playwright Page that satisfies the listing flow.
+
+    All locator-based interactions (cookie banner, filter button, etc.) default
+    to "not visible" so the test only exercises wait_for_selector + content().
+    """
+    page = MagicMock()
+    page.goto = AsyncMock()
+    page.evaluate = AsyncMock(return_value=0)
+    page.wait_for_selector = AsyncMock(side_effect=wait_for_selector_side_effect)
+    page.content = AsyncMock(return_value=content_html)
+    page.reload = AsyncMock()
+
+    locator_first = MagicMock()
+    locator_first.is_visible = AsyncMock(return_value=False)
+    locator_first.is_enabled = AsyncMock(return_value=False)
+    locator_first.click = AsyncMock()
+    locator_first.scroll_into_view_if_needed = AsyncMock()
+    locator = MagicMock()
+    locator.first = locator_first
+    page.locator = MagicMock(return_value=locator)
+
+    return page
+
+
+def _patch_browser_retry(scraper, page):
+    """Replace scraper._with_browser_retry with one yielding the given page."""
+
+    @asynccontextmanager
+    async def _retry(*_args, **_kwargs):
+        result = MagicMock()
+        result.page = page
+        result.is_remote = True
+        yield result
+
+    scraper._with_browser_retry = _retry
+
+
+_VALID_LISTING_HTML = """
+<html><body>
+    <a href="/rehoming/dogs/lurcher/3641644">Lulu Lurcher</a>
+    <a href="/rehoming/dogs/french-bulldog/3625780">Nelly French Bulldog</a>
+    <div>1 of 41</div>
+</body></html>
+"""
+
+
+@pytest.mark.unit
+class TestDogsTrustListingUrl:
+    def test_listing_url_uses_canonical_parameterized_path(self):
+        scraper = DogsTrustScraper()
+        # Skipping the bare /rehoming/dogs redirect removes one anti-bot
+        # interception point during the page load.
+        assert "page=0" in scraper.listing_url
+        assert "currentDistance=1000" in scraper.listing_url
+
+
+@pytest.mark.unit
+class TestDogsTrustPlaywrightResilience:
+    @pytest.mark.asyncio
+    async def test_retries_initial_wait_on_timeout(self):
+        """First wait_for_selector times out, reload + second wait succeeds."""
+        scraper = DogsTrustScraper()
+        page = _build_listing_page_mock(
+            wait_for_selector_side_effect=[TimeoutError("initial timeout"), None],
+            content_html=_VALID_LISTING_HTML,
+        )
+        _patch_browser_retry(scraper, page)
+
+        result = await scraper._get_animal_list_playwright(max_pages_to_scrape=1)
+
+        page.reload.assert_awaited_once()
+        assert page.wait_for_selector.await_count == 2
+        assert len(result) == 2  # both dogs from the listing HTML
+
+    @pytest.mark.asyncio
+    async def test_raises_when_both_wait_attempts_timeout(self):
+        """Both wait attempts fail → raise instead of silently returning []."""
+        scraper = DogsTrustScraper()
+        page = _build_listing_page_mock(
+            wait_for_selector_side_effect=[
+                TimeoutError("first timeout"),
+                TimeoutError("retry timeout"),
+            ],
+            content_html="",
+        )
+        _patch_browser_retry(scraper, page)
+
+        with pytest.raises(Exception):  # noqa: B017 — any exception type counts
+            await scraper._get_animal_list_playwright(max_pages_to_scrape=1)
+
+        page.reload.assert_awaited_once()
+        assert page.wait_for_selector.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_no_retry_when_first_wait_succeeds(self):
+        """Happy path: first wait succeeds, page.reload is never called."""
+        scraper = DogsTrustScraper()
+        page = _build_listing_page_mock(
+            wait_for_selector_side_effect=[None],
+            content_html=_VALID_LISTING_HTML,
+        )
+        _patch_browser_retry(scraper, page)
+
+        result = await scraper._get_animal_list_playwright(max_pages_to_scrape=1)
+
+        page.reload.assert_not_called()
+        assert page.wait_for_selector.await_count == 1
+        assert len(result) == 2


### PR DESCRIPTION
## Summary

Fixes the ~50% Dogs Trust scraper failure rate that's been firing the `Zero animals found for organization_id 28` Sentry alert (`PYTHON-FASTAPI-Y`, 25 events) every Mon/Thu/Sat cron since 2026-04-20.

**Root cause:** Remote Browserless under stealth mode intermittently can't render the dog cards within 15s. The Playwright `wait_for_selector` timed out, the outer `try/except` swallowed the error, and the run finished in ~22s with 0 dogs — triggering a misleading zero-dogs alert with no real error in logs.

Confirmed via Railway logs (`thriving-appreciation` deploy logs from 2026-05-07 / 09 / 11) and DB query on `scrape_logs` showing the alternating success/failure pattern. Site structure is unchanged (verified via Chrome — 608 dogs, 41 pages, URL pattern matches the existing regex).

## Changes

`scrapers/dogstrust/dogstrust_scraper.py`:
1. **Canonical URL** — navigate directly to `?page=0&sort=NEW&...&currentDistance=1000` instead of `/rehoming/dogs`. The site redirects to this URL; skipping the hop removes one anti-bot interception point.
2. **Retry-once with reload** — initial `wait_for_selector` timeout triggers `page.reload()` + fresh OneTrust overlay removal + second wait. Timeout 15s → 45s, with `state=\"attached\"`. Most failures will be caught here based on the alternating production pattern.
3. **Propagate exceptions** — outer `except` re-raises after logging. `collect_data()` already has its own try/except, so the inner one was just hiding the real Playwright trace.
4. Made Playwright/Selenium imports unconditional so both paths are testable regardless of `USE_PLAYWRIGHT`.

## Test plan

- [x] 4 new tests in `tests/scrapers/test_dogstrust_scraper.py`: canonical URL, retry-on-timeout success, both-attempts-fail raises, no-retry on first-attempt success
- [x] All 9 dogstrust tests pass (4 new + 5 existing)
- [x] 453 scraper unit tests green (no regressions)
- [x] \`ruff check\` + \`ruff format\` clean
- [ ] Verify in production: next cron firing (Thu 2026-05-14 15:00 UTC) — expect Dogs Trust to find ~400-600 dogs again, or surface a real error in Railway logs with full Playwright trace if it still fails

## Related Sentry issues

- PYTHON-FASTAPI-Y (Catastrophic failure — zero animals, 25 events) — should resolve
- PYTHON-FASTAPI-1Z (Sent zero-dogs alert, 10 events) — should resolve
- PYTHON-FASTAPI-T (Zero dogs — website may have changed, 25 events) — should resolve