### PR TITLE
feat(scraper): wake/stop Browserless around cron runs

### DIFF
--- a/management/railway_scraper_cron.py
+++ b/management/railway_scraper_cron.py
@@ -130,28 +130,38 @@ def format_batch_summary(result: BatchRunResult, start_time: datetime) -> dict:
 
 
 def start_browserless(controller: RailwayServiceController) -> bool:
-    """Redeploy Browserless and wait for it to be healthy. Returns True on success."""
+    """Trigger a Browserless redeploy and wait until it returns 2xx at BROWSERLESS_HEALTH_URL.
+
+    Returns True only when the health check passes. Returns False if:
+    - BROWSERLESS_HEALTH_URL is not set (treated as misconfiguration — scrapers would race the redeploy)
+    - controller.redeploy() raises (logged via logger.exception)
+    - the health check times out (logged inside wait_for_healthy)
+
+    Callers must treat False as fatal: scrapers should not run against a Browserless that isn't confirmed up.
+    """
     health_url = os.getenv("BROWSERLESS_HEALTH_URL")
     if not health_url:
-        logger.warning("BROWSERLESS_HEALTH_URL not set; skipping health check after redeploy")
-
-    try:
-        status = controller.redeploy()
-    except Exception:
-        logger.exception("Failed to redeploy Browserless; scrapers will likely fail")
+        logger.error("BROWSERLESS_HEALTH_URL is required when Browserless control is configured; without it, scrapers would race the redeploy. Refusing to proceed.")
         return False
 
-    logger.info("Browserless redeploy initiated (status=%s)", status)
+    try:
+        deployment = controller.redeploy()
+    except Exception:
+        logger.exception("Failed to redeploy Browserless")
+        return False
 
-    if not health_url:
-        return True
-
+    logger.info("Browserless redeploy initiated: deployment=%s status=%s", deployment.id, deployment.status)
     timeout = float(os.getenv("BROWSERLESS_HEALTH_TIMEOUT", "180"))
     return controller.wait_for_healthy(health_url, timeout=timeout)
 
 
 def stop_browserless(controller: RailwayServiceController) -> None:
-    """Stop the Browserless deployment. Logs but does not raise on failure."""
+    """Best-effort stop of the Browserless deployment from the cron's finally block.
+
+    Swallows exceptions so a stop failure doesn't mask scrape results. controller.stop()
+    already logs its own outcome (no deployment / already terminal / successful stop), so
+    the return value is intentionally not propagated.
+    """
     try:
         controller.stop()
     except Exception:
@@ -237,10 +247,13 @@ def main():
         sys.exit(1)
 
     browserless = RailwayServiceController.from_env()
-    if browserless is not None:
-        start_browserless(browserless)
+    summary: dict | None = None
 
     try:
+        if browserless is not None and not start_browserless(browserless):
+            logger.error("Browserless wake failed; aborting cron run to avoid wasted scrape attempts")
+            sys.exit(1)
+
         if args.org:
             result = run_single_scraper(runner, args.org)
             if args.json:
@@ -259,6 +272,8 @@ def main():
         if browserless is not None:
             stop_browserless(browserless)
             browserless.close()
+
+    assert summary is not None  # batch path always sets summary; --org path exited above
 
     if args.json:
         print(json.dumps(summary, indent=2))

--- a/management/railway_scraper_cron.py
+++ b/management/railway_scraper_cron.py
@@ -35,6 +35,7 @@ if project_root not in sys.path:
 
 from config import enable_world_class_scraper_logging, get_database_config  # noqa: E402
 from scrapers.sentry_integration import add_scrape_breadcrumb, init_scraper_sentry  # noqa: E402
+from services.railway.service_controller import RailwayServiceController  # noqa: E402
 from utils.db_connection import (  # noqa: E402
     create_database_config_from_env,
     initialize_database_pool,
@@ -128,6 +129,35 @@ def format_batch_summary(result: BatchRunResult, start_time: datetime) -> dict:
     }
 
 
+def start_browserless(controller: RailwayServiceController) -> bool:
+    """Redeploy Browserless and wait for it to be healthy. Returns True on success."""
+    health_url = os.getenv("BROWSERLESS_HEALTH_URL")
+    if not health_url:
+        logger.warning("BROWSERLESS_HEALTH_URL not set; skipping health check after redeploy")
+
+    try:
+        status = controller.redeploy()
+    except Exception:
+        logger.exception("Failed to redeploy Browserless; scrapers will likely fail")
+        return False
+
+    logger.info("Browserless redeploy initiated (status=%s)", status)
+
+    if not health_url:
+        return True
+
+    timeout = float(os.getenv("BROWSERLESS_HEALTH_TIMEOUT", "180"))
+    return controller.wait_for_healthy(health_url, timeout=timeout)
+
+
+def stop_browserless(controller: RailwayServiceController) -> None:
+    """Stop the Browserless deployment. Logs but does not raise on failure."""
+    try:
+        controller.stop()
+    except Exception:
+        logger.exception("Failed to stop Browserless; idle Chrome will keep billing until next run")
+
+
 def list_available_scrapers(runner: SecureConfigScraperRunner) -> None:
     """List all available scrapers and their status."""
     scrapers = runner.list_available_scrapers()
@@ -206,20 +236,29 @@ def main():
         logger.warning("Shutdown requested before scraping started")
         sys.exit(1)
 
-    if args.org:
-        result = run_single_scraper(runner, args.org)
-        if args.json:
-            print(json.dumps(result, indent=2))
-        else:
-            if result["success"]:
-                logger.info(f"Scraper completed: {result['organization']} - {result['animals_found']} animals found")
+    browserless = RailwayServiceController.from_env()
+    if browserless is not None:
+        start_browserless(browserless)
+
+    try:
+        if args.org:
+            result = run_single_scraper(runner, args.org)
+            if args.json:
+                print(json.dumps(result, indent=2))
             else:
-                logger.error(f"Scraper failed: {result['error']}")
+                if result["success"]:
+                    logger.info(f"Scraper completed: {result['organization']} - {result['animals_found']} animals found")
+                else:
+                    logger.error(f"Scraper failed: {result['error']}")
 
