### PR TITLE
fix(scraper): preserve original exception in with_browser_retry

### DIFF
--- a/scrapers/browser_manager.py
+++ b/scrapers/browser_manager.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import sys
 import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -128,7 +129,10 @@ class ScraperBrowserManager:
 
         try:
             yield result
-        finally:
+        except BaseException:
+            if not await cm.__aexit__(*sys.exc_info()):
+                raise
+        else:
             await cm.__aexit__(None, None, None)
 
     async def navigate_with_retry(

--- a/scrapers/browser_manager.py
+++ b/scrapers/browser_manager.py
@@ -104,23 +104,32 @@ class ScraperBrowserManager:
         playwright_service = get_playwright_service()
         opts = options or PlaywrightOptions()
 
+        cm = None
+        result: PlaywrightResult | None = None
         last_error: Exception | None = None
         for attempt in range(max_retries):
+            candidate = playwright_service.get_browser(opts)
             try:
-                async with playwright_service.get_browser(opts) as result:
-                    yield result
-                    return
+                result = await candidate.__aenter__()
+                cm = candidate
+                break
             except Exception as e:
                 last_error = e
                 if attempt < max_retries - 1:
                     delay = base_delay * (2**attempt)
-                    self.logger.warning(f"Browser operation failed (attempt {attempt + 1}/{max_retries}), retrying in {delay}s: {e}")
+                    self.logger.warning(f"Browser acquisition failed (attempt {attempt + 1}/{max_retries}), retrying in {delay}s: {e}")
                     await asyncio.sleep(delay)
                 else:
-                    self.logger.error(f"Browser operation failed after {max_retries} attempts: {e}")
+                    self.logger.error(f"Browser acquisition failed after {max_retries} attempts: {e}")
 
-        if last_error:
+        if cm is None or result is None:
+            assert last_error is not None
             raise last_error
+
+        try:
+            yield result
+        finally:
+            await cm.__aexit__(None, None, None)
 
     async def navigate_with_retry(
         self,

--- a/scrapers/dogstrust/dogstrust_scraper.py
+++ b/scrapers/dogstrust/dogstrust_scraper.py
@@ -584,35 +584,38 @@ class DogsTrustScraper(BaseScraper):
 
                 # Wait for dog cards to appear. Remote Browserless under
                 # stealth_mode intermittently fails to render the initial page;
-                # retry once via reload, then raise so the failure surfaces as
-                # a real Sentry exception with a stack trace instead of a
+                # retry via reload, then raise so the failure surfaces as a
+                # real Sentry exception with a stack trace instead of a
                 # misleading zero-dogs alert.
                 dog_card_selector = 'a[href*="/rehoming/dogs/"]'
-                try:
-                    await page.wait_for_selector(dog_card_selector, timeout=45000, state="attached")
-                    self.logger.info("Initial page loaded successfully")
-                except PlaywrightTimeoutError as first_err:
-                    self.logger.warning(f"Initial page load timed out (attempt 1/2): {first_err}; reloading and retrying...")
-                    await page.reload(wait_until="domcontentloaded")
-                    await asyncio.sleep(1.0)
-                    # OneTrust overlays can re-render after the reload.
-                    try:
-                        await page.evaluate(
-                            """
-                            (() => {
-                                document.querySelector('#onetrust-consent-sdk')?.remove();
-                                document.querySelector('.onetrust-pc-dark-filter')?.remove();
-                            })()
-                        """
-                        )
-                    except Exception as overlay_err:
-                        self.logger.debug(f"Post-reload overlay removal error (non-critical): {overlay_err}")
+                max_initial_attempts = 3
+                for attempt in range(1, max_initial_attempts + 1):
                     try:
                         await page.wait_for_selector(dog_card_selector, timeout=45000, state="attached")
-                        self.logger.info("Initial page loaded successfully after retry")
-                    except PlaywrightTimeoutError as retry_err:
-                        self.logger.error(f"Initial page load failed after retry: {retry_err}")
-                        raise
+                        if attempt == 1:
+                            self.logger.info("Initial page loaded successfully")
+                        else:
+                            self.logger.info(f"Initial page loaded successfully on attempt {attempt}/{max_initial_attempts}")
+                        break
+                    except PlaywrightTimeoutError as err:
+                        if attempt == max_initial_attempts:
+                            self.logger.error(f"Initial page load failed after {max_initial_attempts} attempts: {err}")
+                            raise
+                        self.logger.warning(f"Initial page load timed out (attempt {attempt}/{max_initial_attempts}): {err}; reloading and retrying...")
+                        await page.reload(wait_until="domcontentloaded")
+                        await asyncio.sleep(1.0)
+                        # OneTrust overlays can re-render after the reload.
+                        try:
+                            await page.evaluate(
+                                """
+                                (() => {
+                                    document.querySelector('#onetrust-consent-sdk')?.remove();
+                                    document.querySelector('.onetrust-pc-dark-filter')?.remove();
+                                })()
+                            """
+                            )
+                        except Exception as overlay_err:
+                            self.logger.debug(f"Post-reload overlay removal error (non-critical): {overlay_err}")
 
                 # Apply filter to hide reserved dogs
                 try:

--- a/scrapers/dogstrust/dogstrust_scraper.py
+++ b/scrapers/dogstrust/dogstrust_scraper.py
@@ -582,11 +582,10 @@ class DogsTrustScraper(BaseScraper):
                 except Exception as e:
                     self.logger.debug(f"Overlay removal error (non-critical): {e}")
 
-                # Wait for dog cards to appear. Remote Browserless under
-                # stealth_mode intermittently fails to render the initial page;
-                # retry via reload, then raise so the failure surfaces as a
-                # real Sentry exception with a stack trace instead of a
-                # misleading zero-dogs alert.
+                # Remote Browserless under stealth_mode intermittently fails
+                # to render the initial page. Raise rather than return [] so
+                # the failure surfaces as a real Sentry exception instead of
+                # a misleading zero-dogs alert.
                 dog_card_selector = 'a[href*="/rehoming/dogs/"]'
                 max_initial_attempts = 3
                 for attempt in range(1, max_initial_attempts + 1):

--- a/tests/scrapers/test_browser_manager.py
+++ b/tests/scrapers/test_browser_manager.py
@@ -92,15 +92,13 @@ class TestNavigateWithRetry:
 
 @pytest.mark.unit
 class TestWithBrowserRetry:
-    """Regression tests for the async-generator retry contract.
-
-    Background: a previous implementation retried inside the @asynccontextmanager
-    body, which violated the generator protocol when the caller's `async with`
-    block raised — surfacing as `RuntimeError: generator didn't stop after
-    athrow()` and masking the real exception. See cron failure 2026-05-16.
+    """Pins the async-generator retry contract: a previous implementation
+    yielded twice across retries inside an @asynccontextmanager, raising
+    `RuntimeError: generator didn't stop after athrow()` and masking the
+    real exception when the caller's body raised.
     """
 
-    def _patch_service(self, browser_manager, get_browser_factory):
+    def _patch_service(self, get_browser_factory):
         from contextlib import asynccontextmanager
 
         @asynccontextmanager
@@ -113,8 +111,6 @@ class TestWithBrowserRetry:
         return patch("scrapers.browser_manager.get_playwright_service", return_value=service)
 
     def test_body_exception_propagates_without_runtime_error(self, browser_manager):
-        """Caller-side exceptions must surface as the original exception, not
-        as `RuntimeError: generator didn't stop after athrow()`."""
         from contextlib import asynccontextmanager
 
         close_called = False
@@ -122,19 +118,22 @@ class TestWithBrowserRetry:
         @asynccontextmanager
         async def get_browser_factory():
             nonlocal close_called
-            yield Mock(name="PlaywrightResult")
-            close_called = True
+            try:
+                yield Mock(name="PlaywrightResult")
+            finally:
+                close_called = True
 
         async def run():
-            with self._patch_service(browser_manager, get_browser_factory):
+            with self._patch_service(get_browser_factory):
                 async with browser_manager.with_browser_retry(max_retries=3, base_delay=0.0):
                     raise ValueError("simulated body failure")
 
         with pytest.raises(ValueError, match="simulated body failure"):
             asyncio.new_event_loop().run_until_complete(run())
 
+        assert close_called, "browser cleanup must run even when the body raises"
+
     def test_retries_browser_acquisition_failure(self, browser_manager):
-        """When browser acquisition fails, retry; succeed on a later attempt."""
         from contextlib import asynccontextmanager
 
         attempts = {"count": 0}
@@ -147,7 +146,7 @@ class TestWithBrowserRetry:
             yield Mock(name="PlaywrightResult")
 
         async def run():
-            with self._patch_service(browser_manager, get_browser_factory):
+            with self._patch_service(get_browser_factory):
                 async with browser_manager.with_browser_retry(max_retries=3, base_delay=0.0) as result:
                     return result
 
@@ -156,7 +155,6 @@ class TestWithBrowserRetry:
         assert attempts["count"] == 2
 
     def test_raises_last_error_after_exhausted_acquisition_retries(self, browser_manager):
-        """If every acquisition attempt fails, the last error propagates."""
         from contextlib import asynccontextmanager
 
         @asynccontextmanager
@@ -165,7 +163,7 @@ class TestWithBrowserRetry:
             yield  # pragma: no cover
 
         async def run():
-            with self._patch_service(browser_manager, get_browser_factory):
+            with self._patch_service(get_browser_factory):
                 async with browser_manager.with_browser_retry(max_retries=2, base_delay=0.0):
                     pass
 
@@ -173,8 +171,6 @@ class TestWithBrowserRetry:
             asyncio.new_event_loop().run_until_complete(run())
 
     def test_does_not_retry_after_yield(self, browser_manager):
-        """Exceptions after yield must not trigger another acquisition attempt
-        (no double-yield, no extra browser sessions)."""
         from contextlib import asynccontextmanager
 
         attempts = {"count": 0}
@@ -185,7 +181,7 @@ class TestWithBrowserRetry:
             yield Mock(name="PlaywrightResult")
 
         async def run():
-            with self._patch_service(browser_manager, get_browser_factory):
+            with self._patch_service(get_browser_factory):
                 async with browser_manager.with_browser_retry(max_retries=3, base_delay=0.0):
                     raise RuntimeError("after yield")
 

--- a/tests/scrapers/test_browser_manager.py
+++ b/tests/scrapers/test_browser_manager.py
@@ -88,3 +88,108 @@ class TestNavigateWithRetry:
 
         assert result is False
         assert page.goto.call_count == 2
+
+
+@pytest.mark.unit
+class TestWithBrowserRetry:
+    """Regression tests for the async-generator retry contract.
+
+    Background: a previous implementation retried inside the @asynccontextmanager
+    body, which violated the generator protocol when the caller's `async with`
+    block raised — surfacing as `RuntimeError: generator didn't stop after
+    athrow()` and masking the real exception. See cron failure 2026-05-16.
+    """
+
+    def _patch_service(self, browser_manager, get_browser_factory):
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def fake_get_browser(_opts):
+            async with get_browser_factory() as result:
+                yield result
+
+        service = Mock()
+        service.get_browser = fake_get_browser
+        return patch("scrapers.browser_manager.get_playwright_service", return_value=service)
+
+    def test_body_exception_propagates_without_runtime_error(self, browser_manager):
+        """Caller-side exceptions must surface as the original exception, not
+        as `RuntimeError: generator didn't stop after athrow()`."""
+        from contextlib import asynccontextmanager
+
+        close_called = False
+
+        @asynccontextmanager
+        async def get_browser_factory():
+            nonlocal close_called
+            yield Mock(name="PlaywrightResult")
+            close_called = True
+
+        async def run():
+            with self._patch_service(browser_manager, get_browser_factory):
+                async with browser_manager.with_browser_retry(max_retries=3, base_delay=0.0):
+                    raise ValueError("simulated body failure")
+
+        with pytest.raises(ValueError, match="simulated body failure"):
+            asyncio.new_event_loop().run_until_complete(run())
+
+    def test_retries_browser_acquisition_failure(self, browser_manager):
+        """When browser acquisition fails, retry; succeed on a later attempt."""
+        from contextlib import asynccontextmanager
+
+        attempts = {"count": 0}
+
+        @asynccontextmanager
+        async def get_browser_factory():
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                raise ConnectionError("browserless cold start")
+            yield Mock(name="PlaywrightResult")
+
+        async def run():
+            with self._patch_service(browser_manager, get_browser_factory):
+                async with browser_manager.with_browser_retry(max_retries=3, base_delay=0.0) as result:
+                    return result
+
+        result = asyncio.new_event_loop().run_until_complete(run())
+        assert result is not None
+        assert attempts["count"] == 2
+
+    def test_raises_last_error_after_exhausted_acquisition_retries(self, browser_manager):
+        """If every acquisition attempt fails, the last error propagates."""
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def get_browser_factory():
+            raise ConnectionError("browserless unreachable")
+            yield  # pragma: no cover
+
+        async def run():
+            with self._patch_service(browser_manager, get_browser_factory):
+                async with browser_manager.with_browser_retry(max_retries=2, base_delay=0.0):
+                    pass
+
+        with pytest.raises(ConnectionError, match="browserless unreachable"):
+            asyncio.new_event_loop().run_until_complete(run())
+
+    def test_does_not_retry_after_yield(self, browser_manager):
+        """Exceptions after yield must not trigger another acquisition attempt
+        (no double-yield, no extra browser sessions)."""
+        from contextlib import asynccontextmanager
+
+        attempts = {"count": 0}
+
+        @asynccontextmanager
+        async def get_browser_factory():
+            attempts["count"] += 1
+            yield Mock(name="PlaywrightResult")
+
+        async def run():
+            with self._patch_service(browser_manager, get_browser_factory):
+                async with browser_manager.with_browser_retry(max_retries=3, base_delay=0.0):
+                    raise RuntimeError("after yield")
+
+        with pytest.raises(RuntimeError, match="after yield"):
+            asyncio.new_event_loop().run_until_complete(run())
+
+        assert attempts["count"] == 1

--- a/tests/scrapers/test_dogstrust_scraper.py
+++ b/tests/scrapers/test_dogstrust_scraper.py
@@ -248,13 +248,14 @@ class TestDogsTrustPlaywrightResilience:
         assert len(result) == 2
 
     @pytest.mark.asyncio
-    async def test_raises_when_both_wait_attempts_timeout(self):
-        """Both wait attempts fail → raise instead of silently returning []."""
+    async def test_raises_when_all_wait_attempts_timeout(self):
+        """All 3 wait attempts fail → raise instead of silently returning []."""
         scraper = DogsTrustScraper()
         page = _build_listing_page_mock(
             wait_for_selector_side_effect=[
                 PlaywrightTimeoutError("first timeout"),
-                PlaywrightTimeoutError("retry timeout"),
+                PlaywrightTimeoutError("second timeout"),
+                PlaywrightTimeoutError("third timeout"),
             ],
             content_html="",
         )
@@ -263,8 +264,8 @@ class TestDogsTrustPlaywrightResilience:
         with pytest.raises(PlaywrightTimeoutError):
             await scraper._get_animal_list_playwright(max_pages_to_scrape=1)
 
-        page.reload.assert_awaited_once_with(wait_until="domcontentloaded")
-        assert page.wait_for_selector.await_count == 2
+        assert page.reload.await_count == 2
+        assert page.wait_for_selector.await_count == 3
 
     @pytest.mark.asyncio
     async def test_no_retry_when_first_wait_succeeds(self):
@@ -295,7 +296,8 @@ class TestDogsTrustPlaywrightResilience:
         page = _build_listing_page_mock(
             wait_for_selector_side_effect=[
                 PlaywrightTimeoutError("first timeout"),
-                PlaywrightTimeoutError("retry timeout"),
+                PlaywrightTimeoutError("second timeout"),
+                PlaywrightTimeoutError("third timeout"),
             ],
             content_html="",
         )


### PR DESCRIPTION
## Summary

- Fixes the async-generator retry contract in `with_browser_retry` so caller-side exceptions propagate with their real stack trace instead of being masked by `RuntimeError: generator didn't stop after athrow()`.
- Bumps Dogs Trust initial-page-render retries from 1 to 2 to absorb Browserless 45 s render flakes that triggered the 2026-05-16 cron failure.

## What broke today

Saturday's cron (`thriving-appreciation`, 15:06 UTC):

1. `15:07:24` — Dogs Trust `wait_for_selector` timed out (45 s). In-scraper reload retry kicked in.
2. `15:11:35` — `page.content()` failed mid-pagination with *"Target page, context or browser has been closed"* — Browserless dropped the session.
3. `15:11:35` — That exception propagated out of `async with self._with_browser_retry(...)` and the wrapper attempted a retry.
4. `15:11:38` — Wrapper raised `generator didn't stop after athrow()`; the original error was lost. Dogs Trust contributed 0 dogs; total fell from 1,411 (Thursday) to 988 (Saturday).

## Root cause

`scrapers/browser_manager.py:with_browser_retry` is an `@asynccontextmanager` that retried *inside* the generator:

```python
for attempt in range(max_retries):
    try:
        async with playwright_service.get_browser(opts) as result:
            yield result          # contract: yield exactly once
            return
    except Exception as e:        # also catches body exceptions
        await asyncio.sleep(delay)   # → next iteration yields again
```

After `athrow()`, an async generator must stop; this one yielded a second time. Same wrapper is used by `misis_rescue` too.

## The fix (option B from the audit)

- Acquire the browser via manual `__aenter__()` inside the retry loop (only acquisition errors trigger retries).
- Once acquired, yield exactly once inside a plain `try/finally` that always calls `__aexit__`.
- Post-yield exceptions now surface unchanged.

## Test plan

- [x] New regression tests in `tests/scrapers/test_browser_manager.py::TestWithBrowserRetry`:
  - body exception propagates as the original exception (not RuntimeError)
  - browser-acquisition retry still works
  - exhausted acquisition retries raise the last error
  - body failure does not trigger a second acquisition
- [x] Updated Dogs Trust resilience tests for 3-attempt flow (`test_dogstrust_scraper.py`).
- [x] `uv run ruff check` clean on touched files.
- [x] `uv run pytest tests/scrapers -m "not slow and not browser and not external"` → 642 passed.

## Notes

- Same wrapper is used by `misis_rescue` (`scraper.py:240, 815`); fix benefits it too.
- No change to public API of `with_browser_retry`/`_with_browser_retry`.