### PR TITLE
chore: reduce Vercel Hobby ISR writes + tighten dep automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,29 +1,40 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
+      time: "05:00"
+      timezone: "Europe/Berlin"
     groups:
       python-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
     commit-message:
       prefix: "chore(deps)"
     labels:
       - "dependencies"
       - "python"
+    open-pull-requests-limit: 3
 
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:
       interval: "weekly"
       day: "monday"
+      time: "05:00"
+      timezone: "Europe/Berlin"
     groups:
       npm-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
     ignore:
       - dependency-name: "eslint"
         update-types: ["version-update:semver-major"]
@@ -36,13 +47,25 @@ updates:
     labels:
       - "dependencies"
       - "javascript"
+    open-pull-requests-limit: 3
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "05:00"
+      timezone: "Europe/Berlin"
+    groups:
+      ci-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     commit-message:
       prefix: "chore(ci)"
     labels:
       - "dependencies"
       - "ci"
+    open-pull-requests-limit: 2

--- a/frontend/src/__tests__/seo/static-generation.test.js
+++ b/frontend/src/__tests__/seo/static-generation.test.js
@@ -210,11 +210,11 @@ describe("SEO Static Generation Validation", () => {
       const dogPage = await import("../../app/dogs/[slug]/page");
       const orgPage = await import("../../app/organizations/[slug]/page");
 
-      // Dogs should revalidate hourly (3600 seconds)
-      expect(dogPage.revalidate).toBe(3600);
+      // Dogs revalidate every 48h — matches scraper cadence (Tue/Thu/Sat)
+      expect(dogPage.revalidate).toBe(172800);
 
-      // Organizations should revalidate daily (86400 seconds)
-      expect(orgPage.revalidate).toBe(86400);
+      // Organizations revalidate weekly — config-driven content changes rarely
+      expect(orgPage.revalidate).toBe(604800);
     });
   });
 

--- a/frontend/src/app/breeds/[slug]/page.tsx
+++ b/frontend/src/app/breeds/[slug]/page.tsx
@@ -17,7 +17,7 @@ interface BreedPageProps {
   params: Promise<{ slug: string }>;
 }
 
