### PR TITLE
ci: audit frontend dependencies and migrate uv to dependency-groups

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -144,3 +144,18 @@ jobs:
       - name: Check dependencies for vulnerabilities
         continue-on-error: true
         run: uv run pip-audit || echo "::warning::Security vulnerabilities found in dependencies"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "20"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
+
+      - name: Check frontend dependencies for vulnerabilities
+        continue-on-error: true
+        working-directory: ./frontend
+        run: pnpm audit || echo "::warning::Security vulnerabilities found in frontend dependencies"

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -152,12 +152,28 @@ jobs:
       - name: Check dependencies for vulnerabilities
         run: uv run pip-audit --output security-report.json --format json || echo "::warning::Security vulnerabilities found"
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "20"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
+
+      - name: Check frontend dependencies for vulnerabilities
+        working-directory: ./frontend
+        run: pnpm audit --json > ../frontend-security-report.json || echo "::warning::Security vulnerabilities found in frontend dependencies"
+
       - name: Upload security report
         uses: actions/upload-artifact@v7
         if: always()
         with:
           name: security-scan-results
-          path: security-report.json
+          path: |
+            security-report.json
+            frontend-security-report.json
 
   comprehensive-frontend-tests:
     name: Comprehensive Frontend

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "firecrawl-py>=4.35.0",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "pytest>=9.1.1",
     "pytest-asyncio>=1.4.0",
@@ -68,20 +68,6 @@ packages = ["api", "scrapers", "services", "utils", "database"]
 constraint-dependencies = [
     "PyJWT>=2.12.0",
     "Pygments>=2.20.0",
-]
-dev-dependencies = [
-    "pytest>=9.1.1",
-    "pytest-asyncio>=1.4.0",
-    "pytest-cov>=7.1.0",
-    "pytest-mock>=3.15.1",
-    "pytest-xdist>=3.8.0",
-    "ruff>=0.16.3",
-    "mypy>=2.2.0",
-    "types-requests>=2.33.0.20260712",
-    "ipython>=9.16.1",
-    "watchdog>=6.0.0",
-    "cryptography>=50.0.0",
-    "pip-audit>=2.10.1",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -1605,7 +1605,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -2387,22 +2387,6 @@ dependencies = [
     { name = "werkzeug" },
 ]
 
-[package.optional-dependencies]
-dev = [
-    { name = "cryptography" },
-    { name = "ipython" },
-    { name = "mypy" },
-    { name = "pip-audit" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "pytest-mock" },
-    { name = "pytest-xdist" },
-    { name = "ruff" },
-    { name = "types-requests" },
-    { name = "watchdog" },
-]
-
 [package.dev-dependencies]
 dev = [
     { name = "cryptography" },
@@ -2428,47 +2412,34 @@ requires-dist = [
     { name = "cachetools", specifier = ">=7.1.7" },
     { name = "click", specifier = ">=8.4.2" },
     { name = "colorama", specifier = ">=0.4.6" },
-    { name = "cryptography", marker = "extra == 'dev'", specifier = ">=50.0.0" },
     { name = "fastapi", specifier = ">=0.141.1" },
     { name = "firecrawl-py", specifier = ">=4.35.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "iniconfig", specifier = ">=2.3.0" },
-    { name = "ipython", marker = "extra == 'dev'", specifier = ">=9.16.1" },
     { name = "jsonschema", specifier = ">=4.26.0" },
     { name = "langdetect", specifier = "==1.0.9" },
     { name = "mcp", specifier = ">=2.0.0" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=2.2.0" },
     { name = "nest-asyncio", specifier = ">=1.6.0" },
     { name = "pillow", specifier = ">=12.3.0" },
-    { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.10.1" },
     { name = "playwright", specifier = ">=1.62.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.12" },
     { name = "pydantic", specifier = ">=2.13.4" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.1.1" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.4.0" },
     { name = "pytest-benchmark", specifier = ">=5.2.3" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0" },
-    { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.15.1" },
-    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.8.0" },
     { name = "python-dateutil", specifier = ">=2.9.0.post0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "requests", specifier = ">=2.34.2" },
     { name = "rich", specifier = ">=15.0.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.16.3" },
     { name = "selenium", specifier = ">=4.47.0" },
     { name = "sentry-sdk", extras = ["fastapi", "sqlalchemy"], specifier = ">=2.66.1" },
     { name = "sqlalchemy", specifier = ">=2.0.52,<3.0.0" },
     { name = "starlette", specifier = ">=1.6.0" },
     { name = "tenacity", specifier = ">=9.1.4" },
-    { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.33.0.20260712" },
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.52.3" },
-    { name = "watchdog", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "webdriver-manager", specifier = ">=4.1.2" },
     { name = "werkzeug", specifier = ">=3.1.8" },
 ]
-provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Both follow-ups recommended in #313.

## 1. Frontend dependency audit in CI

The backend has run `pip-audit` since the security jobs existed, but the frontend had **no vulnerability scan in CI at all**. That is the gap that let two high-severity brace-expansion advisories sit unnoticed until #313 — Dependabot had not raised them either, so nothing was watching.

`pnpm audit` is added alongside `pip-audit` in both security jobs:

| Workflow | Job | Behaviour |
| --- | --- | --- |
| `ci-pr.yml` | Security Check | warn-only |
| `pre-merge.yml` | Security Validation | warn-only, JSON report uploaded with the Python one |

Warn-only matches the existing `pip-audit` steps and the "Security scan → ⚠️ warn" row in the CI requirements table. `ci-push.yml` is deliberately untouched, since that table lists no security scan for commits.

**Verified it actually catches things.** Run against the pre-#313 lockfile, `pnpm audit` exits **1** and reports both brace-expansion advisories; against current `main` it exits **0**. So the step would have caught exactly what slipped through, rather than passing silently.

No install step is required — `pnpm audit` resolves from `pnpm-lock.yaml` alone, confirmed with only `package.json` and the lockfile present — so the job stays fast.

## 2. uv `dev-dependencies` → PEP 735 `[dependency-groups]`

uv warns that `tool.uv.dev-dependencies` is deprecated and slated for removal. It also duplicated `project.optional-dependencies.dev` **verbatim**, and nothing referenced that extra: every install path in the repo, the docs, and `nixpacks.toml` uses `uv sync`, never `.[dev]` or `--extra dev`. Both are consolidated into a single `[dependency-groups] dev`.

This was deferred in #313 because it touches the backend install path Railway deploys. That risk is now measured rather than assumed — uv enables the `dev` group by default and maps `--no-dev` onto it, so both paths are preserved:

| Install path | Command | Packages | Result |
| --- | --- | --- | --- |
| CI | `uv sync --frozen` | 424 | identical |
| Railway | `uv sync --frozen --no-dev` | 318 | identical, including environment markers |

Compared with `uv export --frozen` before and after. The only other lockfile change is a `sys_platform != 'win32'` marker on `ptyprocess`, which is dev-only and absent from the production path entirely.

## Verification

- `uv sync --frozen` and `uv sync --frozen --no-dev` both succeed
- uv deprecation warning gone
- `uv run ruff check .` all checks passed; `ruff format --check` 335 files already formatted
- `uv run pytest -m unit` — 785 passed, 1 skipped
- All three workflow files parse as valid YAML; step ordering confirmed
- `pnpm audit --json` writes a valid report for the artifact upload
