### PR TITLE
fix(frontend): remove duplicate @types/node keys from broken pnpm-lockfile

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -2628,9 +2628,6 @@ packages:
   '@types/node@26.0.1':
     resolution: {integrity: sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==}
 
-  '@types/node@26.0.1':
-    resolution: {integrity: sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==}
-
   '@types/pg-pool@2.0.6':
     resolution: {integrity: sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==}
 
@@ -9099,10 +9096,6 @@ snapshots:
   '@types/mysql@2.15.26':
     dependencies:
       '@types/node': 26.0.1
-
-  '@types/node@26.0.1':
-    dependencies:
-      undici-types: 8.3.0
 
   '@types/node@26.0.1':
     dependencies:


### PR DESCRIPTION
## Problem

`frontend/pnpm-lock.yaml` on `main` is corrupt: `@types/node@26.0.1` is declared **twice** in both the `packages:` and `snapshots:` sections (4 occurrences total), from a bad dependabot auto-merge (#252 `@types/node` bump + #260 npm-group both wrote the block, git text-merged with no conflict).

pnpm can't parse it:

```
ERR_PNPM_BROKEN_LOCKFILE  The lockfile ... is broken: duplicated mapping key (2631:3)
```

This fails `pnpm install --frozen-lockfile` on **every** frontend CI job and breaks **Vercel deploys** off main. CI on the individual dependabot PRs was green because each was valid in isolation — the corruption only appeared in the merged result.

## Fix

Remove the two duplicate blocks (7 lines). No resolution changes.

## Verification

`pnpm install --frozen-lockfile` now parses and resolves cleanly (previously errored on parse):

```
Done in 6.1s using pnpm v10.33.0
```

## Impact

Unblocks all frontend CI and Vercel deploys. Should merge before other blocked PRs (e.g. #263) so their merge-with-main picks up the valid lockfile.