### PR TITLE
fix(dogstrust): retry whole scrape on Browserless session drop

### DIFF
--- a/scrapers/dogstrust/dogstrust_scraper.py
+++ b/scrapers/dogstrust/dogstrust_scraper.py
@@ -18,6 +18,7 @@ USE_PLAYWRIGHT = os.environ.get("USE_PLAYWRIGHT", "false").lower() == "true"
 
 # Imports are unconditional so tests can exercise both paths regardless of
 # the env var; USE_PLAYWRIGHT only routes runtime behaviour.
+from playwright.async_api import Error as PlaywrightError  # noqa: E402
 from playwright.async_api import TimeoutError as PlaywrightTimeoutError  # noqa: E402
 from selenium.webdriver.common.by import By  # noqa: E402
 from selenium.webdriver.support import expected_conditions as EC  # noqa: E402
@@ -25,6 +26,23 @@ from selenium.webdriver.support.wait import WebDriverWait  # noqa: E402
 
 from services.browser_service import BrowserOptions, get_browser_service  # noqa: E402
 from services.playwright_browser_service import PlaywrightOptions  # noqa: E402
+
+# Browserless v2 sessions occasionally close mid-pagination — the remote browser
+# is torn down server-side, surfacing as a TargetClosedError partway through the
+# scrape (e.g. at page.content()). Matched by message because Playwright only
+# exports TargetClosedError from a private module, not the public async_api.
+_BROWSER_CLOSED_SIGNATURES = (
+    "target page, context or browser has been closed",
+    "target closed",
+    "browser has been closed",
+    "connection closed",
+)
+
+
+def _is_browser_closed_error(error: BaseException) -> bool:
+    """True if the error is a Browserless session drop worth a full-scrape retry."""
+    message = str(error).lower()
+    return any(signature in message for signature in _BROWSER_CLOSED_SIGNATURES)
 
 
 class DogsTrustScraper(BaseScraper):
