### PR TITLE
fix(scraper): repair dogstrust pagination after site redesign

### DIFF
--- a/scrapers/dogstrust/dogstrust_scraper.py
+++ b/scrapers/dogstrust/dogstrust_scraper.py
@@ -739,6 +739,8 @@ class DogsTrustScraper(BaseScraper):
                         self.logger.info(f"Reached last page ({max_pages} total)")
                         break
 
+                    # "Go to next page" is the current control; the rest are
+                    # retained as defensive fallbacks against another label change.
                     next_selectors = [
                         "button[aria-label='Go to next page']",
                         "button[aria-label='Next']",
@@ -785,7 +787,12 @@ class DogsTrustScraper(BaseScraper):
                             }"""
                         )
 
-                    # Wait for the listing to re-render with a different first card.
+                    # Wait for the listing to re-render with a different first
+                    # card. A timeout means the click did not advance the page
+                    # (stale/intercepted click, or genuinely no further results),
+                    # so stop rather than advance — re-reading the same DOM would
+                    # silently duplicate or skip pages, this scraper's historical
+                    # failure mode.
                     try:
                         await page.wait_for_function(
                             """(prev) => {
@@ -796,7 +803,8 @@ class DogsTrustScraper(BaseScraper):
                             timeout=15000,
                         )
                     except PlaywrightTimeoutError:
-                        self.logger.warning(f"Timeout waiting for page {page_num + 1} to render")
+                        self.logger.warning(f"Page {page_num + 1} did not render after clicking Next - stopping pagination")
+                        break
 
                     await asyncio.sleep(self.rate_limit_delay + random.uniform(0.3, 0.8))
                     page_num += 1
@@ -847,7 +855,10 @@ class DogsTrustScraper(BaseScraper):
             soup: BeautifulSoup object of the listing page
 
         Returns:
