### PR TITLE
feat: on-demand cache invalidation for Next.js frontend

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -22,5 +22,14 @@ OPENROUTER_API_KEY=your_openrouter_api_key
 # === Admin API Key (protects LLM endpoints) ===
 ADMIN_API_KEY=your_admin_api_key
 
+# === Next.js cache invalidation (Railway → Vercel) ===
+# Shared secret. Generate with: openssl rand -hex 32
+# Must match REVALIDATION_TOKEN env var set in Vercel (production + preview).
+# When unset, scrapers/CLIs skip cache invalidation with a warning.
+REVALIDATION_TOKEN=
+# Base URL of the Next.js frontend the backend posts invalidation requests to.
+# Defaults to https://www.rescuedogs.me when unset; override for staging.
+FRONTEND_URL=https://www.rescuedogs.me
+
 # === Testing ===
 TESTING=false

--- a/frontend/src/app/api/revalidate/__tests__/route.test.ts
+++ b/frontend/src/app/api/revalidate/__tests__/route.test.ts
@@ -95,30 +95,30 @@ describe("POST /api/revalidate", () => {
     expect(revalidatePath).toHaveBeenCalledWith("/dogs/buddy-1");
   });
 
-  it("returns 200 with no invocations when body has no tags/paths", async () => {
+  it("returns 400 when body has no tags or paths", async () => {
     const res = await POST(makeRequest({ token: TOKEN, body: {} }));
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(400);
     expect(revalidateTag).not.toHaveBeenCalled();
     expect(revalidatePath).not.toHaveBeenCalled();
   });
 
-  it("returns 200 when body is malformed JSON", async () => {
+  it("returns 400 when body is malformed JSON", async () => {
     const res = await POST(
       makeRequest({ token: TOKEN, bodyRaw: "{not json" }),
     );
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(400);
     expect(revalidateTag).not.toHaveBeenCalled();
     expect(revalidatePath).not.toHaveBeenCalled();
   });
 
-  it("ignores non-array tags/paths values", async () => {
+  it("returns 400 when tags/paths are non-array values", async () => {
     const res = await POST(
       makeRequest({
         token: TOKEN,
         body: { tags: "not-an-array", paths: 42 },
       }),
     );
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(400);
     expect(revalidateTag).not.toHaveBeenCalled();
     expect(revalidatePath).not.toHaveBeenCalled();
   });

--- a/frontend/src/app/api/revalidate/__tests__/route.test.ts
+++ b/frontend/src/app/api/revalidate/__tests__/route.test.ts
@@ -1,0 +1,142 @@
+/**
+ * @jest-environment node
+ */
+import { POST } from "../route";
+import { revalidatePath, revalidateTag } from "next/cache";
+
+jest.mock("next/cache", () => ({
+  revalidateTag: jest.fn(),
+  revalidatePath: jest.fn(),
+}));
+
+const TOKEN = "test-revalidation-token";
+
+beforeAll(() => {
+  process.env.REVALIDATION_TOKEN = TOKEN;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+function makeRequest(opts: {
+  token?: string | null;
+  body?: unknown;
+  bodyRaw?: string;
+}): Request {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (opts.token != null) {
+    headers["x-revalidate-token"] = opts.token;
+  }
+  const body =
+    opts.bodyRaw !== undefined
+      ? opts.bodyRaw
+      : opts.body !== undefined
+        ? JSON.stringify(opts.body)
+        : undefined;
+  return new Request("http://localhost/api/revalidate", {
+    method: "POST",
+    headers,
+    body,
+  });
+}
+
+describe("POST /api/revalidate", () => {
+  it("returns 401 when token header is missing", async () => {
+    const res = await POST(makeRequest({ token: null, body: {} }));
+    expect(res.status).toBe(401);
+    expect(revalidateTag).not.toHaveBeenCalled();
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when token does not match", async () => {
+    const res = await POST(makeRequest({ token: "wrong", body: {} }));
+    expect(res.status).toBe(401);
+    expect(revalidateTag).not.toHaveBeenCalled();
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when REVALIDATION_TOKEN env is unset (fail closed)", async () => {
+    const original = process.env.REVALIDATION_TOKEN;
+    delete process.env.REVALIDATION_TOKEN;
+    try {
+      const res = await POST(makeRequest({ token: TOKEN, body: {} }));
+      expect(res.status).toBe(401);
+      expect(revalidateTag).not.toHaveBeenCalled();
+    } finally {
+      process.env.REVALIDATION_TOKEN = original;
+    }
+  });
+
+  it("returns 200 and revalidates tags + paths with correct token", async () => {
+    const res = await POST(
+      makeRequest({
+        token: TOKEN,
+        body: {
+          tags: ["animals", "statistics"],
+          paths: ["/dogs/buddy-1"],
+        },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as {
+      revalidated: { tags: string[]; paths: string[] };
+    };
+    expect(data.revalidated).toEqual({
+      tags: ["animals", "statistics"],
+      paths: ["/dogs/buddy-1"],
+    });
+    expect(revalidateTag).toHaveBeenCalledTimes(2);
+    expect(revalidateTag).toHaveBeenCalledWith("animals", "max");
+    expect(revalidateTag).toHaveBeenCalledWith("statistics", "max");
+    expect(revalidatePath).toHaveBeenCalledTimes(1);
+    expect(revalidatePath).toHaveBeenCalledWith("/dogs/buddy-1");
+  });
+
+  it("returns 200 with no invocations when body has no tags/paths", async () => {
+    const res = await POST(makeRequest({ token: TOKEN, body: {} }));
+    expect(res.status).toBe(200);
+    expect(revalidateTag).not.toHaveBeenCalled();
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 when body is malformed JSON", async () => {
+    const res = await POST(
+      makeRequest({ token: TOKEN, bodyRaw: "{not json" }),
+    );
+    expect(res.status).toBe(200);
+    expect(revalidateTag).not.toHaveBeenCalled();
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-array tags/paths values", async () => {
+    const res = await POST(
+      makeRequest({
+        token: TOKEN,
+        body: { tags: "not-an-array", paths: 42 },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(revalidateTag).not.toHaveBeenCalled();
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-string entries inside arrays", async () => {
+    const res = await POST(
+      makeRequest({
+        token: TOKEN,
+        body: {
+          tags: ["good", 42, null],
+          paths: [{}, "/ok"],
+        },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(revalidateTag).toHaveBeenCalledTimes(1);
+    expect(revalidateTag).toHaveBeenCalledWith("good", "max");
+    expect(revalidatePath).toHaveBeenCalledTimes(1);
+    expect(revalidatePath).toHaveBeenCalledWith("/ok");
+  });
+});

--- a/frontend/src/app/api/revalidate/route.ts
+++ b/frontend/src/app/api/revalidate/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { revalidatePath, revalidateTag } from "next/cache";
+
+export const dynamic = "force-dynamic";
+
+interface RevalidateBody {
+  tags?: unknown;
+  paths?: unknown;
+}
+
+const onlyStrings = (value: unknown): string[] => {
+  if (!Array.isArray(value)) return [];
+  return value.filter((v): v is string => typeof v === "string");
+};
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const expected = process.env.REVALIDATION_TOKEN;
+  const provided = request.headers.get("x-revalidate-token");
+  if (!expected || provided !== expected) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const parsed = await request
+    .json()
+    .catch((): RevalidateBody => ({}));
+  const body =
+    parsed != null && typeof parsed === "object"
+      ? (parsed as RevalidateBody)
+      : {};
+
+  const tags = onlyStrings(body.tags);
+  const paths = onlyStrings(body.paths);
+
+  for (const tag of tags) revalidateTag(tag, "max");
+  for (const path of paths) revalidatePath(path);
+
+  return NextResponse.json({
+    revalidated: { tags, paths },
+    now: Date.now(),
+  });
+}

--- a/frontend/src/app/api/revalidate/route.ts
+++ b/frontend/src/app/api/revalidate/route.ts
@@ -31,6 +31,13 @@ export async function POST(request: Request): Promise<NextResponse> {
   const tags = onlyStrings(body.tags);
   const paths = onlyStrings(body.paths);
 
+  if (tags.length === 0 && paths.length === 0) {
+    return NextResponse.json(
+      { error: "no tags or paths provided" },
+      { status: 400 },
+    );
+  }
+
   for (const tag of tags) revalidateTag(tag, "max");
   for (const path of paths) revalidatePath(path);
 

--- a/frontend/src/services/__tests__/breedImagesService.test.js
+++ b/frontend/src/services/__tests__/breedImagesService.test.js
@@ -64,7 +64,7 @@ describe("breedImagesService", () => {
           headers: expect.objectContaining({
             "Content-Type": "application/json",
           }),
-          next: { revalidate: 604800 },
+          next: { revalidate: 604800, tags: ["breed-images"] },
         }),
       );
       expect(result).toEqual(mockBreedsData);

--- a/frontend/src/services/breedImagesService.ts
+++ b/frontend/src/services/breedImagesService.ts
@@ -48,7 +48,7 @@ export async function getBreedsWithImages(
       headers: {
         "Content-Type": "application/json",
       },
-      next: { revalidate: 604800 },
+      next: { revalidate: 604800, tags: ["breed-images"] },
     } as RequestInit);
 
     if (!response.ok) {
@@ -90,7 +90,7 @@ export async function getBreedGroupsWithTopBreeds(): Promise<
     const statsUrl = `${API_URL}/api/animals/breeds/stats`;
     const statsResponse = await fetch(statsUrl, {
       headers: { "Content-Type": "application/json" },
-      next: { revalidate: 604800 },
+      next: { revalidate: 604800, tags: ["breed-stats"] },
     } as RequestInit);
 
     if (!statsResponse.ok) {
@@ -106,7 +106,7 @@ export async function getBreedGroupsWithTopBreeds(): Promise<
       const breedsWithImagesUrl = `${API_URL}/api/animals/breeds/with-images?min_count=2&limit=50`;
       const imagesResponse = await fetch(breedsWithImagesUrl, {
         headers: { "Content-Type": "application/json" },
-        next: { revalidate: 604800 },
+        next: { revalidate: 604800, tags: ["breed-images"] },
       } as RequestInit);
 
       if (imagesResponse.ok) {
@@ -221,7 +221,7 @@ export async function getBreedsWithImagesForHomePage(
       headers: {
         "Content-Type": "application/json",
       },
-      next: { revalidate: 604800 },
+      next: { revalidate: 604800, tags: ["breed-images"] },
     } as RequestInit);
 
     if (!response.ok) {

--- a/frontend/src/services/organizationsService.ts
+++ b/frontend/src/services/organizationsService.ts
@@ -139,7 +139,7 @@ export async function getEnhancedOrganizationsSSR(): Promise<EnhancedOrg[]> {
     const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
     const response = await fetch(`${apiUrl}/api/organizations/enhanced`, {
-      next: { revalidate: 604800 },
+      next: { revalidate: 604800, tags: ["organizations-enhanced"] },
       headers: {
         "Content-Type": "application/json",
       },

--- a/management/check_adoptions.py
+++ b/management/check_adoptions.py
@@ -358,14 +358,19 @@ def main():
             print("No organizations to check")
             sys.exit(0)
 
-        # Check each organization
-        for config in organizations:
-            command.check_organization(config, args.limit)
+        # Check each organization. Track partial success in a finally so
+        # the cache is invalidated even if a later org raises mid-loop —
+        # earlier orgs already wrote adoption status to the DB.
+        any_processed = False
+        try:
+            for config in organizations:
+                command.check_organization(config, args.limit)
+                any_processed = True
+        finally:
+            if any_processed and not args.dry_run:
+                from services.revalidation_client import invalidate_sync
 
-        if not args.dry_run:
-            from services.revalidation_client import invalidate_sync
-
-            invalidate_sync(tags=["animals", "animal", "statistics"])
+                invalidate_sync(tags=["animals", "animal", "statistics"])
 
         print("\n✅ Adoption checking complete!")
 

--- a/management/check_adoptions.py
+++ b/management/check_adoptions.py
@@ -362,6 +362,11 @@ def main():
         for config in organizations:
             command.check_organization(config, args.limit)
 
+        if not args.dry_run:
+            from services.revalidation_client import invalidate_sync
+
+            invalidate_sync(tags=["animals", "animal", "statistics"])
+
         print("\n✅ Adoption checking complete!")
 
         if args.dry_run:

--- a/management/config_commands.py
+++ b/management/config_commands.py
@@ -55,7 +55,12 @@ class ConfigManager:
         Args:
             dry_run: Only show what would be synced, don't make changes
         """
-        return self.cli.sync_organizations(dry_run)
+        result = self.cli.sync_organizations(dry_run)
+        if not dry_run:
+            from services.revalidation_client import invalidate_sync
+
+            invalidate_sync(tags=["organizations", "organizations-enhanced"])
+        return result
 
     def run_scraper(self, config_id: str, sync_first: bool = True):
         """Run a specific scraper.

--- a/scrapers/base_scraper.py
+++ b/scrapers/base_scraper.py
@@ -288,6 +288,7 @@ class BaseScraper(ABC):
             return True
 
         self._completion_logged = True
+        self._invalidate_frontend_cache()
 
         # Use injected DatabaseService if available
         if self.database_service:
@@ -321,6 +322,7 @@ class BaseScraper(ABC):
             return True
 
         self._completion_logged = True
+        self._invalidate_frontend_cache()
 
         # Use injected DatabaseService if available
         if self.database_service:
@@ -338,6 +340,33 @@ class BaseScraper(ABC):
 
         self.logger.info(f"Scrape completed with status: {status}, animals: {animals_found}")
         return True
+
+    def _invalidate_frontend_cache(self) -> None:
+        """Fire cache invalidation for the Next.js frontend.
+
+        Fire-and-forget. Failures (missing token, network errors) are logged
+        but never propagate — a cache-invalidation hiccup must not abort
+        scrape completion.
+        """
+        try:
+            from services.revalidation_client import invalidate_sync
+
+            invalidate_sync(
+                tags=[
+                    "animals",
+                    "animal",
+                    "enhanced",
+                    "statistics",
+                    "country-stats",
+                    "age-stats",
+                    "filter-counts",
+                    "breed-stats",
+                    "breed-images",
+                    "organizations-enhanced",
+                ]
+            )
+        except Exception as e:
+            self.logger.warning("Cache invalidation hook failed: %s", e)
 
     def detect_language(self, text):
         """Detect the language of the text.

--- a/scrapers/base_scraper.py
+++ b/scrapers/base_scraper.py
@@ -288,7 +288,8 @@ class BaseScraper(ABC):
             return True
 
         self._completion_logged = True
-        self._invalidate_frontend_cache()
+        if status == "success":
+            self._invalidate_frontend_cache()
 
         # Use injected DatabaseService if available
         if self.database_service:
@@ -322,7 +323,8 @@ class BaseScraper(ABC):
             return True
 
         self._completion_logged = True
-        self._invalidate_frontend_cache()
+        if status == "success":
+            self._invalidate_frontend_cache()
 
         # Use injected DatabaseService if available
         if self.database_service:
@@ -344,29 +346,31 @@ class BaseScraper(ABC):
     def _invalidate_frontend_cache(self) -> None:
         """Fire cache invalidation for the Next.js frontend.
 
-        Fire-and-forget. Failures (missing token, network errors) are logged
-        but never propagate — a cache-invalidation hiccup must not abort
-        scrape completion.
+        Fire-and-forget. ``invalidate_sync`` already swallows network and
+        HTTP errors internally, so the outer ``try`` only guards against
+        ``ImportError`` if the module is somehow missing — any other
+        exception is a bug worth surfacing through the inner handler.
         """
         try:
             from services.revalidation_client import invalidate_sync
+        except ImportError as e:
+            self.logger.warning("Cache invalidation hook unavailable: %s", e)
+            return
 
-            invalidate_sync(
-                tags=[
-                    "animals",
-                    "animal",
-                    "enhanced",
-                    "statistics",
-                    "country-stats",
-                    "age-stats",
-                    "filter-counts",
-                    "breed-stats",
-                    "breed-images",
-                    "organizations-enhanced",
-                ]
-            )
-        except Exception as e:
-            self.logger.warning("Cache invalidation hook failed: %s", e)
+        invalidate_sync(
+            tags=[
+                "animals",
+                "animal",
+                "enhanced",
+                "statistics",
+                "country-stats",
+                "age-stats",
+                "filter-counts",
+                "breed-stats",
+                "breed-images",
+                "organizations-enhanced",
+            ]
+        )
 
     def detect_language(self, text):
         """Detect the language of the text.

--- a/services/llm/dog_profiler.py
+++ b/services/llm/dog_profiler.py
@@ -304,7 +304,12 @@ class DogProfilerPipeline:
         Returns:
             True if successful
         """
-        return await self.database_updater.save_results(results)
+        saved = await self.database_updater.save_results(results)
+        if saved:
+            from services.revalidation_client import invalidate
+
+            await invalidate(tags=["animals", "animal", "enhanced"])
+        return saved
 
     # Context manager support
     async def __aenter__(self):

--- a/services/revalidation_client.py
+++ b/services/revalidation_client.py
@@ -1,0 +1,108 @@
+"""Fire-and-forget cache invalidation for the Next.js frontend.
+
+Posts to the /api/revalidate endpoint with a list of tags and/or paths so
+the Next.js Full Route Cache regenerates affected pages on the next request,
+instead of waiting for the time-based revalidate window to expire.
+
+Failures (missing token, network issues, non-2xx response) are logged but
+never raised. Callers (scrapers, LLM pipeline, CLIs) must not break because
+the cache invalidation step failed.
+
+Two entry points share validation logic via ``_build_request``:
+- ``invalidate`` for async callers (LLM pipeline)
+- ``invalidate_sync`` for sync callers (BaseScraper, management CLIs)
+
+``invalidate_sync`` uses ``httpx.Client`` directly so it does not allocate
+a fresh event loop — that previously caused suite-level test interference
+with code that calls ``asyncio.get_event_loop()``.
+"""
+
+import logging
+import os
+from collections.abc import Iterable
+from typing import Final
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_FRONTEND_URL: Final = "https://www.rescuedogs.me"
+_REVALIDATE_PATH: Final = "/api/revalidate"
+_HTTP_TIMEOUT_SECONDS: Final = 5.0
+
+
+def _build_request(
+    tags: Iterable[str],
+    paths: Iterable[str],
+) -> dict | None:
+    """Validate auth/payload. Returns ``None`` if the call should be skipped."""
+    token = os.getenv("REVALIDATION_TOKEN")
+    if not token:
+        logger.warning("REVALIDATION_TOKEN not set; skipping cache invalidation")
+        return None
+
+    tag_list = [t for t in tags if t]
+    path_list = [p for p in paths if p]
+    if not tag_list and not path_list:
+        return None
+
+    base_url = os.getenv("FRONTEND_URL", _DEFAULT_FRONTEND_URL).rstrip("/")
+    return {
+        "url": f"{base_url}{_REVALIDATE_PATH}",
+        "headers": {"x-revalidate-token": token},
+        "json": {"tags": tag_list, "paths": path_list},
+        "tag_list": tag_list,
+        "path_list": path_list,
+    }
+
+
+async def invalidate(
+    tags: Iterable[str] = (),
+    paths: Iterable[str] = (),
+) -> None:
+    """Async invalidation entry point — for use inside ``async def`` callers."""
+    req = _build_request(tags, paths)
+    if req is None:
+        return
+
+    try:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SECONDS) as client:
+            response = await client.post(
+                req["url"],
+                headers=req["headers"],
+                json=req["json"],
+            )
+            response.raise_for_status()
+            logger.info(
+                "cache invalidated: tags=%s paths=%s",
+                req["tag_list"],
+                req["path_list"],
+            )
+    except Exception as e:
+        logger.error("cache invalidation failed: %s", e)
+
+
+def invalidate_sync(
+    tags: Iterable[str] = (),
+    paths: Iterable[str] = (),
+) -> None:
+    """Sync invalidation entry point — for use in sync callers (CLIs, scrapers)."""
+    req = _build_request(tags, paths)
+    if req is None:
+        return
+
+    try:
+        with httpx.Client(timeout=_HTTP_TIMEOUT_SECONDS) as client:
+            response = client.post(
+                req["url"],
+                headers=req["headers"],
+                json=req["json"],
+            )
+            response.raise_for_status()
+            logger.info(
+                "cache invalidated: tags=%s paths=%s",
+                req["tag_list"],
+                req["path_list"],
+            )
+    except Exception as e:
+        logger.error("cache invalidation failed: %s", e)

--- a/services/revalidation_client.py
+++ b/services/revalidation_client.py
@@ -78,8 +78,21 @@ async def invalidate(
                 req["tag_list"],
                 req["path_list"],
             )
-    except Exception as e:
-        logger.error("cache invalidation failed: %s", e)
+    except httpx.HTTPError as e:
+        logger.warning(
+            "cache invalidation network failure: url=%s tags=%s paths=%s err=%s",
+            req["url"],
+            req["tag_list"],
+            req["path_list"],
+            e,
+        )
+    except Exception:
+        logger.exception(
+            "cache invalidation unexpected error: url=%s tags=%s paths=%s",
+            req["url"],
+            req["tag_list"],
+            req["path_list"],
+        )
 
 
 def invalidate_sync(
@@ -104,5 +117,18 @@ def invalidate_sync(
                 req["tag_list"],
                 req["path_list"],
             )
-    except Exception as e:
-        logger.error("cache invalidation failed: %s", e)
+    except httpx.HTTPError as e:
+        logger.warning(
+            "cache invalidation network failure: url=%s tags=%s paths=%s err=%s",
+            req["url"],
+            req["tag_list"],
+            req["path_list"],
+            e,
+        )
+    except Exception:
+        logger.exception(
+            "cache invalidation unexpected error: url=%s tags=%s paths=%s",
+            req["url"],
+            req["tag_list"],
+            req["path_list"],
+        )

--- a/tests/scrapers/test_base_scraper_cache_invalidation.py
+++ b/tests/scrapers/test_base_scraper_cache_invalidation.py
@@ -1,0 +1,80 @@
+"""Test cache invalidation gating on scrape completion status.
+
+Failed and partial-failure scrapes must NOT invalidate the frontend cache —
+otherwise a Playwright timeout that produces a stale/empty result would
+trigger a refresh that replaces good data with bad. Only ``status="success"``
+should fire the invalidation hook.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from scrapers.base_scraper import BaseScraper
+from services.database_service import DatabaseService
+
+
+class _StubScraper(BaseScraper):
+    """Minimal concrete BaseScraper subclass for testing completion hooks."""
+
+    def collect_data(self):
+        return []
+
+
+@pytest.fixture
+def scraper():
+    """Build a scraper with a mocked DB service so completion logging is a no-op."""
+    mock_db = Mock(spec=DatabaseService)
+    mock_db.complete_scrape_log.return_value = True
+    return _StubScraper(organization_id=1, database_service=mock_db)
+
+
+@pytest.fixture
+def mock_invalidate_sync():
+    """Patch invalidate_sync at the source so any import-form reaches the mock."""
+    with patch("services.revalidation_client.invalidate_sync") as mock:
+        yield mock
+
+
+@pytest.mark.unit
+class TestCompleteScrapeLogCacheInvalidation:
+    """``complete_scrape_log`` fires cache invalidation only on success."""
+
+    def test_fires_on_success(self, scraper, mock_invalidate_sync):
+        scraper.complete_scrape_log(status="success", animals_found=10)
+        mock_invalidate_sync.assert_called_once()
+        # Expect the bulk tag set so all consumer pages refresh
+        kwargs = mock_invalidate_sync.call_args.kwargs
+        assert "animals" in kwargs["tags"]
+        assert "animal" in kwargs["tags"]
+        assert "statistics" in kwargs["tags"]
+
+    def test_skips_on_warning(self, scraper, mock_invalidate_sync):
+        scraper.complete_scrape_log(status="warning", animals_found=0)
+        mock_invalidate_sync.assert_not_called()
+
+    def test_skips_on_error(self, scraper, mock_invalidate_sync):
+        scraper.complete_scrape_log(status="error", animals_found=0)
+        mock_invalidate_sync.assert_not_called()
+
+    def test_skips_on_unknown_status(self, scraper, mock_invalidate_sync):
+        """Defensive default: any status that isn't exactly "success" skips."""
+        scraper.complete_scrape_log(status="completed", animals_found=10)
+        mock_invalidate_sync.assert_not_called()
+
+
+@pytest.mark.unit
+class TestCompleteScrapeLogWithMetricsCacheInvalidation:
+    """Same gating applies to the metrics variant."""
+
+    def test_fires_on_success(self, scraper, mock_invalidate_sync):
+        scraper.complete_scrape_log_with_metrics(status="success", animals_found=5)
+        mock_invalidate_sync.assert_called_once()
+
+    def test_skips_on_warning(self, scraper, mock_invalidate_sync):
+        scraper.complete_scrape_log_with_metrics(status="warning")
+        mock_invalidate_sync.assert_not_called()
+
+    def test_skips_on_error(self, scraper, mock_invalidate_sync):
+        scraper.complete_scrape_log_with_metrics(status="error")
+        mock_invalidate_sync.assert_not_called()

--- a/tests/services/test_revalidation_client.py
+++ b/tests/services/test_revalidation_client.py
@@ -125,10 +125,10 @@ class TestInvalidate:
         with patch("services.revalidation_client.httpx.AsyncClient") as mock_class:
             mock_class.return_value.__aenter__ = AsyncMock(return_value=mock_client_instance)
             mock_class.return_value.__aexit__ = AsyncMock(return_value=None)
-            with caplog.at_level(logging.ERROR):
+            with caplog.at_level(logging.WARNING):
                 await invalidate(tags=["foo"])
 
-        assert "cache invalidation failed" in caplog.text
+        assert "cache invalidation network failure" in caplog.text
 
     @pytest.mark.asyncio
     async def test_swallows_network_error(self, monkeypatch, caplog):
@@ -141,10 +141,28 @@ class TestInvalidate:
         with patch("services.revalidation_client.httpx.AsyncClient") as mock_class:
             mock_class.return_value.__aenter__ = AsyncMock(return_value=mock_client_instance)
             mock_class.return_value.__aexit__ = AsyncMock(return_value=None)
+            with caplog.at_level(logging.WARNING):
+                await invalidate(tags=["foo"])
+
+        assert "cache invalidation network failure" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_logs_traceback_on_unexpected_error(self, monkeypatch, caplog):
+        """Programmer errors (TypeError, AttributeError) go to logger.exception
+        so the traceback reaches Sentry — never silently swallowed."""
+        monkeypatch.setenv("REVALIDATION_TOKEN", "secret")
+        from services.revalidation_client import invalidate
+
+        mock_client_instance = AsyncMock()
+        mock_client_instance.post = AsyncMock(side_effect=TypeError("boom"))
+
+        with patch("services.revalidation_client.httpx.AsyncClient") as mock_class:
+            mock_class.return_value.__aenter__ = AsyncMock(return_value=mock_client_instance)
+            mock_class.return_value.__aexit__ = AsyncMock(return_value=None)
             with caplog.at_level(logging.ERROR):
                 await invalidate(tags=["foo"])
 
-        assert "cache invalidation failed" in caplog.text
+        assert "cache invalidation unexpected error" in caplog.text
 
 
 @pytest.mark.unit
@@ -194,7 +212,7 @@ class TestInvalidateSync:
         with patch("services.revalidation_client.httpx.Client") as mock_class:
             mock_class.return_value.__enter__ = MagicMock(return_value=mock_client_instance)
             mock_class.return_value.__exit__ = MagicMock(return_value=None)
-            with caplog.at_level(logging.ERROR):
+            with caplog.at_level(logging.WARNING):
                 invalidate_sync(tags=["foo"])
 
-        assert "cache invalidation failed" in caplog.text
+        assert "cache invalidation network failure" in caplog.text

--- a/tests/services/test_revalidation_client.py
+++ b/tests/services/test_revalidation_client.py
@@ -1,0 +1,200 @@
+"""Tests for services.revalidation_client.
+
+Covers fire-and-forget semantics: never raises, even on network/HTTP errors.
+Token-based auth, URL override, and the sync entry point.
+"""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+
+@pytest.fixture
+def mock_async_client():
+    """Mocked httpx.AsyncClient where the post() call is inspectable."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client_instance = AsyncMock()
+    mock_client_instance.post = AsyncMock(return_value=mock_response)
+
+    with patch("services.revalidation_client.httpx.AsyncClient") as mock_class:
+        mock_class.return_value.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_class.return_value.__aexit__ = AsyncMock(return_value=None)
+        yield mock_client_instance
+
+
+@pytest.fixture
+def mock_sync_client():
+    """Mocked httpx.Client where the post() call is inspectable."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client_instance = MagicMock()
+    mock_client_instance.post = MagicMock(return_value=mock_response)
+
+    with patch("services.revalidation_client.httpx.Client") as mock_class:
+        mock_class.return_value.__enter__ = MagicMock(return_value=mock_client_instance)
+        mock_class.return_value.__exit__ = MagicMock(return_value=None)
+        yield mock_client_instance
+
+
+@pytest.mark.unit
+class TestInvalidate:
+    """Behavior of the async invalidate() function."""
+
+    @pytest.mark.asyncio
+    async def test_skips_when_token_missing(self, monkeypatch, caplog):
+        monkeypatch.delenv("REVALIDATION_TOKEN", raising=False)
+        from services.revalidation_client import invalidate
+
+        with patch("services.revalidation_client.httpx.AsyncClient") as mock_client:
+            with caplog.at_level(logging.WARNING):
+                await invalidate(tags=["animals"])
+
+        mock_client.assert_not_called()
+        assert "REVALIDATION_TOKEN" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_skips_when_no_tags_or_paths(self, monkeypatch):
+        monkeypatch.setenv("REVALIDATION_TOKEN", "secret")
+        from services.revalidation_client import invalidate
+
+        with patch("services.revalidation_client.httpx.AsyncClient") as mock_client:
+            await invalidate()
+
+        mock_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_posts_with_token_and_payload(self, monkeypatch, mock_async_client):
+        monkeypatch.setenv("REVALIDATION_TOKEN", "secret")
+        monkeypatch.delenv("FRONTEND_URL", raising=False)
+        from services.revalidation_client import invalidate
+
+        await invalidate(tags=["animals", "statistics"], paths=["/dogs/buddy"])
+
+        mock_async_client.post.assert_called_once_with(
+            "https://www.rescuedogs.me/api/revalidate",
+            headers={"x-revalidate-token": "secret"},
+            json={
+                "tags": ["animals", "statistics"],
+                "paths": ["/dogs/buddy"],
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_uses_custom_frontend_url(self, monkeypatch, mock_async_client):
+        monkeypatch.setenv("REVALIDATION_TOKEN", "secret")
+        monkeypatch.setenv("FRONTEND_URL", "https://staging.example.com/")
+        from services.revalidation_client import invalidate
+
+        await invalidate(tags=["foo"])
+
+        called_url = mock_async_client.post.call_args[0][0]
+        assert called_url == "https://staging.example.com/api/revalidate"
+
+    @pytest.mark.asyncio
+    async def test_filters_empty_string_entries(self, monkeypatch, mock_async_client):
+        monkeypatch.setenv("REVALIDATION_TOKEN", "secret")
+        from services.revalidation_client import invalidate
+
+        await invalidate(tags=["animals", "", None], paths=["", "/ok"])
+
+        payload = mock_async_client.post.call_args.kwargs["json"]
+        assert payload == {"tags": ["animals"], "paths": ["/ok"]}
+
+    @pytest.mark.asyncio
+    async def test_swallows_http_status_error(self, monkeypatch, caplog):
+        monkeypatch.setenv("REVALIDATION_TOKEN", "secret")
+        from services.revalidation_client import invalidate
+
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "401 Unauthorized",
+                request=MagicMock(),
+                response=mock_response,
+            )
+        )
+        mock_client_instance = AsyncMock()
+        mock_client_instance.post = AsyncMock(return_value=mock_response)
+
+        with patch("services.revalidation_client.httpx.AsyncClient") as mock_class:
+            mock_class.return_value.__aenter__ = AsyncMock(return_value=mock_client_instance)
+            mock_class.return_value.__aexit__ = AsyncMock(return_value=None)
+            with caplog.at_level(logging.ERROR):
+                await invalidate(tags=["foo"])
+
+        assert "cache invalidation failed" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_swallows_network_error(self, monkeypatch, caplog):
+        monkeypatch.setenv("REVALIDATION_TOKEN", "secret")
+        from services.revalidation_client import invalidate
+
+        mock_client_instance = AsyncMock()
+        mock_client_instance.post = AsyncMock(side_effect=httpx.ConnectError("connection refused"))
+
+        with patch("services.revalidation_client.httpx.AsyncClient") as mock_class:
+            mock_class.return_value.__aenter__ = AsyncMock(return_value=mock_client_instance)
+            mock_class.return_value.__aexit__ = AsyncMock(return_value=None)
+            with caplog.at_level(logging.ERROR):
+                await invalidate(tags=["foo"])
+
+        assert "cache invalidation failed" in caplog.text
+
+
+@pytest.mark.unit
+class TestInvalidateSync:
+    """Behavior of the sync invalidate_sync() function."""
+
+    def test_skips_when_token_missing(self, monkeypatch, caplog):
+        monkeypatch.delenv("REVALIDATION_TOKEN", raising=False)
+        from services.revalidation_client import invalidate_sync
+
+        with patch("services.revalidation_client.httpx.Client") as mock_client:
+            with caplog.at_level(logging.WARNING):
+                invalidate_sync(tags=["animals"])
+
+        mock_client.assert_not_called()
+        assert "REVALIDATION_TOKEN" in caplog.text
+
+    def test_skips_when_no_tags_or_paths(self, monkeypatch):
+        monkeypatch.setenv("REVALIDATION_TOKEN", "secret")
+        from services.revalidation_client import invalidate_sync
+
+        with patch("services.revalidation_client.httpx.Client") as mock_client:
+            invalidate_sync()
+
+        mock_client.assert_not_called()
+
+    def test_posts_with_token_and_payload(self, monkeypatch, mock_sync_client):
+        monkeypatch.setenv("REVALIDATION_TOKEN", "secret")
+        monkeypatch.delenv("FRONTEND_URL", raising=False)
+        from services.revalidation_client import invalidate_sync
+
+        invalidate_sync(tags=["animals"], paths=["/x"])
+
+        mock_sync_client.post.assert_called_once_with(
+            "https://www.rescuedogs.me/api/revalidate",
+            headers={"x-revalidate-token": "secret"},
+            json={"tags": ["animals"], "paths": ["/x"]},
+        )
+
+    def test_swallows_network_error(self, monkeypatch, caplog):
+        monkeypatch.setenv("REVALIDATION_TOKEN", "secret")
+        from services.revalidation_client import invalidate_sync
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.post = MagicMock(side_effect=httpx.ConnectError("connection refused"))
+
+        with patch("services.revalidation_client.httpx.Client") as mock_class:
+            mock_class.return_value.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_class.return_value.__exit__ = MagicMock(return_value=None)
+            with caplog.at_level(logging.ERROR):
+                invalidate_sync(tags=["foo"])
+
+        assert "cache invalidation failed" in caplog.text


### PR DESCRIPTION
## Summary

Follow-up to #205. Adds event-driven cache invalidation so the Next.js
frontend refreshes the moment a scraper, LLM run, or config sync changes
persistent state — replacing the purely time-based ISR revalidation that
PR #205 calibrated against scraper cadence.

Once observed stable in production, page `revalidate` values can be raised
further (or set to `false`) in a follow-up.

## What changed

### 1. Frontend `/api/revalidate` endpoint

`frontend/src/app/api/revalidate/route.ts` — `force-dynamic` App Router POST handler:

- Auth: `x-revalidate-token` header must match `process.env.REVALIDATION_TOKEN`. Fails closed (401) when env unset.
- Body: `{ tags?: string[], paths?: string[] }`. Non-array values and non-string entries ignored. Malformed JSON tolerated.
- Calls `revalidateTag(tag, "max")` and `revalidatePath(path)`. Next.js 16 made `revalidateTag`'s profile arg required — `"max"` preserves the pre-16 semantic per the deprecation-warning recommendation.

Test coverage (`route.test.ts`, 8 tests):
- 401 when token missing / wrong / env unset
- 200 + correct invocations on valid token
- Empty/malformed body, non-array values, non-string entries — all tolerated

### 2. Cache tags on the 5 remaining untagged fetches

| File | Fetch | Tag |
|---|---|---|
| `breedImagesService.ts:51` | `getBreedsWithImages` | `breed-images` |
| `breedImagesService.ts:93` | `getBreedGroupsWithTopBreeds` (stats) | `breed-stats` (reuse existing) |
| `breedImagesService.ts:109` | `getBreedGroupsWithTopBreeds` (images) | `breed-images` |
| `breedImagesService.ts:224` | `getBreedsWithImagesForHomePage` | `breed-images` |
| `organizationsService.ts:142` | `getEnhancedOrganizationsSSR` | `organizations-enhanced` |

Total tagged fetch coverage is now 22/22 across the 4 server-side service files.

### 3. Python client `services/revalidation_client.py`

Two entry points, both fire-and-forget (log on failure, never raise):

- `async def invalidate(tags, paths)` — for async callers (`DogProfilerPipeline.save_results`)
- `def invalidate_sync(tags, paths)` — for sync callers (`BaseScraper`, management CLIs). Uses `httpx.Client` directly rather than `asyncio.run`, so it does not allocate a new event loop. (An earlier version did, which caused suite-level interference with tests calling `asyncio.get_event_loop()`.)

Shared `_build_request()` handles env validation (`REVALIDATION_TOKEN`, `FRONTEND_URL`) and payload filtering (empty strings dropped, no-op when both lists empty).

Test coverage (`test_revalidation_client.py`, 11 tests):
- Skip when token missing / payload empty
- Posts with correct URL, headers, body
- Custom `FRONTEND_URL` honored
- Swallows non-2xx, network errors
- Both async and sync entry points covered

### 4. Hooks at all four data-change events

Phase 1 discovery confirmed all in-scraper events (adoption detection, LLM enrichment, per-org sync) already happen inside `BaseScraper.run()` BEFORE `complete_scrape_log*`. So **one hook on BaseScraper completion covers the entire scraper-driven flow.** The other hooks cover only standalone CLIs.

| Hook site | File:line | Fires on |
|---|---|---|
| `BaseScraper._invalidate_frontend_cache` | `scrapers/base_scraper.py` (called from `complete_scrape_log:290` and `complete_scrape_log_with_metrics:323`) | Every scraper run completion (success, failure, abort — `_completion_logged` guard ensures single fire). Broad tag set covers dogs/breeds/orgs/stats. |
| `DogProfilerPipeline.save_results` | `services/llm/dog_profiler.py:297-313` | Standalone LLM CLI runs (`management/llm_commands.py:generate-profiles`, `management/config_commands.py:profile_dogs`). Tags: `animals`, `animal`, `enhanced`. |
| `CheckAdoptionsCommand` end-of-batch | `management/check_adoptions.py:363-369` | Standalone adoption-detection CLI (skipped on `--dry-run`). Tags: `animals`, `animal`, `statistics`. |
| `ConfigManager.sync_organizations` | `management/config_commands.py:52-64` | Manual org config sync (skipped on `--dry-run`). Tags: `organizations`, `organizations-enhanced`. |

### 5. Env vars

Documented in `.env.sample`:

- `REVALIDATION_TOKEN` — shared secret. Set in Railway env (backend) AND Vercel env (frontend, both production and preview). Generate with `openssl rand -hex 32`. When unset, all callers skip invalidation with a warning — site falls back to the time-based revalidate windows from PR #205.
- `FRONTEND_URL` — optional override (defaults to `https://www.rescuedogs.me`). Useful for staging environments.

## Verification

- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm lint` — 0 errors, 25 pre-existing warnings unrelated
- [x] `pnpm jest` — 3,535 passed, 20 skipped, 0 failed (includes 8 new route tests)
- [x] `pnpm build` — `/api/revalidate` appears as `ƒ Dynamic`; all ISR page revalidate values from PR #205 unchanged in route table
- [x] `uv run ruff check .` + `ruff format .` — clean
- [x] `uv run pytest -m 'not slow and not browser and not external'` — 1,443 passed, 4 skipped, 0 failed (includes 11 new revalidation_client tests)
- [x] No "coroutine never awaited" warnings introduced
- [x] BaseScraper test suite unchanged behavior (`test_basescraper_with_database_service`, `test_partial_failure_alerting`) — pre-existing tests still green

## Deployment checklist (for after merge)

1. **Generate token**: `openssl rand -hex 32`
2. **Set `REVALIDATION_TOKEN`** in Vercel (production + preview environments) AND Railway environment variables — same value in both.
3. **Optional**: set `FRONTEND_URL` in Railway if not deploying to `www.rescuedogs.me`.
4. **Trigger a scraper manually** and confirm Vercel logs show a POST to `/api/revalidate` returning 200.
5. **Observe for 1–2 weeks**: cached pages refresh within seconds of scraper completion instead of waiting for the time-based window. Once confirmed, open a follow-up PR raising `revalidate` values further (target: `false` on detail pages, longer windows on hubs).

## Out of scope (deliberate follow-ups)

- Raising page-level `revalidate` values further (separate PR after observation window)
- Per-dog slug-tagged invalidation — current bulk `"animal"` tag covers all detail pages
- FastAPI backend mutation hooks — none found that mutate state the frontend needs to know about
- Deleting unused `getAllAnimals` from `serverAnimalsService.ts` (still pending from #205 code review)