### PR TITLE
fix(security): close incomplete HTML sanitization (CodeQL alerts #109-111)

### DIFF
--- a/frontend/src/__tests__/security/content-sanitization.test.js
+++ b/frontend/src/__tests__/security/content-sanitization.test.js
@@ -1,9 +1,38 @@
 /**
  * Tests for content sanitization and XSS prevention
  */
-import { sanitizeHtml, sanitizeText, validateUrl } from "../../utils/security";
+import {
+  sanitizeHtml,
+  sanitizeText,
+  stripHtml,
+  validateUrl,
+} from "../../utils/security";
 
 describe("Content Sanitization", () => {
+  describe("stripHtml", () => {
+    test("removes simple tags and keeps text", () => {
+      const result = stripHtml("<p>Hello <strong>world</strong></p>");
+      expect(result).toBe("Hello world");
+    });
+
+    test("returns empty string for non-string input", () => {
+      expect(stripHtml(null)).toBe("");
+      expect(stripHtml(undefined)).toBe("");
+      expect(stripHtml(123)).toBe("");
+    });
+
+    test("strips unclosed tags so the result cannot contain <script", () => {
+      const result = stripHtml("<p>Safe text<script");
+      expect(result).not.toContain("<script");
+      expect(result).toBe("Safe text");
+    });
+
+    test("strips tags that reconstruct after a single pass", () => {
+      const result = stripHtml("<scr<script>ipt>alert(1)</script>");
+      expect(result).not.toContain("<script");
+    });
+  });
+
   describe("HTML Sanitization", () => {
     test("should remove script tags", () => {
       const input = '<p>Hello</p><script>alert("xss")</script>';

--- a/frontend/src/components/dogs/DogDescription.tsx
+++ b/frontend/src/components/dogs/DogDescription.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useCallback } from "react";
-import { sanitizeText, sanitizeHtml } from "../../utils/security";
+import { sanitizeText, sanitizeHtml, stripHtml } from "../../utils/security";
 import type { DogDescriptionProps } from "@/types/dogComponents";
 
 export default function DogDescription({
@@ -13,7 +13,7 @@ export default function DogDescription({
   const getPlainTextLength = useCallback((htmlString: string): number => {
     if (!htmlString || typeof htmlString !== "string") return 0;
     if (typeof window === "undefined") {
-      return htmlString.replace(/<[^>]*>/g, "").length;
+      return stripHtml(htmlString).length;
     }
 
     const tempDiv = document.createElement("div");
@@ -65,10 +65,7 @@ export default function DogDescription({
     if (plainTextLength <= 200) return descriptionMeta.cleanDescription;
 
     if (typeof window === "undefined") {
-      const plainText = descriptionMeta.cleanDescription.replace(
-        /<[^>]*>/g,
-        "",
-      );
+      const plainText = stripHtml(descriptionMeta.cleanDescription);
       const truncated = plainText.substring(0, 200);
       const lastSpace = truncated.lastIndexOf(" ");
       const breakPoint = lastSpace > 150 ? lastSpace : 200;

--- a/frontend/src/utils/descriptionQuality.ts
+++ b/frontend/src/utils/descriptionQuality.ts
@@ -1,9 +1,5 @@
 import type { Dog } from "@/types/dog";
-
-const stripHtmlTags = (text: string): string => {
-  if (!text || typeof text !== "string") return "";
-  return text.replace(/<[^>]+>/g, "");
-};
+import { stripHtml } from "./security";
 
 const isFallbackContent = (text: string): boolean => {
   if (!text || typeof text !== "string") return true;
@@ -30,7 +26,7 @@ export const hasQualityDescription = (description: string | null | undefined): b
     return false;
   }
 
-  const plainText = stripHtmlTags(description.trim());
+  const plainText = stripHtml(description.trim());
 
   if (plainText.length < 200) {
     return false;
@@ -48,12 +44,12 @@ export const getQualityDescription = (dog: Partial<Dog> | null | undefined): str
 
   const propsDescription = dog.properties?.description;
   if (propsDescription && hasQualityDescription(propsDescription)) {
-    return stripHtmlTags(propsDescription.trim());
+    return stripHtml(propsDescription.trim());
   }
 
   const rootDescription = dog.description;
   if (rootDescription && hasQualityDescription(rootDescription)) {
-    return stripHtmlTags(rootDescription.trim());
+    return stripHtml(rootDescription.trim());
   }
 
   return null;

--- a/frontend/src/utils/security.ts
+++ b/frontend/src/utils/security.ts
@@ -17,17 +17,23 @@ const DOMPURIFY_CONFIG = {
   ALLOWED_ATTR: ["href", "target", "rel", "src", "alt"],
 };
 
+export function stripHtml(html: string | null | undefined): string {
+  if (typeof html !== "string") return "";
+
+  let result = html;
+  let prev: string;
+  do {
+    prev = result;
+    result = result.replace(/<[^>]*>?/g, "");
+  } while (result !== prev);
+  return result;
+}
+
 export function sanitizeHtml(html: string): string {
   if (typeof html !== "string") return "";
 
   if (typeof window === "undefined") {
-    let result = html;
-    let prev: string;
-    do {
-      prev = result;
-      result = result.replace(/<[^>]*>?/g, "");
-    } while (result !== prev);
-    return result;
+    return stripHtml(html);
   }
 
   return DOMPurify.sanitize(html, DOMPURIFY_CONFIG);


### PR DESCRIPTION
## Summary

Resolves the 3 open CodeQL `js/incomplete-multi-character-sanitization` alerts (#109, #110, #111).

Three call sites stripped HTML with a single-pass regex (`replace(/<[^>]*>/g, "")` / `/<[^>]+>/g`). A single pass leaves unclosed tags (e.g. a trailing `<script`) and tags that reconstruct after one removal, so the output "may still contain `<script`".

## Changes

- Add a shared `stripHtml` helper in `security.ts` that repeats the replace (using the `<[^>]*>?` pattern, which also matches unclosed tags) until the string is stable — the same approach already used inside `sanitizeHtml`'s SSR branch.
- `sanitizeHtml` SSR branch now delegates to `stripHtml` (removes the duplicated loop).
- `DogDescription.tsx`: both SSR plain-text strips now use `stripHtml`.
- `descriptionQuality.ts`: local single-pass `stripHtmlTags` removed in favor of `stripHtml`.

Note: in `DogDescription`, stripped content was already re-sanitized via `sanitizeHtml` before `dangerouslySetInnerHTML`; this hardens the intermediate strip and satisfies the static analysis.

## Tests

- New `stripHtml` tests cover simple stripping, non-string input, unclosed-tag stripping, and reconstruction.
- Affected suites green: `content-sanitization`, `DogDescription`, `descriptionQuality`, `seo.llm` (50 tests).
- `tsc --noEmit` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)