### PR TITLE
fix(tests): use asyncio.run in navigate_with_retry tests

### DIFF
--- a/tests/scrapers/test_browser_manager.py
+++ b/tests/scrapers/test_browser_manager.py
@@ -75,7 +75,7 @@ class TestNavigateWithRetry:
         page = AsyncMock()
         page.goto = AsyncMock()
 
-        result = asyncio.get_event_loop().run_until_complete(browser_manager.navigate_with_retry(page, "https://example.com", max_retries=2))
+        result = asyncio.run(browser_manager.navigate_with_retry(page, "https://example.com", max_retries=2))
 
         assert result is True
         page.goto.assert_called_once()
@@ -84,7 +84,7 @@ class TestNavigateWithRetry:
         page = AsyncMock()
         page.goto = AsyncMock(side_effect=Exception("navigation failed"))
 
-        result = asyncio.get_event_loop().run_until_complete(browser_manager.navigate_with_retry(page, "https://example.com", max_retries=2))
+        result = asyncio.run(browser_manager.navigate_with_retry(page, "https://example.com", max_retries=2))
 
         assert result is False
         assert page.goto.call_count == 2


### PR DESCRIPTION
## Summary
- Replace deprecated `asyncio.get_event_loop().run_until_complete()` with `asyncio.run()` in `TestNavigateWithRetry`.

## Why
pytest-asyncio 1.4 (bumped in #236) no longer tolerates implicit event loop creation in sync tests, failing with `RuntimeError: There is no current event loop in thread 'MainThread'`. This unblocks the python-dependencies Dependabot PR.

## Verification
- `uv run pytest tests/scrapers/test_browser_manager.py` — 11 passed
- `uv run --with pytest-asyncio==1.4.0 pytest tests/scrapers/test_browser_manager.py::TestNavigateWithRetry` — 2 passed (reproduces the CI environment of #236)

🤖 Generated with [Claude Code](https://claude.com/claude-code)