-        sys.exit(0 if result["success"] else 1)
+            sys.exit(0 if result["success"] else 1)
 
-    batch_result = run_all_scrapers(runner)
-    summary = format_batch_summary(batch_result, start_time)
+        batch_result = run_all_scrapers(runner)
+        summary = format_batch_summary(batch_result, start_time)
+    finally:
+        if browserless is not None:
+            stop_browserless(browserless)
+            browserless.close()
 
     if args.json:
         print(json.dumps(summary, indent=2))

--- a/services/railway/service_controller.py
+++ b/services/railway/service_controller.py
@@ -15,13 +15,34 @@ import logging
 import os
 import time
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 import httpx
 
 logger = logging.getLogger(__name__)
 
 RAILWAY_GRAPHQL_ENDPOINT = "https://backboard.railway.com/graphql/v2"
+
+DeploymentStatus = Literal[
+    "INITIALIZING",
+    "BUILDING",
+    "DEPLOYING",
+    "SUCCESS",
+    "REMOVING",
+    "REMOVED",
+    "CRASHED",
+    "FAILED",
+    "SKIPPED",
+    "QUEUED",
+]
+
+_TERMINAL_STATUSES: frozenset[DeploymentStatus] = frozenset({"REMOVED", "CRASHED", "FAILED"})
+
+_BASE_REQUIRED_ENV_NAMES: tuple[str, ...] = (
+    "RAILWAY_API_TOKEN",
+    "RAILWAY_PROJECT_ID",
+    "RAILWAY_ENVIRONMENT_ID",
+)
 
 _LATEST_DEPLOYMENT_QUERY = """
 query latestDeployment($input: DeploymentListInput!) {
@@ -53,7 +74,7 @@ mutation deploymentRedeploy($id: String!) {
 
 
 class RailwayApiError(RuntimeError):
-    """Raised when the Railway GraphQL API returns an error."""
+    """Raised on any Railway GraphQL error: API error response, malformed payload, or unexpected schema."""
 
 
 @dataclass(frozen=True)
@@ -63,15 +84,13 @@ class Deployment:
 
 
 class RailwayServiceController:
-    """Controls a single Railway service via GraphQL: stop, redeploy, wait-for-health."""
-
     def __init__(
         self,
         api_token: str,
+        *,
         project_id: str,
         environment_id: str,
         service_id: str,
-        *,
         client: httpx.Client | None = None,
         request_timeout: float = 30.0,
     ) -> None:
@@ -90,31 +109,34 @@ class RailwayServiceController:
 
     @classmethod
     def from_env(cls, service_id_env: str = "BROWSERLESS_SERVICE_ID") -> RailwayServiceController | None:
-        """Build a controller from environment variables. Returns None if not fully configured."""
+        """Build a controller from environment variables.
+
+        Returns None if any required variable is missing. Logs at WARNING when *some but
+        not all* are set (likely misconfiguration) and INFO when all are unset (deliberately off).
+        """
+        required_names = (*_BASE_REQUIRED_ENV_NAMES, service_id_env)
+        missing = [name for name in required_names if not os.getenv(name)]
+        if missing:
+            if len(missing) < len(required_names):
+                logger.warning(
+                    "Railway service control PARTIALLY configured; missing env vars suggest misconfiguration: %s",
+                    ", ".join(missing),
+                )
+            else:
+                logger.info("Railway service control disabled (no env vars set)")
+            return None
+
         api_token = os.getenv("RAILWAY_API_TOKEN")
         project_id = os.getenv("RAILWAY_PROJECT_ID")
         environment_id = os.getenv("RAILWAY_ENVIRONMENT_ID")
         service_id = os.getenv(service_id_env)
-
-        missing = [
-            name
-            for name, value in (
-                ("RAILWAY_API_TOKEN", api_token),
-                ("RAILWAY_PROJECT_ID", project_id),
-                ("RAILWAY_ENVIRONMENT_ID", environment_id),
-                (service_id_env, service_id),
-            )
-            if not value
-        ]
-        if missing:
-            logger.info("Railway service control disabled (missing env: %s)", ", ".join(missing))
-            return None
+        assert api_token and project_id and environment_id and service_id  # narrowed by `missing` check above
 
         return cls(
-            api_token=api_token,  # type: ignore[arg-type]
-            project_id=project_id,  # type: ignore[arg-type]
-            environment_id=environment_id,  # type: ignore[arg-type]
-            service_id=service_id,  # type: ignore[arg-type]
+            api_token=api_token,
+            project_id=project_id,
+            environment_id=environment_id,
+            service_id=service_id,
         )
 
     def close(self) -> None:
@@ -128,7 +150,6 @@ class RailwayServiceController:
         self.close()
 
     def latest_deployment(self) -> Deployment | None:
-        """Return the most recent deployment for the service, or None if there isn't one."""
         data = self._graphql(
             _LATEST_DEPLOYMENT_QUERY,
             {
@@ -139,61 +160,91 @@ class RailwayServiceController:
                 }
             },
         )
-        edges = data["deployments"]["edges"]
-        if not edges:
-            return None
-        node = edges[0]["node"]
-        return Deployment(id=node["id"], status=node["status"])
+        try:
+            edges = data["deployments"]["edges"]
+            if not edges:
+                return None
+            node = edges[0]["node"]
+            return Deployment(id=node["id"], status=node["status"])
+        except (KeyError, TypeError) as exc:
+            raise RailwayApiError(f"Unexpected response shape from latestDeployment: {data!r}") from exc
 
     def stop(self) -> bool:
-        """Stop the running deployment. Returns True on success, False if nothing to stop."""
+        """Stop the latest deployment if it's running.
+
+        Returns True if a stop mutation was issued, False if there's no deployment or
+        it's already in a terminal state (REMOVED/CRASHED/FAILED).
+        """
         deployment = self.latest_deployment()
         if deployment is None:
             logger.warning("No deployment found for service %s; nothing to stop", self._service_id)
             return False
