### PR TITLE
fix(misisrescue): retry transient navigation stalls instead of losing the org

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Build an open-source platform aggregating rescue dogs from multiple organization
 - Site live at www.rescuedogs.me
 - 1,500+ active dogs from 12 organizations
 - Deployment: Vercel (frontend), Railway (backend + PostgreSQL + cron)
-- Scrapers: Railway cron (Tue/Thu/Sat 6am UTC)
+- Scrapers: Railway cron (Mon/Thu/Sat 3pm UTC)
 - Traffic: 20+ daily users, growing steadily
 
 ## USE SUB-AGENTS FOR CONTEXT OPTIMIZATION

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ uv run python management/llm_commands.py cost-report
 - **Frontend**: Vercel (automatic from main branch)
 - **Backend**: Railway (automatic from main branch)
 - **Database**: Railway PostgreSQL with automated backups
-- **Scrapers**: Railway cron job (Tue/Thu/Sat 6am UTC)
+- **Scrapers**: Railway cron job (Mon/Thu/Sat 3pm UTC)
 
 ### Monitoring
 

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -192,7 +192,7 @@ print('LLM configured:', get_llm_config().openrouter_api_key is not None)
 # Edit crontab
 crontab -e
 
-# Scrapers run on Railway cron (Tue/Thu/Sat at 6am UTC)
+# Scrapers run on Railway cron (Mon/Thu/Sat at 3pm UTC)
 # For local/manual runs:
 uv run python management/railway_scraper_cron.py           # Run all enabled
 uv run python management/railway_scraper_cron.py --org=dogstrust  # Single org

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -166,7 +166,7 @@ Environment variables: `USE_PLAYWRIGHT=true`, `BROWSERLESS_WS_ENDPOINT`, `BROWSE
 
 ### Railway Cron Job
 
-Scrapers run automatically on Railway as a cron service (Tue/Thu/Sat 6am UTC):
+Scrapers run automatically on Railway as a cron service (Mon/Thu/Sat 3pm UTC):
 
 - **Entry**: `management/railway_scraper_cron.py`
 - **Routing**: `start.sh` routes via `SERVICE_TYPE` env var

--- a/docs/technical/scraper-architecture.md
+++ b/docs/technical/scraper-architecture.md
@@ -33,7 +33,7 @@ The scraper system follows a **Template Method Pattern** with a base class (`Bas
 
 Scrapers run automatically on Railway as a cron service:
 
-**Schedule:** Tue/Thu/Sat at 6am UTC
+**Schedule:** Mon/Thu/Sat at 3pm UTC
 
 **Entry Point:** `management/railway_scraper_cron.py`
 