-            Maximum page number detected (defaults to 47 if not found)
+            Total page count from the indicator, or a fixed fallback bound if
+            none is found. The fallback is only a ceiling — the pagination loop's
+            empty-page check is the real terminator, so the exact value is not
+            load-bearing.
         """
         # Look for pagination indicator with pattern "X of Y" or "X / Y".
         # Dogs Trust switched the rendered separator from "of" to "/", so accept both.

--- a/scrapers/dogstrust/dogstrust_scraper.py
+++ b/scrapers/dogstrust/dogstrust_scraper.py
@@ -700,10 +700,14 @@ class DogsTrustScraper(BaseScraper):
                 await page.evaluate("window.scrollTo(0, 0)")
                 await asyncio.sleep(0.2)
 
-                # Pagination loop
+                # Pagination loop — Dogs Trust is a client-side SPA: navigating
+                # directly to ?page=N is rewritten back to page 0, so we must
+                # advance by clicking the "Next" control and waiting for the
+                # cards to re-render. The control's aria-label is "Go to next
+                # page"; older selectors ("Next") no longer match, which is what
+                # stranded the scraper on page 0.
                 page_num = 0
                 max_pages = None
-                pages_scraped = 0
 
                 while True:
                     html_content = await page.content()
@@ -717,11 +721,16 @@ class DogsTrustScraper(BaseScraper):
                     if page_dogs:
                         all_dogs.extend(page_dogs)
                         self.logger.info(f"Page {page_num}: Found {len(page_dogs)} dogs (total so far: {len(all_dogs)})")
+                    elif page_num > 0:
+                        # An empty page past the first means we've run off the end
+                        # of the results — stop even if the detected max is higher
+                        # (the indicator can be stale or fall back to a fixed bound).
+                        self.logger.info(f"Page {page_num}: No dogs found - reached end of results")
+                        break
                     else:
                         self.logger.warning(f"Page {page_num}: No dogs found")
 
-                    pages_scraped += 1
-
+                    pages_scraped = page_num + 1
                     if max_pages_to_scrape and pages_scraped >= max_pages_to_scrape:
                         self.logger.info(f"Reached debug limit of {max_pages_to_scrape} pages")
                         break
@@ -730,64 +739,67 @@ class DogsTrustScraper(BaseScraper):
                         self.logger.info(f"Reached last page ({max_pages} total)")
                         break
 
-                    # Navigate to next page
-                    try:
-                        await page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
-                        await asyncio.sleep(0.5)
+                    next_selectors = [
+                        "button[aria-label='Go to next page']",
+                        "button[aria-label='Next']",
+                        "a[aria-label='Next page']",
+                        "button:has-text('Next')",
+                    ]
+                    next_button = None
+                    for selector in next_selectors:
+                        try:
+                            btn = page.locator(selector).first
+                            if await btn.is_visible() and await btn.is_enabled():
+                                next_button = btn
+                                break
+                        except Exception:
+                            continue
 
-                        next_selectors = [
-                            "button[aria-label='Next']",
-                            "button:has-text('Next')",
-                            "a[aria-label='Next page']",
-                        ]
-                        next_button = None
-                        for selector in next_selectors:
-                            try:
-                                btn = page.locator(selector).first
-                                if await btn.is_visible() and await btn.is_enabled():
-                                    next_button = btn
-                                    break
-                            except Exception:
-                                continue
-
-                        if next_button:
-                            self.logger.debug(f"Clicking Next button to navigate to page {page_num + 1}")
-                            await next_button.scroll_into_view_if_needed()
-                            await asyncio.sleep(0.3)
-                            # Use JavaScript click to bypass any overlay issues
-                            try:
-                                await page.evaluate(
-                                    """
-                                    (() => {
-                                        const btn = document.querySelector('button[aria-label="Next"]')
-                                            || document.querySelector('a[aria-label="Next page"]')
-                                            || [...document.querySelectorAll('button')].find(b => b.textContent.includes('Next'));
-                                        if (btn) btn.click();
-                                    })()
-                                """
-                                )
-                            except Exception:
-                                # Fallback to Playwright click with force
-                                await next_button.click(force=True, timeout=10000)
-                            await asyncio.sleep(self.rate_limit_delay + random.uniform(0.3, 0.8))
-
-                            try:
-                                await page.wait_for_selector('a[href*="/rehoming/dogs/"]', timeout=10000)
-                            except Exception:
-                                self.logger.warning(f"Timeout waiting for page {page_num + 1}")
-
-                            await page.evaluate("window.scrollTo(0, document.body.scrollHeight / 2)")
-                            await asyncio.sleep(0.2)
-                            await page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
-                            await asyncio.sleep(0.2)
-
-                            page_num += 1
-                        else:
-                            self.logger.info("No enabled Next button found - reached end of results")
-                            break
-                    except Exception as e:
-                        self.logger.info(f"Could not find or click Next button: {e}")
+                    if not next_button:
+                        self.logger.info("No enabled Next button found - reached end of results")
                         break
+
+                    # Capture the current first card so we can detect the
+                    # client-side re-render after clicking Next.
+                    prev_first_href = await page.evaluate(
+                        """() => {
+                            const a = document.querySelector('a[href*="/rehoming/dogs/"]');
+                            return a ? a.getAttribute('href') : null;
+                        }"""
+                    )
+
+                    self.logger.debug(f"Clicking Next to navigate to page {page_num + 1}")
+                    await next_button.scroll_into_view_if_needed()
+                    await asyncio.sleep(0.3)
+                    try:
+                        await next_button.click(timeout=10000)
+                    except Exception:
+                        # Fallback to a JS click if an overlay intercepts the click.
+                        await page.evaluate(
+                            """() => {
+                                const btn = document.querySelector('button[aria-label="Go to next page"]')
+                                    || document.querySelector('button[aria-label="Next"]')
+                                    || document.querySelector('a[aria-label="Next page"]')
+                                    || [...document.querySelectorAll('button')].find(b => b.textContent.includes('Next'));
+                                if (btn) btn.click();
+                            }"""
+                        )
+
+                    # Wait for the listing to re-render with a different first card.
+                    try:
+                        await page.wait_for_function(
+                            """(prev) => {
+                                const a = document.querySelector('a[href*="/rehoming/dogs/"]');
+                                return a && a.getAttribute('href') !== prev;
+                            }""",
+                            arg=prev_first_href,
+                            timeout=15000,
+                        )
+                    except PlaywrightTimeoutError:
+                        self.logger.warning(f"Timeout waiting for page {page_num + 1} to render")
+
+                    await asyncio.sleep(self.rate_limit_delay + random.uniform(0.3, 0.8))
+                    page_num += 1
 
             except Exception as e:
                 self.logger.error(f"Error during Playwright pagination scraping: {e}")
@@ -828,8 +840,8 @@ class DogsTrustScraper(BaseScraper):
     def _detect_max_pages(self, soup: BeautifulSoup) -> int:
         """Detect maximum page count from pagination indicator.
 
-        Looks for pagination text like "1 of 47" to determine total pages.
-        Based on analysis findings showing 47 total pages.
+        Looks for pagination text like "1 / 38" (or legacy "1 of 47") to
+        determine total pages, falling back to a fixed bound if not found.
 
         Args:
             soup: BeautifulSoup object of the listing page
