### PR TITLE
test(favorites): fix flaky FilterPanel debounce timeouts

### DIFF
--- a/frontend/src/components/favorites/FilterPanel.test.tsx
+++ b/frontend/src/components/favorites/FilterPanel.test.tsx
@@ -120,7 +120,7 @@ describe("FilterPanel Component", () => {
         () => {
           expect(onFilter).toHaveBeenCalled();
         },
-        { timeout: 400 },
+        { timeout: 2000 },
       );
 
       // Should filter with user-initiated flag
@@ -213,7 +213,7 @@ describe("FilterPanel Component", () => {
         () => {
           expect(onFilter).toHaveBeenCalled();
         },
-        { timeout: 400 },
+        { timeout: 2000 },
       );
 
       expect(onFilter).toHaveBeenLastCalledWith(
@@ -275,7 +275,7 @@ describe("FilterPanel Component", () => {
             onFilter.mock.calls[onFilter.mock.calls.length - 1][0];
           expect(lastCall).toHaveLength(3);
         },
-        { timeout: 400 },
+        { timeout: 2000 },
       );
 
       const lastCall = onFilter.mock.calls[onFilter.mock.calls.length - 1][0];
@@ -331,7 +331,7 @@ describe("FilterPanel Component", () => {
         () => {
           expect(onFilter).toHaveBeenCalled();
         },
-        { timeout: 400 },
+        { timeout: 2000 },
       );
 
       expect(onFilter).toHaveBeenLastCalledWith(
@@ -382,7 +382,7 @@ describe("FilterPanel Component", () => {
         () => {
           expect(onFilter).toHaveBeenCalled();
         },
-        { timeout: 400 },
+        { timeout: 2000 },
       );
 
       expect(onFilter).toHaveBeenLastCalledWith(
@@ -502,7 +502,7 @@ describe("FilterPanel Component", () => {
         () => {
           expect(onFilter).toHaveBeenCalled();
         },
-        { timeout: 400 },
+        { timeout: 2000 },
       );
 
       // Apply age filter
@@ -526,7 +526,7 @@ describe("FilterPanel Component", () => {
           }
           return false;
         },
-        { timeout: 400 },
+        { timeout: 2000 },
       );
 
       // Should only return Max (large size, 48 months = Adult)
@@ -564,7 +564,7 @@ describe("FilterPanel Component", () => {
         () => {
           expect(onFilter).toHaveBeenCalled();
         },
-        { timeout: 400 },
+        { timeout: 2000 },
       );
 
       // Clear button should appear


### PR DESCRIPTION
## Problem

Both open dependabot PRs (#277 setup-node, #281 postcss) fail CI on the identical test: `FilterPanel.test.tsx`. Neither dependency bump touches this test — it's pre-existing flakiness.

## Root cause

The component debounces filter values by 300ms. Eight `waitFor` calls in the test used `{ timeout: 400 }`, leaving only ~100ms of headroom over the debounce. Under CI load the 300ms timer plus render regularly exceeds 400ms, so `onFilter` hasn't fired yet when `waitFor` gives up.

## Fix

Widen all eight timeouts to 2000ms. Test-only change; passes reliably locally and unblocks both dependabot PRs once they rebase onto this.