--- a/frontend/src/__tests__/seo/static-generation.test.js
+++ b/frontend/src/__tests__/seo/static-generation.test.js
@@ -210,7 +210,7 @@ describe("SEO Static Generation Validation", () => {
       const dogPage = await import("../../app/dogs/[slug]/page");
       const orgPage = await import("../../app/organizations/[slug]/page");
 
-      // Dogs revalidate every 48h — matches scraper cadence (Tue/Thu/Sat)
+      // Dogs revalidate every 48h — scraper cadence is Mon/Thu/Sat
       expect(dogPage.revalidate).toBe(172800);
 
       // Organizations revalidate weekly — config-driven content changes rarely

--- a/management/railway_scraper_cron.py
+++ b/management/railway_scraper_cron.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """Railway cron job entrypoint for running all scrapers.
 
-This script is designed to run as a Railway cron job on Tue/Thu/Sat at 6am UTC.
+This script is designed to run as a Railway cron job on Mon/Thu/Sat at 3pm UTC.
 It initializes Sentry, runs all enabled scrapers, and outputs a JSON summary.
 
 Usage:

--- a/scrapers/misis_rescue/scraper.py
+++ b/scrapers/misis_rescue/scraper.py
@@ -215,7 +215,12 @@ class MisisRescueScraper(BaseScraper):
         async with self._with_browser_retry(options) as browser_result:
             page = browser_result.page
 
-            await page.goto(self.listing_url, wait_until="load", timeout=60000)
+            # Retry transient stalls: a single un-retried goto loses the whole
+            # organization to a one-off Browserless/network hiccup. Failure must
+            # raise, never yield an empty listing (see #215).
+            if not await self.browser_manager.navigate_with_retry(page, self.listing_url):
+                raise RuntimeError(f"Navigation to {self.listing_url} failed after retries")
+
             await asyncio.sleep(5)  # Give Wix time to load dynamic content
 
             await self._scroll_to_load_all_content_playwright(page)
@@ -784,7 +789,10 @@ class MisisRescueScraper(BaseScraper):
             async with self._with_browser_retry(options) as browser_result:
                 page = browser_result.page
 
-                await page.goto(url, wait_until="load", timeout=60000)
+                # Retry transient stalls. Exhaustion raises into the handler
+                # below, which skips this one dog rather than the whole org.
+                if not await self.browser_manager.navigate_with_retry(page, url):
+                    raise RuntimeError(f"Navigation to {url} failed after retries")
 
                 # Give Wix time to load dynamic content (same as Selenium)
                 await asyncio.sleep(3)

--- a/tests/scrapers/test_misis_rescue_scraper.py
+++ b/tests/scrapers/test_misis_rescue_scraper.py
@@ -1,8 +1,12 @@
+import asyncio
+from contextlib import asynccontextmanager
 from datetime import datetime
-from unittest.mock import Mock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from bs4 import BeautifulSoup
+from playwright.async_api import TimeoutError as PlaywrightTimeoutError
 
 from scrapers.misis_rescue.detail_parser import MisisRescueDetailParser
 from scrapers.misis_rescue.normalizer import (
@@ -1495,3 +1499,104 @@ class TestListingExtraction:
                 scraper.collect_data()
 
         assert "except Exception" not in inspect.getsource(scraper.collect_data), "collect_data must not catch and return [] — that re-introduces the silent-failure bug"
+
+
+@pytest.mark.unit
+class TestMisisRescueNavigationResilience(ScraperTestBase):
+    """Listing navigation must survive a transient Browserless/network stall.
+
+    Production evidence: the misisrescue org failed a scheduled run with
+    'Page.goto: Timeout 60000ms exceeded' while the site itself served 200 in
+    ~0.5s, and neighbouring runs succeeded. A single un-retried goto therefore
+    loses a whole organization to a one-off stall.
+    """
+
+    scraper_class = MisisRescueScraper
+    config_id = "misisrescue"
+    expected_org_name = "MISIs Animal Rescue"
+    expected_base_url = "https://www.misisrescue.com"
+
+    LISTING_HTML = '<html><body><div><a href="/post/dog1">Dog 1</a></div></body></html>'
+
+    def _patch_page_into(self, scraper, page):
+        """Yield `page` from the browser-retry context manager."""
+
+        @asynccontextmanager
+        async def fake_retry(options=None, **kwargs):
+            yield SimpleNamespace(page=page)
+
+        return patch.object(scraper, "_with_browser_retry", fake_retry)
+
+    def _make_page(self, goto):
+        page = Mock()
+        page.goto = goto
+        page.content = AsyncMock(return_value=self.LISTING_HTML)
+        return page
+
+    def _run_listing(self, scraper, page):
+        # PlaywrightOptions is only imported when USE_PLAYWRIGHT=true at import
+        # time, so under the test default (Selenium branch) the name is absent.
+        with (
+            patch("scrapers.misis_rescue.scraper.PlaywrightOptions", create=True),
+            self._patch_page_into(scraper, page),
+            patch.object(scraper, "_scroll_to_load_all_content_playwright", new=AsyncMock()),
+            patch.object(scraper, "_click_pagination_button_playwright", new=AsyncMock(return_value=False)),
+            patch("scrapers.misis_rescue.scraper.asyncio.sleep", new=AsyncMock()),
+            patch("scrapers.browser_manager.asyncio.sleep", new=AsyncMock()),
+        ):
+            return asyncio.run(scraper._get_all_dogs_from_listing_playwright())
+
+    def test_listing_navigation_recovers_from_transient_stall(self, scraper):
+        """One stalled goto must not cost the whole organization: the navigation
+        retries and the listing is still scraped."""
+        goto = AsyncMock(side_effect=[PlaywrightTimeoutError("Page.goto: Timeout 60000ms exceeded."), None])
+        page = self._make_page(goto)
+
+        dogs = self._run_listing(scraper, page)
+
+        assert goto.await_count == 2, "navigation must be retried after a transient stall"
+        assert [d["url"] for d in dogs] == ["/post/dog1"], "listing must still be scraped after the retry succeeds"
+
+    def test_listing_navigation_raises_when_retries_exhausted(self, scraper):
+        """When every attempt stalls the scraper must fail loudly. Returning []
+        here would re-introduce the misleading zero-dogs alert of #215."""
+        goto = AsyncMock(side_effect=PlaywrightTimeoutError("Page.goto: Timeout 60000ms exceeded."))
+        page = self._make_page(goto)
+
+        with pytest.raises(RuntimeError, match="available-for-adoption"):
+            self._run_listing(scraper, page)
+
+        assert goto.await_count == 3, "all retry attempts must be used before giving up"
+
+    def test_listing_navigation_does_not_wait_for_full_load_event(self, scraper):
+        """The page is a Wix site pulling ~250 subresources including third-party
+        tags (HubSpot, Sentry CDN); waiting on the full `load` event couples the
+        scrape to hosts we do not control. Dynamic content is handled by the
+        explicit scroll/sleep that follows, so `domcontentloaded` suffices."""
+        goto = AsyncMock(return_value=None)
+        page = self._make_page(goto)
+
+        self._run_listing(scraper, page)
+
+        assert goto.await_args.kwargs["wait_until"] == "domcontentloaded"
+
+    def _run_detail(self, scraper, page):
+        with (
+            patch("scrapers.misis_rescue.scraper.PlaywrightOptions", create=True),
+            self._patch_page_into(scraper, page),
+            patch("scrapers.misis_rescue.scraper.asyncio.sleep", new=AsyncMock()),
+            patch("scrapers.browser_manager.asyncio.sleep", new=AsyncMock()),
+        ):
+            return asyncio.run(scraper._scrape_dog_detail_playwright("https://www.misisrescue.com/post/dog1"))
+
+    def test_detail_navigation_retries_then_skips_only_that_dog(self, scraper):
+        """A detail page that stalls on every attempt must be retried and then
+        skipped (None) — losing one dog, not the whole organization. This is
+        deliberately different from the listing, which must raise."""
+        goto = AsyncMock(side_effect=PlaywrightTimeoutError("Page.goto: Timeout 60000ms exceeded."))
+        page = self._make_page(goto)
+
+        result = self._run_detail(scraper, page)
+
+        assert goto.await_count == 3, "detail navigation must be retried before giving up"
+        assert result is None, "an unreachable detail page must skip that dog, not raise"


### PR DESCRIPTION
## Problem

The scheduled run on Jul 13 failed with `"overall_success": false` — but 10 of 11 orgs succeeded. The whole batch was marked failed because **misisrescue** died on:

```
Page.goto: Timeout 60000ms exceeded.
  - navigating to "https://www.misisrescue.com/available-for-adoption", waiting until "load"
```

The site is **not** down — it serves HTTP 200 in ~0.5s, and neighbouring runs (Jul 11, 09, 06) were green. This is an **intermittent** stall, and both Playwright `goto` calls navigated **raw, with no retry**, so a single hiccup cost every dog from the org.

## Fix

Route both `goto` calls through `browser_manager.navigate_with_retry` (3 attempts, exponential backoff). That helper already existed but **had no callers** — this is reuse, not new machinery.

It also drops `wait_until` from `"load"` to the helper's `"domcontentloaded"` default. Measured with Chrome DevTools, the listing is a Wix page pulling **250 subresources** including third-party tags (HubSpot, Sentry CDN); `load` couples the scrape to hosts we don't control. Dynamic content is already handled by the explicit scroll/sleep that follows, so `load` was buying nothing.

## Failure semantics are deliberately different per call site

- **Listing** → raises on exhaustion. Returning `[]` would re-introduce the misleading zero-dogs alert fixed in #215/#216. `navigate_with_retry` returns `False` rather than raising, so the return is checked explicitly — dropping it in naively would have regressed that fix.
- **Detail page** → skips only that dog (existing `except → None`), preserving today's per-dog tolerance.

## Tests

Adds the **first unit coverage of the Playwright path**, which was previously untested at all: `PlaywrightOptions` is imported only when `USE_PLAYWRIGHT=true`, so tests silently exercised the Selenium branch while production ran Playwright. That gap is why this reached prod.

Tests drive the real `navigate_with_retry` (only its sleep is stubbed), so the integration is genuinely covered.

- `669 passed` across `tests/scrapers/`, ruff check + format clean.

## Also included

A docs commit correcting the cron schedule: docs claimed Tue/Thu/Sat 6am UTC in seven places, but Railway is configured for **Mon/Thu/Sat 15:00 UTC**.

> Note: next scheduled run is Thu Jul 16 15:00 UTC.