-export const revalidate = 3600;
+export const revalidate = 604800;
 
 export async function generateMetadata(
   props: BreedPageProps,

--- a/frontend/src/app/breeds/mixed/page.tsx
+++ b/frontend/src/app/breeds/mixed/page.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/services/serverAnimalsService";
 import { logger, reportError } from "@/utils/logger";
 
-export const revalidate = 3600;
+export const revalidate = 604800;
 
 export async function generateMetadata(): Promise<Metadata> {
   try {

--- a/frontend/src/app/breeds/page.tsx
+++ b/frontend/src/app/breeds/page.tsx
@@ -12,7 +12,7 @@ import {
 import BreedStructuredData from "@/components/seo/BreedStructuredData";
 import { logger, reportError } from "@/utils/logger";
 
-export const revalidate = 300;
+export const revalidate = 604800;
 
 export async function generateMetadata(): Promise<Metadata> {
   const breedStats = await getBreedStats();

--- a/frontend/src/app/dogs/[slug]/page.tsx
+++ b/frontend/src/app/dogs/[slug]/page.tsx
@@ -203,7 +203,7 @@ async function DogDetailPageAsync(props: DogDetailPageProps): Promise<React.JSX.
   );
 }
 
-export const revalidate = 3600;
+export const revalidate = 172800;
 
 export async function generateStaticParams(): Promise<Array<{ slug: string }>> {
   try {

--- a/frontend/src/app/dogs/age/page.tsx
+++ b/frontend/src/app/dogs/age/page.tsx
@@ -5,7 +5,7 @@ import Layout from "@/components/layout/Layout";
 import AgeStructuredData from "@/components/age/AgeStructuredData";
 import { getAgeStats } from "@/services/serverAnimalsService";
 
-export const revalidate = 300;
+export const revalidate = 604800;
 
 export async function generateMetadata(): Promise<Metadata> {
   const stats = await getAgeStats();

--- a/frontend/src/app/dogs/country/[code]/page.tsx
+++ b/frontend/src/app/dogs/country/[code]/page.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/utils/countryData";
 import DogCardSkeletonOptimized from "@/components/ui/DogCardSkeletonOptimized";
 
-export const revalidate = 300;
+export const revalidate = 86400;
 
 interface CountryPageProps {
   params: Promise<{ code: string }>;

--- a/frontend/src/app/dogs/country/page.tsx
+++ b/frontend/src/app/dogs/country/page.tsx
@@ -5,7 +5,7 @@ import Layout from "@/components/layout/Layout";
 import CountryStructuredData from "@/components/countries/CountryStructuredData";
 import { getCountryStats } from "@/services/serverAnimalsService";
 
-export const revalidate = 300;
+export const revalidate = 604800;
 
 export async function generateMetadata(): Promise<Metadata> {
   const stats = await getCountryStats();

--- a/frontend/src/app/dogs/page.tsx
+++ b/frontend/src/app/dogs/page.tsx
@@ -13,7 +13,7 @@ interface DogsPageProps {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }
 
-export const revalidate = 300;
+export const revalidate = 21600;
 
 export async function generateMetadata(): Promise<Metadata> {
   return {

--- a/frontend/src/app/dogs/puppies/page.tsx
+++ b/frontend/src/app/dogs/puppies/page.tsx
@@ -7,7 +7,7 @@ import { getAnimals, getAllMetadata, getAgeStats } from "@/services/serverAnimal
 import { AGE_CATEGORIES } from "@/utils/ageData";
 import DogCardSkeletonOptimized from "@/components/ui/DogCardSkeletonOptimized";
 
-export const revalidate = 300;
+export const revalidate = 86400;
 
 const puppyCategory = AGE_CATEGORIES.puppies;
 

--- a/frontend/src/app/dogs/senior/page.tsx
+++ b/frontend/src/app/dogs/senior/page.tsx
@@ -7,7 +7,7 @@ import { getAnimals, getAllMetadata, getAgeStats } from "@/services/serverAnimal
 import { AGE_CATEGORIES } from "@/utils/ageData";
 import DogCardSkeletonOptimized from "@/components/ui/DogCardSkeletonOptimized";
 
-export const revalidate = 300;
+export const revalidate = 86400;
 
 const seniorCategory = AGE_CATEGORIES.senior;
 

--- a/frontend/src/app/organizations/[slug]/page.tsx
+++ b/frontend/src/app/organizations/[slug]/page.tsx
@@ -128,7 +128,7 @@ async function OrganizationDetailPageAsync(props: OrganizationDetailPageProps): 
   );
 }
 
-export const revalidate = 86400;
+export const revalidate = 604800;
 
 export async function generateStaticParams(): Promise<Array<{ slug: string }>> {
   try {

--- a/frontend/src/app/organizations/page.tsx
+++ b/frontend/src/app/organizations/page.tsx
@@ -5,7 +5,7 @@ import Layout from "../../components/layout/Layout";
 import { getEnhancedOrganizationsSSR } from "../../services/organizationsService";
 import { reportError } from "../../utils/logger";
 
-export const revalidate = 300;
+export const revalidate = 604800;
 
 export function generateMetadata(): Metadata {
   return {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -9,7 +9,7 @@ import { getBreedsWithImagesForHomePage } from "../services/breedImagesService";
 import { getEnhancedOrganizationsSSR } from "../services/organizationsService";
 import { reportError } from "../utils/logger";
 
-export const revalidate = 300;
+export const revalidate = 21600;
 
 export async function generateMetadata(): Promise<Metadata> {
   let stats = { total_dogs: 4500, total_organizations: 13 };

--- a/frontend/src/app/swipe/page.tsx
+++ b/frontend/src/app/swipe/page.tsx
@@ -5,7 +5,7 @@ import {
 } from "../../services/serverSwipeService";
 import SwipePageClient from "./SwipePageClient";
 
-export const revalidate = 300;
+export const revalidate = 604800;
 
 interface SwipePageProps {
   searchParams: Promise<Record<string, string | string[] | undefined>>;

--- a/frontend/src/services/__tests__/breedImagesService.test.js
+++ b/frontend/src/services/__tests__/breedImagesService.test.js
@@ -64,7 +64,7 @@ describe("breedImagesService", () => {
           headers: expect.objectContaining({
             "Content-Type": "application/json",
           }),
-          next: { revalidate: 300 },
+          next: { revalidate: 604800 },
         }),
       );
       expect(result).toEqual(mockBreedsData);

--- a/frontend/src/services/__tests__/serverAnimalsService.test.ts
+++ b/frontend/src/services/__tests__/serverAnimalsService.test.ts
@@ -47,7 +47,7 @@ describe("Server Animals Service", () => {
     expect(fetch).toHaveBeenCalledWith(
       expect.stringContaining("/api/animals/?limit=20&search=test"),
       expect.objectContaining({
-        next: { revalidate: 300, tags: ["animals"] },
+        next: { revalidate: 86400, tags: ["animals"] },
       }),
     );
     expect(result).toMatchObject(mockResponse);

--- a/frontend/src/services/breedImagesService.ts
+++ b/frontend/src/services/breedImagesService.ts
@@ -48,7 +48,7 @@ export async function getBreedsWithImages(
       headers: {
         "Content-Type": "application/json",
       },
-      next: { revalidate: 300 },
+      next: { revalidate: 604800 },
     } as RequestInit);
 
     if (!response.ok) {
@@ -90,7 +90,7 @@ export async function getBreedGroupsWithTopBreeds(): Promise<
     const statsUrl = `${API_URL}/api/animals/breeds/stats`;
     const statsResponse = await fetch(statsUrl, {
       headers: { "Content-Type": "application/json" },
-      next: { revalidate: 300 },
+      next: { revalidate: 604800 },
     } as RequestInit);
 
     if (!statsResponse.ok) {
@@ -106,7 +106,7 @@ export async function getBreedGroupsWithTopBreeds(): Promise<
       const breedsWithImagesUrl = `${API_URL}/api/animals/breeds/with-images?min_count=2&limit=50`;
       const imagesResponse = await fetch(breedsWithImagesUrl, {
         headers: { "Content-Type": "application/json" },
-        next: { revalidate: 300 },
+        next: { revalidate: 604800 },
       } as RequestInit);
 
       if (imagesResponse.ok) {
@@ -221,7 +221,7 @@ export async function getBreedsWithImagesForHomePage(
       headers: {
         "Content-Type": "application/json",
       },
-      next: { revalidate: 300 },
+      next: { revalidate: 604800 },
     } as RequestInit);
 
     if (!response.ok) {

--- a/frontend/src/services/organizationsService.ts
+++ b/frontend/src/services/organizationsService.ts
@@ -139,7 +139,7 @@ export async function getEnhancedOrganizationsSSR(): Promise<EnhancedOrg[]> {
     const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
     const response = await fetch(`${apiUrl}/api/organizations/enhanced`, {
-      next: { revalidate: 300 },
+      next: { revalidate: 604800 },
       headers: {
         "Content-Type": "application/json",
       },

--- a/frontend/src/services/serverAnimalsService.ts
+++ b/frontend/src/services/serverAnimalsService.ts
@@ -175,7 +175,7 @@ export const getAnimals = cache(
 
     const response = await fetch(url, {
       next: {
-        revalidate: 300,
+        revalidate: 86400,
         tags: ["animals"],
       },
       headers: {
@@ -198,7 +198,7 @@ export const getStandardizedBreeds = cache(
   async (): Promise<string[]> => {
     const response = await fetch(`${API_URL}/api/animals/meta/breeds/`, {
       next: {
-        revalidate: 3600,
+        revalidate: 86400,
         tags: ["breeds"],
       },
     });
@@ -219,7 +219,7 @@ export const getLocationCountries = cache(
       `${API_URL}/api/animals/meta/location_countries`,
       {
         next: {
-          revalidate: 3600,
+          revalidate: 86400,
           tags: ["location-countries"],
         },
       },
@@ -243,7 +243,7 @@ export const getAvailableCountries = cache(
       `${API_URL}/api/animals/meta/available_countries`,
       {
         next: {
-          revalidate: 3600,
+          revalidate: 86400,
           tags: ["available-countries"],
         },
       },
@@ -271,7 +271,7 @@ export const getAvailableRegions = cache(
       `${API_URL}/api/animals/meta/available_regions?country=${encodeURIComponent(country)}`,
       {
         next: {
-          revalidate: 3600,
+          revalidate: 86400,
           tags: ["available-regions", country],
         },
       },
@@ -291,7 +291,7 @@ export const getOrganizations = cache(
   async (): Promise<z.infer<typeof ApiOrganizationEmbeddedSchema>[]> => {
     const response = await fetch(`${API_URL}/api/organizations/`, {
       next: {
-        revalidate: 3600,
+        revalidate: 86400,
         tags: ["organizations"],
       },
     });
@@ -346,7 +346,7 @@ export const getStatistics = cache(
   async (): Promise<z.infer<typeof StatisticsSchema>> => {
     const response = await fetch(`${API_URL}/api/animals/statistics`, {
       next: {
-        revalidate: 300,
+        revalidate: 21600,
         tags: ["statistics"],
       },
     });
@@ -365,7 +365,7 @@ export const getBreedStats = cache(
   async (): Promise<BreedStats> => {
     const response = await fetch(`${API_URL}/api/animals/breeds/stats`, {
       next: {
-        revalidate: 3600,
+        revalidate: 604800,
         tags: ["breed-stats"],
       },
       headers: {
@@ -408,7 +408,7 @@ export const getAnimalsByCuration = cache(
       `${API_URL}/api/animals/?${queryParams.toString()}`,
       {
         next: {
-          revalidate: 300,
+          revalidate: 21600,
           tags: ["animals", `curation-${curationType}`],
         },
       },
@@ -862,7 +862,7 @@ export const getEnhancedDogContent = cache(
           "Content-Type": "application/json",
         },
         next: {
-          revalidate: 300,
+          revalidate: 172800,
           tags: ["enhanced", `animal-enhanced-${animalId}`],
         },
       });
@@ -922,7 +922,7 @@ export const getAnimalBySlug = cache(async (slug: string): Promise<DogWithLlm | 
   try {
     const response = await fetch(`${API_URL}/api/animals/${slug}/`, {
       next: {
-        revalidate: 300,
+        revalidate: 172800,
         tags: ["animal", slug],
       },
       headers: {
@@ -980,7 +980,7 @@ export const getCountryStats = cache(
   async (): Promise<z.infer<typeof CountryStatsResponseSchema>> => {
     const response = await fetch(`${API_URL}/api/animals/stats/by-country`, {
       next: {
-        revalidate: 300,
+        revalidate: 86400,
         tags: ["country-stats"],
       },
       headers: {
@@ -1015,7 +1015,7 @@ export const getAgeStats = cache(
   async (): Promise<AgeStats> => {
     const response = await fetch(`${API_URL}/api/animals/meta/filter_counts`, {
       next: {
-        revalidate: 300,
+        revalidate: 86400,
         tags: ["age-stats"],
       },
       headers: {

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "[ \"$VERCEL_ENV\" = \"preview\" ] && git log -1 --pretty=%an | grep -qiE '^dependabot'"
+}


### PR DESCRIPTION
## Summary

Reduces Vercel Hobby ISR-Writes overage and tightens Dependabot to reduce
Build-Minute consumption from bot churn. Three concerns in one PR because
they share the same goal (stay on Hobby) and the same scope (frontend
revalidate config + dep automation).

## 1. Page-level `revalidate` changes

| Route | From | To |
|---|---|---|
| `/` | 300s | 21600s (6h) |
| `/dogs` | 300s | 21600s (6h)¹ |
| `/dogs/[slug]` | 3600s | 172800s (48h) |
| `/dogs/senior` | 300s | 86400s (24h) |
| `/dogs/puppies` | 300s | 86400s (24h) |
| `/dogs/age` | 300s | 604800s (7d) |
| `/dogs/country` | 300s | 604800s (7d) |
| `/dogs/country/[code]` | 300s | 86400s (24h) |
| `/breeds` | 300s | 604800s (7d) |
| `/breeds/[slug]` | 3600s | 604800s (7d) |
| `/breeds/mixed` | 3600s | 604800s (7d) |
| `/organizations` | 300s | 604800s (7d) |
| `/organizations/[slug]` | 86400s | 604800s (7d) |
| `/swipe` | 300s | 604800s (7d)¹ |

¹ `/dogs` and `/swipe` now resolve to `ƒ Dynamic` in build output because both
consume `searchParams`; the page `revalidate` is moot for those — they no
longer ISR-write at all.

## 2. Fetch-level `revalidate` changes (`serverAnimalsService.ts`, `breedImagesService.ts`, `organizationsService.ts`)

Page-level alone is **insufficient** in Next.js — the effective Full Route
Cache lifetime is `min(page revalidate, every fetch's revalidate)`. Without
moving the fetch layer too, the page-level changes get capped at 5m–1h.

| Function | From | To |
|---|---|---|
| `getAnimals` | 300s | 86400s |
| `getAnimalBySlug` | 300s | 172800s |
| `getEnhancedDogContent` | 300s | 172800s |
| `getAnimalsByCuration` | 300s | 21600s |
| `getStatistics` | 300s | 21600s |
| `getCountryStats` | 300s | 86400s |
| `getAgeStats` | 300s | 86400s |
| `getBreedStats` | 3600s | 604800s |
| `getStandardizedBreeds` | 3600s | 86400s |
| `getLocationCountries` | 3600s | 86400s |
| `getAvailableCountries` | 3600s | 86400s |
| `getAvailableRegions` | 3600s | 86400s |
| `getOrganizations` (meta) | 3600s | 86400s |
| `getEnhancedOrganizationsSSR` | 300s | 604800s |
| `breedImagesService.ts` (all 4 fetches) | 300s | 604800s |
| `getFilterCounts` | 60s | unchanged (filter UI freshness) |
| `getAllAnimals` (unused server-side) | 3600s | unchanged |

## 3. Routes converted from ISR to fully static

None — the candidates (`/guides`, `/guides/[slug]`, `/about`, `/privacy`,
`/faq`, `/favorites`) were already static (no `revalidate` export, no SSR
data fetch, or `export const dynamic = 'force-static'`). No conversion
needed; left as-is.

## 4. Byte-identical confirmations

These files / behaviors are zero-diff in this PR:

- Sitemap routes (`sitemap.xml`, `sitemap_index.xml`, `sitemap-breeds.xml`,
  `-dogs`, `-countries`, `-guides`, `-images`, `-organizations`) — no
  files modified, all still `ƒ Dynamic` in build output
- `robots.txt` — unchanged
- JSON-LD components (`DogSchema`, `BreedStructuredData`,
  `OrganizationSchema`, `BreadcrumbSchema`, `GuideSchema`, `PersonSchema`,
  `CollectionPage` inline blobs) — zero changes
- Canonical URL helpers — zero changes
- `generateMetadata` for OG/Twitter cards — zero changes
- FallbackImage / R2 image config — zero changes
- LLM pipeline, scrapers, anything in `services/` (backend) or
  `scrapers/` — out of scope, not touched

## 5. Expected ISR Writes reduction

Worst-case (every URL crawled at exactly its revalidate cadence):

| | Current (writes/day) | After (writes/day) |
|---|---|---|
| `/dogs/[slug]` (1,632 active URLs) | 39,168 | 816 |
| `/dogs/country/[code]` (10 URLs) | 2,880 | 10 |
| `/breeds/[slug]` (~26 URLs) | 624 | ~4 |
| `/organizations/[slug]` (11 URLs) | 11 | ~2 |
| Single-URL hubs (10 of them at 5m) | 2,880 | ~10 |
| `/` (homepage) | 288 | 4 |
| `/breeds/mixed` | 24 | ~1 |
| **TOTAL** | **~45,900/day** | **~860/day** |

≈ **98% reduction** in worst-case ISR writes. Real Googlebot crawl rate is
lower than worst case, but the relative drop holds.

## 6. Dependabot tightening (`.github/dependabot.yml`)

Investigation surfaced the assumption "updates are already grouped weekly"
was wrong — the configured `python-dependencies` group was being
**bypassed** because the ecosystem keyword was `pip` but the project uses
`uv.lock`. Dependabot was auto-detecting uv separately and creating
individual PRs (urllib3 #204, python-multipart #200/#185, pip #199,
cryptography #179, aiohttp #175, requests #170, pillow #183, etc.).

Changes:
- `pip` → `uv` ecosystem (matches what Dependabot actually sees)
- All three ecosystem groups gated to `update-types: [minor, patch]` so
  majors get standalone PRs and security updates remain ungrouped/immediate
- Schedule pinned to Monday 05:00 Europe/Berlin
- `github-actions` group added (was previously ungrouped)
- `open-pull-requests-limit` added per ecosystem to prevent rebase storms

## 7. Vercel preview-build skip for Dependabot (`frontend/vercel.json`)

Added `ignoreCommand` that skips Vercel preview builds when:
- `VERCEL_ENV == "preview"` AND
- the latest commit author starts with `dependabot`

Production deploys are **not** affected — squash-merged Dependabot PRs land
on `main` with the merger as author, so `VERCEL_ENV=production` always
builds regardless. Verified with a 4-case shell test (preview+bot →
SKIP, preview+human → BUILD, production+bot → BUILD, production+human →
BUILD).

## Follow-up (NOT in this PR)

The real root cause of the overage is **no on-demand revalidation
anywhere in the codebase**. `grep -rn "revalidatePath|revalidateTag"
frontend/src/` returned zero matches. Current `revalidate` values are
compensating for the absence of an event-driven refresh path.

Recommend wiring `revalidatePath` into the Railway scraper cron
completion step (and LLM enrichment completion). With that in place, the
revalidate values introduced here can go much higher — or disappear
entirely in favor of `cache: 'force-cache'` plus targeted tag-based
invalidation.

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm lint` — 0 errors, 25 pre-existing warnings unrelated to changes
- [x] `pnpm jest --watchAll=false` — 3,527 passed, 20 skipped, 0 failed
- [x] `pnpm build` — succeeded; Route table shows new effective revalidate
- [x] Static-generation test (`src/__tests__/seo/static-generation.test.js`)
      updated with new values; ran RED → GREEN
- [x] Service tests (`serverAnimalsService.test.ts`,
      `breedImagesService.test.js`) updated with new values; RED → GREEN
- [x] `git diff` confirmed: zero changes to sitemap routes, JSON-LD,
      canonical helpers, OG metadata, robots, FallbackImage, R2 config
- [x] Vercel `ignoreCommand` smoke-tested across all 4 (env × author)
      combinations
- [x] Dependabot YAML validated parseable
- [ ] After merge: monitor Vercel dashboard for ISR-Writes drop over 48h
- [ ] After merge: confirm next Dependabot run (Monday) lands a single
      grouped PR per ecosystem, not individual ones