-        if deployment.status in {"REMOVED", "CRASHED", "FAILED"}:
-            logger.info("Deployment %s already in non-running state: %s", deployment.id, deployment.status)
+        if deployment.status in _TERMINAL_STATUSES:
+            logger.info("Deployment %s already in terminal state: %s", deployment.id, deployment.status)
             return False
 
         logger.info("Stopping deployment %s (status=%s)", deployment.id, deployment.status)
         self._graphql(_STOP_DEPLOYMENT_MUTATION, {"id": deployment.id})
         return True
 
-    def redeploy(self) -> str:
-        """Redeploy the latest deployment. Returns the new deployment status."""
+    def redeploy(self) -> Deployment:
+        """Redeploy the latest deployment.
+
+        Raises RailwayApiError if no prior deployment exists or the API returns an error.
+        """
         deployment = self.latest_deployment()
         if deployment is None:
             raise RailwayApiError(f"No deployment exists for service {self._service_id} to redeploy")
 
         logger.info("Redeploying deployment %s (current status=%s)", deployment.id, deployment.status)
         data = self._graphql(_REDEPLOY_MUTATION, {"id": deployment.id})
-        return data["deploymentRedeploy"]["status"]
+        try:
+            node = data["deploymentRedeploy"]
+            return Deployment(id=node["id"], status=node["status"])
+        except (KeyError, TypeError) as exc:
+            raise RailwayApiError(f"Unexpected response shape from deploymentRedeploy: {data!r}") from exc
 
     def wait_for_healthy(self, health_url: str, *, timeout: float = 180.0, interval: float = 3.0) -> bool:
-        """Poll `health_url` until it returns 2xx or timeout elapses. Returns True on success."""
+        """Poll health_url until it returns 2xx or timeout elapses.
+
+        Returns True on the first 2xx response, False if the deadline passes (also logs
+        an ERROR with attempts and the last observed failure).
+        """
         deadline = time.monotonic() + timeout
         attempts = 0
         last_error: str | None = None
 
-        while time.monotonic() < deadline:
-            attempts += 1
-            try:
-                response = httpx.get(health_url, timeout=5.0)
-                if 200 <= response.status_code < 300:
-                    logger.info("Service healthy at %s after %d attempts", health_url, attempts)
-                    return True
-                last_error = f"HTTP {response.status_code}"
-            except httpx.HTTPError as exc:
-                last_error = type(exc).__name__
-            time.sleep(interval)
+        with httpx.Client(timeout=5.0) as health_client:
+            while time.monotonic() < deadline:
+                attempts += 1
+                try:
+                    response = health_client.get(health_url)
+                    if 200 <= response.status_code < 300:
+                        logger.info("Service healthy at %s after %d attempts", health_url, attempts)
+                        return True
+                    last_error = f"HTTP {response.status_code}"
+                except httpx.HTTPError as exc:
+                    last_error = f"{type(exc).__name__}: {exc}"
+                time.sleep(interval)
 
-        logger.error("Service did not become healthy at %s within %.0fs (last error: %s)", health_url, timeout, last_error)
+        logger.error(
+            "Service did not become healthy at %s within %.0fs after %d attempts (last error: %s)",
+            health_url,
+            timeout,
+            attempts,
+            last_error,
+        )
         return False
 
     def _graphql(self, query: str, variables: dict[str, Any]) -> dict[str, Any]:
         response = self._client.post("", json={"query": query, "variables": variables})
         response.raise_for_status()
-        payload = response.json()
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise RailwayApiError(f"Railway returned non-JSON ({response.status_code}): {response.text[:200]}") from exc
         if payload.get("errors"):
             raise RailwayApiError(f"Railway GraphQL error: {payload['errors']}")
+        if "data" not in payload:
+            raise RailwayApiError(f"Railway response missing 'data' field: {payload!r}")
         return payload["data"]