@@ -216,8 +234,29 @@ class DogsTrustScraper(BaseScraper):
             List of dictionaries containing basic dog information from all pages
         """
         if USE_PLAYWRIGHT:
-            return asyncio.run(self._get_animal_list_playwright(max_pages_to_scrape))
+            return self._run_playwright_pagination_with_retry(max_pages_to_scrape)
         return self._get_animal_list_selenium(max_pages_to_scrape)
+
+    def _run_playwright_pagination_with_retry(self, max_pages_to_scrape: int = None, max_attempts: int = 3) -> list[dict[str, Any]]:
+        """Run Playwright pagination, retrying from a fresh browser on a session drop.
+
+        ``_with_browser_retry`` only retries browser *acquisition*; a Browserless
+        session that dies mid-pagination (TargetClosedError at page.content())
+        otherwise loses the whole scrape and fires a Sentry alert. Retrying from
+        page 0 with a new browser is the safe recovery — salvaging the partial
+        pages collected so far would let stale detection mark unseen dogs as
+        adopted. Non-session-drop errors (e.g. a genuine initial-load timeout)
+        are re-raised immediately so real failures still surface.
+        """
+        for attempt in range(1, max_attempts + 1):
+            try:
+                return asyncio.run(self._get_animal_list_playwright(max_pages_to_scrape))
+            except PlaywrightError as error:
+                if not _is_browser_closed_error(error) or attempt == max_attempts:
+                    raise
+                delay = 2.0 * attempt
+                self.logger.warning(f"Browserless session dropped mid-scrape (attempt {attempt}/{max_attempts}): {error}; retrying from a fresh browser in {delay}s")
+                time.sleep(delay)
 
     def _get_animal_list_selenium(self, max_pages_to_scrape: int = None) -> list[dict[str, Any]]:
         """Fetch list of available dogs using Selenium WebDriver with pagination."""

--- a/tests/scrapers/test_dogstrust_scraper.py
+++ b/tests/scrapers/test_dogstrust_scraper.py
@@ -9,6 +9,7 @@ from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
+from playwright.async_api import Error as PlaywrightError
 from playwright.async_api import TimeoutError as PlaywrightTimeoutError
 
 from scrapers.base_scraper import BaseScraper
@@ -341,6 +342,55 @@ class TestDogsTrustPlaywrightResilience:
 
         source = inspect.getsource(scraper.collect_data)
         assert "except Exception" not in source, "collect_data must not catch and return [] — that re-introduces the silent-failure bug this PR fixes"
+
+
+@pytest.mark.unit
+class TestDogsTrustBrowserDropRetry:
+    """Browserless v2 sessions occasionally close mid-pagination, surfacing as a
+    TargetClosedError at page.content(). get_animal_list must retry the whole
+    scrape from a fresh browser rather than losing the run on a transient drop.
+    """
+
+    _CLOSED_MESSAGE = "Page.content: Target page, context or browser has been closed"
+
+    @patch("scrapers.dogstrust.dogstrust_scraper.USE_PLAYWRIGHT", True)
+    @patch("scrapers.dogstrust.dogstrust_scraper.time.sleep")
+    def test_retries_whole_scrape_on_browser_drop(self, mock_sleep):
+        scraper = DogsTrustScraper()
+        dogs = [{"external_id": "1"}, {"external_id": "2"}]
+        attempt = AsyncMock(side_effect=[PlaywrightError(self._CLOSED_MESSAGE), dogs])
+        scraper._get_animal_list_playwright = attempt
+
+        result = scraper.get_animal_list()
+
+        assert result == dogs
+        assert attempt.await_count == 2
+        mock_sleep.assert_called_once()
+
+    @patch("scrapers.dogstrust.dogstrust_scraper.USE_PLAYWRIGHT", True)
+    @patch("scrapers.dogstrust.dogstrust_scraper.time.sleep")
+    def test_reraises_after_exhausting_retries(self, mock_sleep):
+        scraper = DogsTrustScraper()
+        attempt = AsyncMock(side_effect=PlaywrightError(self._CLOSED_MESSAGE))
+        scraper._get_animal_list_playwright = attempt
+
+        with pytest.raises(PlaywrightError):
+            scraper.get_animal_list()
+
+        assert attempt.await_count == 3
+
+    @patch("scrapers.dogstrust.dogstrust_scraper.USE_PLAYWRIGHT", True)
+    @patch("scrapers.dogstrust.dogstrust_scraper.time.sleep")
+    def test_does_not_retry_non_browser_closed_error(self, mock_sleep):
+        scraper = DogsTrustScraper()
+        attempt = AsyncMock(side_effect=PlaywrightTimeoutError("initial page load timed out"))
+        scraper._get_animal_list_playwright = attempt
+
+        with pytest.raises(PlaywrightTimeoutError):
+            scraper.get_animal_list()
+
+        assert attempt.await_count == 1
+        mock_sleep.assert_not_called()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Diagnosis

Sentry **PYTHON-FASTAPI-2A** (#120330901) and **PYTHON-FASTAPI-2G** (#130328538) are the **same single failure** — identical \`trace_id\` (\`ff9b12af…\`) and \`scrape_log_id\` 1075 on 2026-06-25 15:10 UTC. \`2G\` is the exception; \`2A\` is the logged failure message from the same event.

**Root cause:** \`TargetClosedError: Page.content: Target page, context or browser has been closed\` — the remote **Browserless v2 session dropped mid-pagination**. The event's \`all_dogs\` local already held parsed dogs, so selectors/parsing were fine; this is a browser-lifecycle/connection drop, not a scraping bug (those surface as \`PlaywrightTimeoutError\`, already handled gracefully).

**Not a one-off:** \`2A\` shows 2 occurrences (2026-05-16 and 2026-06-25). Dogs Trust runs Tue/Thu/Sat (~18 runs in window) → ~10% failure rate. It will recur.

**Why it needs a fix:** \`_with_browser_retry\` only retries browser *acquisition*. Once the page is yielded, a mid-scrape drop propagates through \`get_animal_list → collect_data\` and loses the entire run. Dogs Trust is the longest-running scrape (up to 47 SPA pages with 15s render waits), so it's the most exposed.

## Fix

Wrap the Playwright pagination in a 3-attempt retry that detects a session-drop error (matched by message — \`TargetClosedError\` is only exported from Playwright's private module) and restarts from a **fresh browser**.

Retrying from page 0 rather than salvaging the partial pages is deliberate: returning partial results could let stale/adoption detection mark unseen dogs as adopted. Non-session-drop errors (e.g. a genuine initial-load timeout) re-raise immediately so real failures still surface to Sentry.

## Tests

- \`test_retries_whole_scrape_on_browser_drop\` — drop on attempt 1, fresh browser on attempt 2 succeeds
- \`test_reraises_after_exhausting_retries\` — persistent drop re-raises after 3 attempts
- \`test_does_not_retry_non_browser_closed_error\` — timeout is not retried

656 scraper tests pass; ruff check/format clean.

Fixes PYTHON-FASTAPI-2A
Fixes PYTHON-FASTAPI-2G