@@ -837,11 +849,13 @@ class DogsTrustScraper(BaseScraper):
         Returns:
             Maximum page number detected (defaults to 47 if not found)
         """
-        # Look for pagination indicator with pattern "X of Y"
-        elements = soup.find_all(string=re.compile(r"\d+ of \d+"))
+        # Look for pagination indicator with pattern "X of Y" or "X / Y".
+        # Dogs Trust switched the rendered separator from "of" to "/", so accept both.
+        indicator_pattern = re.compile(r"\d+\s*(?:of|/)\s*\d+")
+        elements = soup.find_all(string=indicator_pattern)
         for element in elements:
             element_text = str(element).strip()
-            match = re.search(r"(\d+) of (\d+)", element_text)
+            match = re.search(r"(\d+)\s*(?:of|/)\s*(\d+)", element_text)
             if match:
                 total_pages = int(match.group(2))
                 self.logger.debug(f"Found pagination indicator: {element_text}")
@@ -879,10 +893,11 @@ class DogsTrustScraper(BaseScraper):
                     continue  # Skip duplicate links on the same page
                 seen_urls.add(href)
 
-                # Check if this dog is reserved
-                # Look for RESERVED indicator within the link element
+                # Check if this dog is reserved. The card renders the indicator
+                # as "Reserved" (title case); match case-insensitively so a
+                # casing change on the site doesn't let reserved dogs slip through.
                 link_text = link.get_text(separator=" ", strip=True)
-                if "RESERVED" in link_text:
+                if "reserved" in link_text.lower():
                     self.logger.debug(f"Skipping reserved dog: {href}")
                     continue
 

--- a/tests/scrapers/test_dogstrust_scraper.py
+++ b/tests/scrapers/test_dogstrust_scraper.py
@@ -404,6 +404,12 @@ class TestDogsTrustPagination:
     (aria-label 'Go to next page'). The old 'Next' selectors no longer match,
     which stranded the scraper on page 0 (15/422 dogs)."""
 
+    @pytest.fixture(autouse=True)
+    def _no_real_sleep(self):
+        """Skip the rate-limit/scroll sleeps so these stay unit-fast (<10ms)."""
+        with patch("scrapers.dogstrust.dogstrust_scraper.asyncio.sleep", new=AsyncMock()):
+            yield
+
     def _page_html(self, indicator, dog_id):
         return f'<html><body><a href="/rehoming/dogs/breed/{dog_id}">Dog</a><div>{indicator}</div></body></html>'
 
@@ -459,5 +465,39 @@ class TestDogsTrustPagination:
         result = await scraper._get_animal_list_playwright()
 
         assert len(result) == 1
-        # Only one Next click happened (page 0 → empty page 1, then stop).
+        # Read exactly two pages — page 0, then the empty page 1 — before
+        # stopping, rather than marching toward the detected max of 47.
         assert page.content.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_js_click_when_playwright_click_fails(self):
+        """If the Playwright click raises (e.g. overlay intercept), the JS-click
+        fallback must run and pagination must still advance, not silently stop."""
+        scraper = DogsTrustScraper()
+        page = _build_paginated_page_mock([self._page_html("1 / 2", 111), self._page_html("2 / 2", 222)])
+        page.locator.return_value.first.click = AsyncMock(side_effect=Exception("intercepted"))
+        _patch_browser_retry(scraper, page)
+
+        result = await scraper._get_animal_list_playwright()
+
+        # Both pages still collected despite the failed Playwright click.
+        assert sorted(d["external_id"] for d in result) == ["111", "222"]
+        # The pagination fallback script (unique 'Go to next page' selector) ran.
+        evaluated = [call.args[0] for call in page.evaluate.await_args_list if call.args]
+        assert any("Go to next page" in script for script in evaluated)
+
+    @pytest.mark.asyncio
+    async def test_stops_when_next_page_never_renders(self):
+        """A re-render timeout means the page didn't advance; stop instead of
+        re-reading the same DOM (which would duplicate or skip pages)."""
+        scraper = DogsTrustScraper()
+        page = _build_paginated_page_mock([self._page_html("1 / 38", 111), self._page_html("2 / 38", 222)])
+        page.wait_for_function = AsyncMock(side_effect=PlaywrightTimeoutError("no re-render"))
+        _patch_browser_retry(scraper, page)
+
+        result = await scraper._get_animal_list_playwright()
+
+        # Only page 0 collected; the loop stopped on the unrendered page rather
+        # than advancing and re-scraping.
+        assert [d["external_id"] for d in result] == ["111"]
+        assert page.content.await_count == 1

