### PR TITLE
fix(scraper): move service_controller out of services/railway/ package

### DIFF
--- a/management/railway_scraper_cron.py
+++ b/management/railway_scraper_cron.py
@@ -35,7 +35,7 @@ if project_root not in sys.path:
 
 from config import enable_world_class_scraper_logging, get_database_config  # noqa: E402
 from scrapers.sentry_integration import add_scrape_breadcrumb, init_scraper_sentry  # noqa: E402
-from services.railway.service_controller import RailwayServiceController  # noqa: E402
+from services.railway_service_controller import RailwayServiceController  # noqa: E402
 from utils.db_connection import (  # noqa: E402
     create_database_config_from_env,
     initialize_database_pool,

--- a/services/railway_service_controller.py
+++ b/services/railway_service_controller.py
@@ -3,6 +3,10 @@
 Used by management/railway_scraper_cron.py to wake the Browserless service before
 scrape runs and stop it after, eliminating ~24/7 idle Chrome memory billing.
 
+Note: lives at services/railway_service_controller.py (flat), NOT in services/railway/.
+The services/railway/ package's __init__.py eagerly imports SQLAlchemy via connection.py
+and crashed the cron runtime on first import; this flat path bypasses that init.
+
 Required environment variables:
     RAILWAY_API_TOKEN: Account-level Personal Access Token (Bearer)
     RAILWAY_PROJECT_ID: Project ID (auto-injected by Railway runtime)

--- a/tests/management/test_railway_scraper_cron.py
+++ b/tests/management/test_railway_scraper_cron.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from management.railway_scraper_cron import start_browserless, stop_browserless
-from services.railway.service_controller import Deployment, RailwayApiError
+from services.railway_service_controller import Deployment, RailwayApiError
 
 
 @pytest.mark.unit

--- a/tests/services/test_railway_service_controller.py
+++ b/tests/services/test_railway_service_controller.py
@@ -8,7 +8,7 @@ from typing import Any
 import httpx
 import pytest
 
-from services.railway.service_controller import (
+from services.railway_service_controller import (
     Deployment,
     RailwayApiError,
     RailwayServiceController,
@@ -63,7 +63,7 @@ class TestFromEnv:
         monkeypatch.delenv("RAILWAY_ENVIRONMENT_ID", raising=False)
         monkeypatch.delenv("BROWSERLESS_SERVICE_ID", raising=False)
 
-        with caplog.at_level("WARNING", logger="services.railway.service_controller"):
+        with caplog.at_level("WARNING", logger="services.railway_service_controller"):
             assert RailwayServiceController.from_env() is None
         assert any("PARTIALLY configured" in record.message for record in caplog.records)
 
@@ -71,7 +71,7 @@ class TestFromEnv:
         for name in self._ALL_ENV:
             monkeypatch.delenv(name, raising=False)
 
-        with caplog.at_level("INFO", logger="services.railway.service_controller"):
+        with caplog.at_level("INFO", logger="services.railway_service_controller"):
             assert RailwayServiceController.from_env() is None
         assert any("disabled" in record.message for record in caplog.records)
         assert not any(record.levelname == "WARNING" for record in caplog.records)
@@ -232,7 +232,7 @@ class TestGraphQLErrors:
 class TestWaitForHealthy:
     @pytest.fixture(autouse=True)
     def _no_sleep(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr("services.railway.service_controller.time.sleep", lambda _s: None)
+        monkeypatch.setattr("services.railway_service_controller.time.sleep", lambda _s: None)
 
     def test_returns_true_on_first_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(httpx.Client, "get", lambda self, url: httpx.Response(200))
@@ -262,7 +262,7 @@ class TestWaitForHealthy:
     def test_returns_false_on_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # Deterministic clock: start at 0, then jump past deadline of 0.05 on second check.
         times = iter([0.0, 0.0, 0.06])
-        monkeypatch.setattr("services.railway.service_controller.time.monotonic", lambda: next(times))
+        monkeypatch.setattr("services.railway_service_controller.time.monotonic", lambda: next(times))
         monkeypatch.setattr(httpx.Client, "get", lambda self, url: httpx.Response(503))
 
         controller = _build_controller(httpx.MockTransport(lambda _r: _graphql_response({})))
@@ -270,7 +270,7 @@ class TestWaitForHealthy:
 
     def test_logs_last_error_with_message(self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
         times = iter([0.0, 0.0, 0.06])
-        monkeypatch.setattr("services.railway.service_controller.time.monotonic", lambda: next(times))
+        monkeypatch.setattr("services.railway_service_controller.time.monotonic", lambda: next(times))
 
         def fake_get(_self: httpx.Client, _url: str) -> httpx.Response:
             raise httpx.ConnectError("DNS resolution failed for example.com")
@@ -278,7 +278,7 @@ class TestWaitForHealthy:
         monkeypatch.setattr(httpx.Client, "get", fake_get)
         controller = _build_controller(httpx.MockTransport(lambda _r: _graphql_response({})))
 
-        with caplog.at_level("ERROR", logger="services.railway.service_controller"):
+        with caplog.at_level("ERROR", logger="services.railway_service_controller"):
             controller.wait_for_healthy("http://example/health", timeout=0.05, interval=0.01)
 
         assert any("DNS resolution failed" in record.message for record in caplog.records)


### PR DESCRIPTION
## Hotfix for #211

The cron service `thriving-appreciation` crashed on first run after #211 merged with:

\`\`\`
ModuleNotFoundError: No module named 'services.railway'
\`\`\`

## Root cause

I placed the new module inside the existing \`services/railway/\` package. That package's \`__init__.py\` eagerly imports \`connection.py\`, which imports SQLAlchemy at module level. In the Railway cron runtime, that import chain fails — and when a package's \`__init__.py\` raises, Python removes it from \`sys.modules\` and subsequent imports of the parent get the misleading \"No module named 'services.railway'\" error.

CI passed because the dev environment has all deps. The API service didn't fail because its existing imports already exercise that chain without issue in its own runtime.

## Fix

Move \`services/railway/service_controller.py\` → \`services/railway_service_controller.py\` (flat path) so it never touches the buggy \`__init__.py\`. Tests move correspondingly. No other code changes.

## Test plan
- [x] All 33 tests still pass (same suite, just new path)
- [x] \`ruff check\` clean
- [ ] After merge: trigger cron run; expect successful import + wake/stop cycle