--- a/services/railway/service_controller.py
+++ b/services/railway/service_controller.py
@@ -1,0 +1,199 @@
+"""Railway service controller for starting/stopping deployments via GraphQL API.
+
+Used by management/railway_scraper_cron.py to wake the Browserless service before
+scrape runs and stop it after, eliminating ~24/7 idle Chrome memory billing.
+
+Required environment variables:
+    RAILWAY_API_TOKEN: Account-level Personal Access Token (Bearer)
+    RAILWAY_PROJECT_ID: Project ID (auto-injected by Railway runtime)
+    RAILWAY_ENVIRONMENT_ID: Environment ID (auto-injected by Railway runtime)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+RAILWAY_GRAPHQL_ENDPOINT = "https://backboard.railway.com/graphql/v2"
+
+_LATEST_DEPLOYMENT_QUERY = """
+query latestDeployment($input: DeploymentListInput!) {
+  deployments(input: $input, first: 1) {
+    edges {
+      node {
+        id
+        status
+      }
+    }
+  }
+}
+"""
+
+_STOP_DEPLOYMENT_MUTATION = """
+mutation deploymentStop($id: String!) {
+  deploymentStop(id: $id)
+}
+"""
+
+_REDEPLOY_MUTATION = """
+mutation deploymentRedeploy($id: String!) {
+  deploymentRedeploy(id: $id) {
+    id
+    status
+  }
+}
+"""
+
+
+class RailwayApiError(RuntimeError):
+    """Raised when the Railway GraphQL API returns an error."""
+
+
+@dataclass(frozen=True)
+class Deployment:
+    id: str
+    status: str
+
+
+class RailwayServiceController:
+    """Controls a single Railway service via GraphQL: stop, redeploy, wait-for-health."""
+
+    def __init__(
+        self,
+        api_token: str,
+        project_id: str,
+        environment_id: str,
+        service_id: str,
+        *,
+        client: httpx.Client | None = None,
+        request_timeout: float = 30.0,
+    ) -> None:
+        self._project_id = project_id
+        self._environment_id = environment_id
+        self._service_id = service_id
+        self._owns_client = client is None
+        self._client = client or httpx.Client(
+            base_url=RAILWAY_GRAPHQL_ENDPOINT,
+            headers={
+                "Authorization": f"Bearer {api_token}",
+                "Content-Type": "application/json",
+            },
+            timeout=request_timeout,
+        )
+
+    @classmethod
+    def from_env(cls, service_id_env: str = "BROWSERLESS_SERVICE_ID") -> RailwayServiceController | None:
+        """Build a controller from environment variables. Returns None if not fully configured."""
+        api_token = os.getenv("RAILWAY_API_TOKEN")
+        project_id = os.getenv("RAILWAY_PROJECT_ID")
+        environment_id = os.getenv("RAILWAY_ENVIRONMENT_ID")
+        service_id = os.getenv(service_id_env)
+
+        missing = [
+            name
+            for name, value in (
+                ("RAILWAY_API_TOKEN", api_token),
+                ("RAILWAY_PROJECT_ID", project_id),
+                ("RAILWAY_ENVIRONMENT_ID", environment_id),
+                (service_id_env, service_id),
+            )
+            if not value
+        ]
+        if missing:
+            logger.info("Railway service control disabled (missing env: %s)", ", ".join(missing))
+            return None
+
+        return cls(
+            api_token=api_token,  # type: ignore[arg-type]
+            project_id=project_id,  # type: ignore[arg-type]
+            environment_id=environment_id,  # type: ignore[arg-type]
+            service_id=service_id,  # type: ignore[arg-type]
+        )
+
+    def close(self) -> None:
+        if self._owns_client:
+            self._client.close()
+
+    def __enter__(self) -> RailwayServiceController:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+    def latest_deployment(self) -> Deployment | None:
+        """Return the most recent deployment for the service, or None if there isn't one."""
+        data = self._graphql(
+            _LATEST_DEPLOYMENT_QUERY,
+            {
+                "input": {
+                    "projectId": self._project_id,
+                    "serviceId": self._service_id,
+                    "environmentId": self._environment_id,
+                }
+            },
+        )
+        edges = data["deployments"]["edges"]
+        if not edges:
+            return None
+        node = edges[0]["node"]
+        return Deployment(id=node["id"], status=node["status"])
+
+    def stop(self) -> bool:
+        """Stop the running deployment. Returns True on success, False if nothing to stop."""
+        deployment = self.latest_deployment()
+        if deployment is None:
+            logger.warning("No deployment found for service %s; nothing to stop", self._service_id)
+            return False
+        if deployment.status in {"REMOVED", "CRASHED", "FAILED"}:
+            logger.info("Deployment %s already in non-running state: %s", deployment.id, deployment.status)
+            return False
+
+        logger.info("Stopping deployment %s (status=%s)", deployment.id, deployment.status)
+        self._graphql(_STOP_DEPLOYMENT_MUTATION, {"id": deployment.id})
+        return True
+
+    def redeploy(self) -> str:
+        """Redeploy the latest deployment. Returns the new deployment status."""
+        deployment = self.latest_deployment()
+        if deployment is None:
+            raise RailwayApiError(f"No deployment exists for service {self._service_id} to redeploy")
+
+        logger.info("Redeploying deployment %s (current status=%s)", deployment.id, deployment.status)
+        data = self._graphql(_REDEPLOY_MUTATION, {"id": deployment.id})
+        return data["deploymentRedeploy"]["status"]
+
+    def wait_for_healthy(self, health_url: str, *, timeout: float = 180.0, interval: float = 3.0) -> bool:
+        """Poll `health_url` until it returns 2xx or timeout elapses. Returns True on success."""
+        deadline = time.monotonic() + timeout
+        attempts = 0
+        last_error: str | None = None
+
+        while time.monotonic() < deadline:
+            attempts += 1
+            try:
+                response = httpx.get(health_url, timeout=5.0)
+                if 200 <= response.status_code < 300:
+                    logger.info("Service healthy at %s after %d attempts", health_url, attempts)
+                    return True
+                last_error = f"HTTP {response.status_code}"
+            except httpx.HTTPError as exc:
+                last_error = type(exc).__name__
+            time.sleep(interval)
+
+        logger.error("Service did not become healthy at %s within %.0fs (last error: %s)", health_url, timeout, last_error)
+        return False
+
+    def _graphql(self, query: str, variables: dict[str, Any]) -> dict[str, Any]:
+        response = self._client.post("", json={"query": query, "variables": variables})
+        response.raise_for_status()
+        payload = response.json()
+        if payload.get("errors"):
+            raise RailwayApiError(f"Railway GraphQL error: {payload['errors']}")
+        return payload["data"]