--- a/tests/scrapers/test_dogstrust_scraper.py
+++ b/tests/scrapers/test_dogstrust_scraper.py
@@ -170,6 +170,33 @@ class TestDogsTrustUnifiedStandardization:
 # a real Sentry exception (not a misleading zero-dogs alert).
 
 
+def _build_paginated_page_mock(page_htmls):
+    """Build a mock Playwright Page whose content() returns a different HTML per page.
+
+    Used to exercise click-based pagination: each call to page.content() yields
+    the next page's markup, and the Next control reports visible+enabled so the
+    loop clicks through.
+    """
+    page = MagicMock()
+    page.goto = AsyncMock()
+    page.evaluate = AsyncMock(return_value=None)
+    page.wait_for_selector = AsyncMock(return_value=None)
+    page.wait_for_function = AsyncMock(return_value=None)
+    page.content = AsyncMock(side_effect=list(page_htmls))
+    page.reload = AsyncMock()
+
+    locator_first = MagicMock()
+    locator_first.is_visible = AsyncMock(return_value=True)
+    locator_first.is_enabled = AsyncMock(return_value=True)
+    locator_first.click = AsyncMock()
+    locator_first.scroll_into_view_if_needed = AsyncMock()
+    locator = MagicMock()
+    locator.first = locator_first
+    page.locator = MagicMock(return_value=locator)
+
+    return page
+
+
 def _build_listing_page_mock(wait_for_selector_side_effect, content_html=""):
     """Build a mock Playwright Page that satisfies the listing flow.
 
@@ -180,6 +207,7 @@ def _build_listing_page_mock(wait_for_selector_side_effect, content_html=""):
     page.goto = AsyncMock()
     page.evaluate = AsyncMock(return_value=0)
     page.wait_for_selector = AsyncMock(side_effect=wait_for_selector_side_effect)
+    page.wait_for_function = AsyncMock(return_value=None)
     page.content = AsyncMock(return_value=content_html)
     page.reload = AsyncMock()
 
@@ -313,3 +341,123 @@ class TestDogsTrustPlaywrightResilience:
 
         source = inspect.getsource(scraper.collect_data)
         assert "except Exception" not in source, "collect_data must not catch and return [] — that re-introduces the silent-failure bug this PR fixes"
+
+
+@pytest.mark.unit
+class TestDogsTrustDetectMaxPages:
+    """Dogs Trust renders its page indicator as 'N / M' (e.g. '2 / 38').
+
+    Earlier markup used 'N of M'; both must parse so a site-side format flip
+    doesn't silently collapse pagination to the hardcoded fallback.
+    """
+
+    def test_parses_slash_format(self):
+        from bs4 import BeautifulSoup
+
+        scraper = DogsTrustScraper()
+        soup = BeautifulSoup("<div>2 / 38</div>", "html.parser")
+        assert scraper._detect_max_pages(soup) == 38
+
+    def test_parses_of_format_still_supported(self):
+        from bs4 import BeautifulSoup
+
+        scraper = DogsTrustScraper()
+        soup = BeautifulSoup("<div>1 of 41</div>", "html.parser")
+        assert scraper._detect_max_pages(soup) == 41
+
+    def test_defaults_when_no_indicator(self):
+        from bs4 import BeautifulSoup
+
+        scraper = DogsTrustScraper()
+        soup = BeautifulSoup("<div>no pagination here</div>", "html.parser")
+        assert scraper._detect_max_pages(soup) == 47
+
+
+@pytest.mark.unit
+class TestDogsTrustReservedFiltering:
+    """The card's reserved indicator renders as 'Reserved' (title case).
+
+    The skip check must be case-insensitive so reserved dogs aren't surfaced
+    as available when the site changes the indicator's casing.
+    """
+
+    def test_skips_title_case_reserved(self):
+        from bs4 import BeautifulSoup
+
+        scraper = DogsTrustScraper()
+        html = """
+        <html><body>
+            <a href="/rehoming/dogs/beagle/111"><span>Bella</span><span>Reserved</span></a>
+            <a href="/rehoming/dogs/collie/222"><span>Max</span></a>
+        </body></html>
+        """
+        soup = BeautifulSoup(html, "html.parser")
+        dogs = scraper._extract_dogs_from_page(soup)
+        ids = sorted(d["external_id"] for d in dogs)
+        assert ids == ["222"]
+
+
+@pytest.mark.unit
+class TestDogsTrustPagination:
+    """Dogs Trust is a client-side SPA: a hard navigation to ?page=N is rewritten
+    back to page 0, so pagination must advance by clicking the Next control
+    (aria-label 'Go to next page'). The old 'Next' selectors no longer match,
+    which stranded the scraper on page 0 (15/422 dogs)."""
+
+    def _page_html(self, indicator, dog_id):
+        return f'<html><body><a href="/rehoming/dogs/breed/{dog_id}">Dog</a><div>{indicator}</div></body></html>'
+
+    @pytest.mark.asyncio
+    async def test_clicks_through_distinct_pages(self):
+        scraper = DogsTrustScraper()
+        page = _build_paginated_page_mock(
+            [
+                self._page_html("1 / 3", 111),
+                self._page_html("2 / 3", 222),
+                self._page_html("3 / 3", 333),
+            ]
+        )
+        _patch_browser_retry(scraper, page)
+
+        result = await scraper._get_animal_list_playwright()
+
+        # All three pages scraped, each yielding a distinct dog.
+        assert sorted(d["external_id"] for d in result) == ["111", "222", "333"]
+        # Pagination is click-driven, not URL-driven: goto fires once (initial load).
+        assert page.goto.await_count == 1
+        # The corrected Next selector must be among those tried.
+        tried_selectors = [call.args[0] for call in page.locator.call_args_list]
+        assert "button[aria-label='Go to next page']" in tried_selectors
+
+    @pytest.mark.asyncio
+    async def test_stops_when_no_next_button(self):
+        scraper = DogsTrustScraper()
+        page = _build_paginated_page_mock([self._page_html("1 / 38", 111)])
+        # No Next control is visible/enabled → must stop after page 0.
+        page.locator.return_value.first.is_visible = AsyncMock(return_value=False)
+        page.locator.return_value.first.is_enabled = AsyncMock(return_value=False)
+        _patch_browser_retry(scraper, page)
+
+        result = await scraper._get_animal_list_playwright()
+
+        assert [d["external_id"] for d in result] == ["111"]
+        assert page.locator.return_value.first.click.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_stops_on_empty_page_even_when_max_pages_overestimates(self):
+        scraper = DogsTrustScraper()
+        # Indicator claims 47 pages, but the second page returns no dogs:
+        # an empty page past the first must end the loop, not march to 47.
+        page = _build_paginated_page_mock(
+            [
+                self._page_html("1 / 47", 111),
+                "<html><body><div>2 / 47</div></body></html>",
+            ]
+        )
+        _patch_browser_retry(scraper, page)
+
+        result = await scraper._get_animal_list_playwright()
+
+        assert len(result) == 1
+        # Only one Next click happened (page 0 → empty page 1, then stop).
+        assert page.content.await_count == 2


### PR DESCRIPTION
## Problem

Dogs Trust's last few scraper runs failed: every run found only **15 of 422 dogs** and fired a critical partial-failure Sentry alert ([issue 118308130](https://sampo-cr.sentry.io/issues/118308130/)). The listing page itself renders fine for humans — the scraper's pagination automation broke after a site redesign.

## Root cause (verified against the live DOM)

1. **Fatal:** The "Next" control's `aria-label` changed from `"Next"`/`"Next page"` to **`"Go to next page"`**. None of the scraper's `next_selectors` matched, so `next_button` stayed `None` and the loop broke after page 0 → 15 dogs (one page's worth).
2. **Symptom:** The page indicator format flipped from `"X of Y"` to **`"X / Y"`**, so `_detect_max_pages` couldn't parse it ("defaulting to 47"; real count is now 38).
3. **Latent bug:** The reserved indicator renders as `<span>Reserved</span>` (title case) but the skip check was case-sensitive (`"RESERVED"`), so reserved dogs leaked through as available.

Also confirmed: Dogs Trust is a **client-side SPA** — a hard navigation to `?page=N` is rewritten back to `page=0`. Pagination only advances via in-app clicks (verified: clicking "Go to next page" steps the indicator 1→2→3 of 38 with fully distinct dogs).

## Changes

- **`_detect_max_pages`**: parse both `"X / Y"` and legacy `"X of Y"`.
- **Pagination loop**: click `button[aria-label='Go to next page']` (old labels kept as fallbacks), then `wait_for_function` for the first card's href to change before reading — reliable signal for the SPA's async re-render. Added an empty-page safety break.
- **Reserved filter**: case-insensitive match.

## Tests

Added unit tests: slash/of/fallback indicator parsing; click-through across distinct pages (asserts `goto` fires once → not URL-driven, and the corrected selector is tried); stop-when-no-next-button; stop-on-empty-page; title-case reserved filtering.

- 28/28 dogstrust tests pass
- 649/649 scraper unit+integration tests pass
- ruff clean

## Scope note

The Selenium listing path is untouched — production runs Playwright (logs show `Page.wait_for_selector`/Browserless). It already inherits the shared `_detect_max_pages` and reserved-filter fixes.