--- a/tests/management/test_railway_scraper_cron.py
+++ b/tests/management/test_railway_scraper_cron.py
@@ -1,0 +1,78 @@
+"""Tests for the Browserless wake/stop wrappers in railway_scraper_cron.
+
+These guard the PR's stated billing benefit: if the try/finally cleanup or the wake-failure
+abort regress, Browserless can run indefinitely or scrapers can race a cold Chrome instance.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from management.railway_scraper_cron import start_browserless, stop_browserless
+from services.railway.service_controller import Deployment, RailwayApiError
+
+
+@pytest.mark.unit
+class TestStartBrowserless:
+    def test_returns_false_when_health_url_missing(self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+        monkeypatch.delenv("BROWSERLESS_HEALTH_URL", raising=False)
+        controller = MagicMock()
+
+        with caplog.at_level("ERROR", logger="management.railway_scraper_cron"):
+            assert start_browserless(controller) is False
+
+        controller.redeploy.assert_not_called()
+        assert any("BROWSERLESS_HEALTH_URL is required" in record.message for record in caplog.records)
+
+    def test_returns_false_when_redeploy_raises(self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+        monkeypatch.setenv("BROWSERLESS_HEALTH_URL", "http://example/health")
+        controller = MagicMock()
+        controller.redeploy.side_effect = RailwayApiError("API down")
+
+        with caplog.at_level("ERROR", logger="management.railway_scraper_cron"):
+            assert start_browserless(controller) is False
+
+        controller.wait_for_healthy.assert_not_called()
+        assert any("Failed to redeploy Browserless" in record.message for record in caplog.records)
+
+    def test_returns_false_when_health_check_times_out(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BROWSERLESS_HEALTH_URL", "http://example/health")
+        controller = MagicMock()
+        controller.redeploy.return_value = Deployment(id="d1", status="DEPLOYING")
+        controller.wait_for_healthy.return_value = False
+
+        assert start_browserless(controller) is False
+
+    def test_returns_true_on_success_and_passes_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BROWSERLESS_HEALTH_URL", "http://example/health")
+        monkeypatch.setenv("BROWSERLESS_HEALTH_TIMEOUT", "30")
+        controller = MagicMock()
+        controller.redeploy.return_value = Deployment(id="d1", status="DEPLOYING")
+        controller.wait_for_healthy.return_value = True
+
+        assert start_browserless(controller) is True
+        controller.wait_for_healthy.assert_called_once_with("http://example/health", timeout=30.0)
+
+
+@pytest.mark.unit
+class TestStopBrowserless:
+    def test_calls_stop(self) -> None:
+        controller = MagicMock()
+        stop_browserless(controller)
+        controller.stop.assert_called_once()
+
+    def test_swallows_exceptions(self, caplog: pytest.LogCaptureFixture) -> None:
+        controller = MagicMock()
+        controller.stop.side_effect = RailwayApiError("boom")
+
+        with caplog.at_level("ERROR", logger="management.railway_scraper_cron"):
+            stop_browserless(controller)  # must not raise
+
+        assert any("Failed to stop Browserless" in record.message for record in caplog.records)
+
+    def test_swallows_unexpected_exception_type(self) -> None:
+        controller = MagicMock()
+        controller.stop.side_effect = RuntimeError("anything")
+        stop_browserless(controller)  # must not raise

--- a/tests/services/railway/test_service_controller.py
+++ b/tests/services/railway/test_service_controller.py
@@ -1,0 +1,201 @@
+"""Unit tests for RailwayServiceController."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from services.railway.service_controller import (
+    RailwayApiError,
+    RailwayServiceController,
+)
+
+
+def _build_controller(handler: httpx.MockTransport) -> RailwayServiceController:
+    client = httpx.Client(
+        base_url="https://backboard.railway.com/graphql/v2",
+        headers={"Authorization": "Bearer test-token", "Content-Type": "application/json"},
+        transport=handler,
+    )
+    return RailwayServiceController(
+        api_token="test-token",
+        project_id="proj-1",
+        environment_id="env-1",
+        service_id="svc-1",
+        client=client,
+    )
+
+
+def _graphql_response(data: dict[str, Any]) -> httpx.Response:
+    return httpx.Response(200, json={"data": data})
+
+
+@pytest.mark.unit
+class TestFromEnv:
+    def test_returns_none_when_token_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("RAILWAY_API_TOKEN", raising=False)
+        monkeypatch.setenv("RAILWAY_PROJECT_ID", "p")
+        monkeypatch.setenv("RAILWAY_ENVIRONMENT_ID", "e")
+        monkeypatch.setenv("BROWSERLESS_SERVICE_ID", "s")
+
+        assert RailwayServiceController.from_env() is None
+
+    def test_returns_none_when_service_id_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("RAILWAY_API_TOKEN", "t")
+        monkeypatch.setenv("RAILWAY_PROJECT_ID", "p")
+        monkeypatch.setenv("RAILWAY_ENVIRONMENT_ID", "e")
+        monkeypatch.delenv("BROWSERLESS_SERVICE_ID", raising=False)
+
+        assert RailwayServiceController.from_env() is None
+
+    def test_returns_controller_when_all_env_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("RAILWAY_API_TOKEN", "t")
+        monkeypatch.setenv("RAILWAY_PROJECT_ID", "p")
+        monkeypatch.setenv("RAILWAY_ENVIRONMENT_ID", "e")
+        monkeypatch.setenv("BROWSERLESS_SERVICE_ID", "s")
+
+        controller = RailwayServiceController.from_env()
+        assert controller is not None
+        controller.close()
+
+
+@pytest.mark.unit
+class TestLatestDeployment:
+    def test_returns_deployment_when_present(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = request.read().decode()
+            assert "latestDeployment" in body
+            assert "proj-1" in body
+            return _graphql_response({"deployments": {"edges": [{"node": {"id": "dep-99", "status": "SUCCESS"}}]}})
+
+        controller = _build_controller(httpx.MockTransport(handler))
+        deployment = controller.latest_deployment()
+
+        assert deployment is not None
+        assert deployment.id == "dep-99"
+        assert deployment.status == "SUCCESS"
+
+    def test_returns_none_when_no_deployments(self) -> None:
+        handler = httpx.MockTransport(lambda _req: _graphql_response({"deployments": {"edges": []}}))
+        controller = _build_controller(handler)
+
+        assert controller.latest_deployment() is None
+
+
+@pytest.mark.unit
+class TestStop:
+    def test_stops_running_deployment(self) -> None:
+        calls: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = request.read().decode()
+            if "latestDeployment" in body:
+                calls.append("query")
+                return _graphql_response({"deployments": {"edges": [{"node": {"id": "dep-1", "status": "SUCCESS"}}]}})
+            assert "deploymentStop" in body
+            assert "dep-1" in body
+            calls.append("stop")
+            return _graphql_response({"deploymentStop": True})
+
+        controller = _build_controller(httpx.MockTransport(handler))
+        assert controller.stop() is True
+        assert calls == ["query", "stop"]
+
+    def test_returns_false_when_no_deployment(self) -> None:
+        handler = httpx.MockTransport(lambda _req: _graphql_response({"deployments": {"edges": []}}))
+        controller = _build_controller(handler)
+
+        assert controller.stop() is False
+
+    def test_skips_when_already_removed(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = request.read().decode()
+            assert "latestDeployment" in body, "Stop mutation must not be called for REMOVED deployment"
+            return _graphql_response({"deployments": {"edges": [{"node": {"id": "dep-1", "status": "REMOVED"}}]}})
+
+        controller = _build_controller(httpx.MockTransport(handler))
+        assert controller.stop() is False
+
+
+@pytest.mark.unit
+class TestRedeploy:
+    def test_redeploys_latest(self) -> None:
+        calls: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = request.read().decode()
+            if "latestDeployment" in body:
+                calls.append("query")
+                return _graphql_response({"deployments": {"edges": [{"node": {"id": "dep-7", "status": "REMOVED"}}]}})
+            assert "deploymentRedeploy" in body
+            assert "dep-7" in body
+            calls.append("redeploy")
+            return _graphql_response({"deploymentRedeploy": {"id": "dep-8", "status": "DEPLOYING"}})
+
+        controller = _build_controller(httpx.MockTransport(handler))
+        assert controller.redeploy() == "DEPLOYING"
+        assert calls == ["query", "redeploy"]
+
+    def test_raises_when_no_deployment_to_redeploy(self) -> None:
+        handler = httpx.MockTransport(lambda _req: _graphql_response({"deployments": {"edges": []}}))
+        controller = _build_controller(handler)
+
+        with pytest.raises(RailwayApiError):
+            controller.redeploy()
+
+
+@pytest.mark.unit
+class TestGraphQLErrors:
+    def test_raises_on_graphql_error_response(self) -> None:
+        handler = httpx.MockTransport(lambda _req: httpx.Response(200, json={"errors": [{"message": "Unauthorized"}]}))
+        controller = _build_controller(handler)
+
+        with pytest.raises(RailwayApiError, match="Unauthorized"):
+            controller.latest_deployment()
+
+    def test_raises_on_http_error(self) -> None:
+        handler = httpx.MockTransport(lambda _req: httpx.Response(500, json={}))
+        controller = _build_controller(handler)
+
+        with pytest.raises(httpx.HTTPStatusError):
+            controller.latest_deployment()
+
+
+@pytest.mark.unit
+class TestWaitForHealthy:
+    def test_returns_true_on_first_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("time.sleep", lambda _s: None)
+        monkeypatch.setattr(httpx, "get", lambda *_a, **_kw: httpx.Response(200))
+
+        controller = _build_controller(httpx.MockTransport(lambda _r: _graphql_response({})))
+        assert controller.wait_for_healthy("http://example/health", timeout=5.0, interval=0.1) is True
+
+    def test_polls_until_healthy(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("time.sleep", lambda _s: None)
+        responses = iter(
+            [
+                httpx.ConnectError("refused"),
+                httpx.Response(503),
+                httpx.Response(200),
+            ]
+        )
+
+        def fake_get(*_args: Any, **_kw: Any) -> httpx.Response:
+            value = next(responses)
+            if isinstance(value, Exception):
+                raise value
+            return value
+
+        monkeypatch.setattr(httpx, "get", fake_get)
+        controller = _build_controller(httpx.MockTransport(lambda _r: _graphql_response({})))
+
+        assert controller.wait_for_healthy("http://example/health", timeout=10.0, interval=0.01) is True
+
+    def test_returns_false_on_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("time.sleep", lambda _s: None)
+        monkeypatch.setattr(httpx, "get", lambda *_a, **_kw: (_ for _ in ()).throw(httpx.ConnectError("refused")))
+        controller = _build_controller(httpx.MockTransport(lambda _r: _graphql_response({})))
+
+        assert controller.wait_for_healthy("http://example/health", timeout=0.05, interval=0.01) is False

--- a/tests/services/railway/test_service_controller.py
+++ b/tests/services/railway/test_service_controller.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import httpx
 import pytest
 
 from services.railway.service_controller import (
+    Deployment,
     RailwayApiError,
     RailwayServiceController,
 )
@@ -32,32 +34,58 @@ def _graphql_response(data: dict[str, Any]) -> httpx.Response:
     return httpx.Response(200, json={"data": data})
 
 
+def _parse_body(request: httpx.Request) -> dict[str, Any]:
+    return json.loads(request.read().decode())
+
+
 @pytest.mark.unit
 class TestFromEnv:
-    def test_returns_none_when_token_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("RAILWAY_API_TOKEN", raising=False)
-        monkeypatch.setenv("RAILWAY_PROJECT_ID", "p")
-        monkeypatch.setenv("RAILWAY_ENVIRONMENT_ID", "e")
-        monkeypatch.setenv("BROWSERLESS_SERVICE_ID", "s")
+    _ALL_ENV = {
+        "RAILWAY_API_TOKEN": "t",
+        "RAILWAY_PROJECT_ID": "p",
+        "RAILWAY_ENVIRONMENT_ID": "e",
+        "BROWSERLESS_SERVICE_ID": "s",
+    }
+
+    @pytest.mark.parametrize("missing_var", list(_ALL_ENV.keys()))
+    def test_returns_none_when_any_var_missing(self, monkeypatch: pytest.MonkeyPatch, missing_var: str) -> None:
+        for name, value in self._ALL_ENV.items():
+            if name == missing_var:
+                monkeypatch.delenv(name, raising=False)
+            else:
+                monkeypatch.setenv(name, value)
 
         assert RailwayServiceController.from_env() is None
 
-    def test_returns_none_when_service_id_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_partial_config_logs_warning(self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
         monkeypatch.setenv("RAILWAY_API_TOKEN", "t")
         monkeypatch.setenv("RAILWAY_PROJECT_ID", "p")
-        monkeypatch.setenv("RAILWAY_ENVIRONMENT_ID", "e")
+        monkeypatch.delenv("RAILWAY_ENVIRONMENT_ID", raising=False)
         monkeypatch.delenv("BROWSERLESS_SERVICE_ID", raising=False)
 
-        assert RailwayServiceController.from_env() is None
+        with caplog.at_level("WARNING", logger="services.railway.service_controller"):
+            assert RailwayServiceController.from_env() is None
+        assert any("PARTIALLY configured" in record.message for record in caplog.records)
+
+    def test_fully_unset_logs_info_not_warning(self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+        for name in self._ALL_ENV:
+            monkeypatch.delenv(name, raising=False)
+
+        with caplog.at_level("INFO", logger="services.railway.service_controller"):
+            assert RailwayServiceController.from_env() is None
+        assert any("disabled" in record.message for record in caplog.records)
+        assert not any(record.levelname == "WARNING" for record in caplog.records)
 
     def test_returns_controller_when_all_env_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("RAILWAY_API_TOKEN", "t")
-        monkeypatch.setenv("RAILWAY_PROJECT_ID", "p")
-        monkeypatch.setenv("RAILWAY_ENVIRONMENT_ID", "e")
-        monkeypatch.setenv("BROWSERLESS_SERVICE_ID", "s")
+        for name, value in self._ALL_ENV.items():
+            monkeypatch.setenv(name, value)
 
         controller = RailwayServiceController.from_env()
         assert controller is not None
+        assert controller._project_id == "p"
+        assert controller._environment_id == "e"
+        assert controller._service_id == "s"
+        assert controller._owns_client is True
         controller.close()
 
 
@@ -65,9 +93,10 @@ class TestFromEnv:
 class TestLatestDeployment:
     def test_returns_deployment_when_present(self) -> None:
         def handler(request: httpx.Request) -> httpx.Response:
-            body = request.read().decode()
-            assert "latestDeployment" in body
-            assert "proj-1" in body
+            body = _parse_body(request)
+            assert "latestDeployment" in body["query"]
+            assert body["variables"]["input"]["projectId"] == "proj-1"
+            assert body["variables"]["input"]["serviceId"] == "svc-1"
             return _graphql_response({"deployments": {"edges": [{"node": {"id": "dep-99", "status": "SUCCESS"}}]}})
 
         controller = _build_controller(httpx.MockTransport(handler))
@@ -83,6 +112,13 @@ class TestLatestDeployment:
 
         assert controller.latest_deployment() is None
 
+    def test_raises_on_unexpected_schema(self) -> None:
+        handler = httpx.MockTransport(lambda _req: _graphql_response({"deployments": {"unexpected": []}}))
+        controller = _build_controller(handler)
+
+        with pytest.raises(RailwayApiError, match="Unexpected response shape"):
+            controller.latest_deployment()
+
 
 @pytest.mark.unit
 class TestStop:
@@ -90,12 +126,12 @@ class TestStop:
         calls: list[str] = []
 
         def handler(request: httpx.Request) -> httpx.Response:
-            body = request.read().decode()
-            if "latestDeployment" in body:
+            body = _parse_body(request)
+            if "latestDeployment" in body["query"]:
                 calls.append("query")
                 return _graphql_response({"deployments": {"edges": [{"node": {"id": "dep-1", "status": "SUCCESS"}}]}})
-            assert "deploymentStop" in body
-            assert "dep-1" in body
+            assert "deploymentStop" in body["query"]
+            assert body["variables"]["id"] == "dep-1"
             calls.append("stop")
             return _graphql_response({"deploymentStop": True})
 
@@ -109,11 +145,12 @@ class TestStop:
 
         assert controller.stop() is False
 
-    def test_skips_when_already_removed(self) -> None:
+    @pytest.mark.parametrize("terminal_status", ["REMOVED", "CRASHED", "FAILED"])
+    def test_skips_when_already_terminal(self, terminal_status: str) -> None:
         def handler(request: httpx.Request) -> httpx.Response:
-            body = request.read().decode()
-            assert "latestDeployment" in body, "Stop mutation must not be called for REMOVED deployment"
-            return _graphql_response({"deployments": {"edges": [{"node": {"id": "dep-1", "status": "REMOVED"}}]}})
+            body = _parse_body(request)
+            assert "latestDeployment" in body["query"], "Stop mutation must not be called for terminal deployment"
+            return _graphql_response({"deployments": {"edges": [{"node": {"id": "dep-1", "status": terminal_status}}]}})
 
         controller = _build_controller(httpx.MockTransport(handler))
         assert controller.stop() is False
@@ -121,21 +158,23 @@ class TestStop:
 
 @pytest.mark.unit
 class TestRedeploy:
-    def test_redeploys_latest(self) -> None:
+    def test_redeploys_latest_returns_deployment(self) -> None:
         calls: list[str] = []
 
         def handler(request: httpx.Request) -> httpx.Response:
-            body = request.read().decode()
-            if "latestDeployment" in body:
+            body = _parse_body(request)
+            if "latestDeployment" in body["query"]:
                 calls.append("query")
                 return _graphql_response({"deployments": {"edges": [{"node": {"id": "dep-7", "status": "REMOVED"}}]}})
-            assert "deploymentRedeploy" in body
-            assert "dep-7" in body
+            assert "deploymentRedeploy" in body["query"]
+            assert body["variables"]["id"] == "dep-7"
             calls.append("redeploy")
             return _graphql_response({"deploymentRedeploy": {"id": "dep-8", "status": "DEPLOYING"}})
 
         controller = _build_controller(httpx.MockTransport(handler))
-        assert controller.redeploy() == "DEPLOYING"
+        result = controller.redeploy()
+
+        assert result == Deployment(id="dep-8", status="DEPLOYING")
         assert calls == ["query", "redeploy"]
 
     def test_raises_when_no_deployment_to_redeploy(self) -> None:
@@ -143,6 +182,18 @@ class TestRedeploy:
         controller = _build_controller(handler)
 
         with pytest.raises(RailwayApiError):
+            controller.redeploy()
+
+    def test_raises_on_unexpected_redeploy_response(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = _parse_body(request)
+            if "latestDeployment" in body["query"]:
+                return _graphql_response({"deployments": {"edges": [{"node": {"id": "dep-1", "status": "SUCCESS"}}]}})
+            return _graphql_response({"deploymentRedeploy": None})
+
+        controller = _build_controller(httpx.MockTransport(handler))
+
+        with pytest.raises(RailwayApiError, match="Unexpected response shape"):
             controller.redeploy()
 
 
@@ -155,7 +206,21 @@ class TestGraphQLErrors:
         with pytest.raises(RailwayApiError, match="Unauthorized"):
             controller.latest_deployment()
 
-    def test_raises_on_http_error(self) -> None:
+    def test_raises_railway_error_on_missing_data_field(self) -> None:
+        handler = httpx.MockTransport(lambda _req: httpx.Response(200, json={}))
+        controller = _build_controller(handler)
+
+        with pytest.raises(RailwayApiError, match="missing 'data' field"):
+            controller.latest_deployment()
+
+    def test_raises_railway_error_on_non_json_response(self) -> None:
+        handler = httpx.MockTransport(lambda _req: httpx.Response(200, text="<html>maintenance</html>"))
+        controller = _build_controller(handler)
+
+        with pytest.raises(RailwayApiError, match="non-JSON"):
+            controller.latest_deployment()
+
+    def test_raises_on_http_error_status(self) -> None:
         handler = httpx.MockTransport(lambda _req: httpx.Response(500, json={}))
         controller = _build_controller(handler)
 
@@ -165,37 +230,55 @@ class TestGraphQLErrors:
 
 @pytest.mark.unit
 class TestWaitForHealthy:
+    @pytest.fixture(autouse=True)
+    def _no_sleep(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("services.railway.service_controller.time.sleep", lambda _s: None)
+
     def test_returns_true_on_first_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr("time.sleep", lambda _s: None)
-        monkeypatch.setattr(httpx, "get", lambda *_a, **_kw: httpx.Response(200))
+        monkeypatch.setattr(httpx.Client, "get", lambda self, url: httpx.Response(200))
 
         controller = _build_controller(httpx.MockTransport(lambda _r: _graphql_response({})))
         assert controller.wait_for_healthy("http://example/health", timeout=5.0, interval=0.1) is True
 
     def test_polls_until_healthy(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr("time.sleep", lambda _s: None)
-        responses = iter(
-            [
-                httpx.ConnectError("refused"),
-                httpx.Response(503),
-                httpx.Response(200),
-            ]
-        )
+        responses: list[httpx.Response | Exception] = [
+            httpx.ConnectError("refused"),
+            httpx.Response(503),
+            httpx.Response(200),
+        ]
 
-        def fake_get(*_args: Any, **_kw: Any) -> httpx.Response:
-            value = next(responses)
+        def fake_get(_self: httpx.Client, _url: str) -> httpx.Response:
+            value = responses.pop(0)
             if isinstance(value, Exception):
                 raise value
             return value
 
-        monkeypatch.setattr(httpx, "get", fake_get)
+        monkeypatch.setattr(httpx.Client, "get", fake_get)
         controller = _build_controller(httpx.MockTransport(lambda _r: _graphql_response({})))
 
         assert controller.wait_for_healthy("http://example/health", timeout=10.0, interval=0.01) is True
+        assert responses == []  # all consumed
 
     def test_returns_false_on_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr("time.sleep", lambda _s: None)
-        monkeypatch.setattr(httpx, "get", lambda *_a, **_kw: (_ for _ in ()).throw(httpx.ConnectError("refused")))
+        # Deterministic clock: start at 0, then jump past deadline of 0.05 on second check.
+        times = iter([0.0, 0.0, 0.06])
+        monkeypatch.setattr("services.railway.service_controller.time.monotonic", lambda: next(times))
+        monkeypatch.setattr(httpx.Client, "get", lambda self, url: httpx.Response(503))
+
+        controller = _build_controller(httpx.MockTransport(lambda _r: _graphql_response({})))
+        assert controller.wait_for_healthy("http://example/health", timeout=0.05, interval=0.01) is False
+
+    def test_logs_last_error_with_message(self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+        times = iter([0.0, 0.0, 0.06])
+        monkeypatch.setattr("services.railway.service_controller.time.monotonic", lambda: next(times))
+
+        def fake_get(_self: httpx.Client, _url: str) -> httpx.Response:
+            raise httpx.ConnectError("DNS resolution failed for example.com")
+
+        monkeypatch.setattr(httpx.Client, "get", fake_get)
         controller = _build_controller(httpx.MockTransport(lambda _r: _graphql_response({})))
 
-        assert controller.wait_for_healthy("http://example/health", timeout=0.05, interval=0.01) is False
+        with caplog.at_level("ERROR", logger="services.railway.service_controller"):
+            controller.wait_for_healthy("http://example/health", timeout=0.05, interval=0.01)
+
+        assert any("DNS resolution failed" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary
- Browserless is a 24/7 Chrome service used only 3×/week during scrapes (Tue/Thu/Sat 6am UTC) — costs ~\$3/mo in idle Chrome memory on Railway
- This wires the cron job to redeploy Browserless before scrapes and stop it after via Railway's GraphQL API (`deploymentRedeploy` + `deploymentStop`)
- Falls back to no-op if the required env vars aren't set, so it's safe to merge before configuration is in place

## Required Railway env vars (must be set on the cron service after merge)
| Var | Value | Where to get it |
|---|---|---|
| `RAILWAY_API_TOKEN` | account PAT (Bearer) | Railway dashboard → Account Settings → Tokens |
| `BROWSERLESS_SERVICE_ID` | `3022fc56-2c98-4d07-8162-df7c7b1b547a` | from `railway variables --service Browserless` |
| `BROWSERLESS_HEALTH_URL` | `https://browserless-production-c420.up.railway.app/` | Browserless public domain |

`RAILWAY_PROJECT_ID` and `RAILWAY_ENVIRONMENT_ID` are auto-injected by Railway at runtime.

## Related change (already applied to production)
`DB_POOL_MIN_CONN=2` was set on the `rescue-dog-aggregator` service to trim idle PG pool from 5 → 2 connections, saving ~30MB on both API and Postgres sides.

## Test plan
- [x] 15 new unit tests pass (`tests/services/railway/test_service_controller.py`)
- [x] `ruff check` and `ruff format --check` pass
- [x] No-op path verified (missing env vars → controller is `None`, scrape runs untouched)
- [ ] After merge: set the env vars and run one cron manually to confirm wake/stop cycle works end-to-end
- [ ] Verify next scheduled cron (Thu 6am UTC) succeeds with Browserless redeploy/stop visible in Railway deployment list

## Expected billing impact
- Browserless idle hours go from ~672/mo → ~12/mo (~98% reduction in that service's memory bill)
- Combined with `DB_POOL_MIN_CONN` drop: ~720MB → ~350-400MB average → fits inside the \$5 Hobby credit, taking total bill from \$9.28/mo to ~\$5.95/mo (just the flat fee + VAT)