### PR TITLE
perf(cache): scope frontend cache invalidation to changed dogs

### DIFF
--- a/management/check_adoptions.py
+++ b/management/check_adoptions.py
@@ -25,6 +25,7 @@ from psycopg2.extras import RealDictCursor
 
 from services.adoption_detection import AdoptionCheckResult, AdoptionDetectionService
 from utils.config_loader import ConfigLoader
+from utils.slug_generator import fetch_slugs_by_ids
 
 load_dotenv()
 
@@ -45,6 +46,7 @@ class CheckAdoptionsCommand:
         self.cursor = None
         self.config_loader = ConfigLoader()
         self.adoption_service = AdoptionDetectionService()
+        self.changed_animal_ids: list[int] = []
 
     def connect(self):
         """Connect to the database."""
@@ -267,6 +269,15 @@ class CheckAdoptionsCommand:
             (result.detected_status, json.dumps(check_data), result.checked_at, dog_id),
         )
         self.conn.commit()
+        self.changed_animal_ids.append(dog_id)
+
+    def changed_slugs(self) -> list[str]:
+        """Detail-page cache tags for the dogs this run updated.
+
+        Lets the caller purge exactly those pages instead of the bare
+        ``"animal"`` tag, which fans out to every dog detail page.
+        """
+        return fetch_slugs_by_ids(self.conn, self.changed_animal_ids)
 
     def print_summary(self, org_name: str, results: list[AdoptionCheckResult]):
         """Print summary of adoption checks.
@@ -370,7 +381,7 @@ def main():
             if any_processed and not args.dry_run:
                 from services.revalidation_client import invalidate_sync
 
-                invalidate_sync(tags=["animals", "animal", "statistics"])
+                invalidate_sync(tags=["animals", "statistics", *command.changed_slugs()])
 
         print("\n✅ Adoption checking complete!")
 

--- a/scrapers/base_scraper.py
+++ b/scrapers/base_scraper.py
@@ -180,6 +180,9 @@ class BaseScraper(ABC):
         # Track animals for LLM enrichment
         self.animals_for_llm_enrichment = []
 
+        # Track animals changed this run, to scope frontend cache invalidation
+        self._changed_animal_ids: list[int] = []
+
         # Track completion state to prevent duplicates
         self._completion_logged = False
 
@@ -343,8 +346,45 @@ class BaseScraper(ABC):
         self.logger.info(f"Scrape completed with status: {status}, animals: {animals_found}")
         return True
 
+    def mark_animal_changed(self, animal_id: int) -> None:
+        """Record that an animal was added or updated in this run.
+
+        Drives scoped cache invalidation — only the detail pages for these
+        animals get purged on completion.
+        """
+        if animal_id not in self._changed_animal_ids:
+            self._changed_animal_ids.append(animal_id)
+
+    def _changed_animal_slug_tags(self) -> list[str]:
+        """Resolve changed animal IDs to per-page cache tags.
+
+        The frontend tags each dog-detail fetch ``["animal", slug]``, so one
+        slug tag purges exactly one page. Returns empty on any failure — the
+        aggregate listing tags still fire, and the stale detail pages expire
+        on their own ``revalidate`` window.
+        """
+        if not self._changed_animal_ids:
+            return []
+
+        if not self.database_service:
+            self._log_service_unavailable("DatabaseService", "cannot scope cache invalidation")
+            return []
+
+        try:
+            return self.database_service.get_slugs_for_animals(self._changed_animal_ids)
+        except Exception as e:
+            self.logger.warning("Could not resolve changed slugs for cache invalidation: %s", e)
+            return []
+
     def _invalidate_frontend_cache(self) -> None:
         """Fire cache invalidation for the Next.js frontend.
+
+        Sends the aggregate listing tags plus one tag per changed dog. It
+        deliberately does NOT send the bare ``animal``/``enhanced`` tags:
+        those are attached to every dog-detail fetch, so purging them
+        invalidates all ~1,300 detail pages at once. With 13 orgs scraping
+        3x/week that produced ~150 full-site purges per month and exceeded
+        the Vercel ISR write budget by 3.5x.
 
         Fire-and-forget. ``invalidate_sync`` already swallows network and
         HTTP errors internally, so the outer ``try`` only guards against
@@ -357,11 +397,12 @@ class BaseScraper(ABC):
             self.logger.warning("Cache invalidation hook unavailable: %s", e)
             return
 
+        slug_tags = self._changed_animal_slug_tags()
+        self._changed_animal_ids = []
+
         invalidate_sync(
             tags=[
                 "animals",
-                "animal",
-                "enhanced",
                 "statistics",
                 "country-stats",
                 "age-stats",
@@ -369,8 +410,10 @@ class BaseScraper(ABC):
                 "breed-stats",
                 "breed-images",
                 "organizations-enhanced",
+                *slug_tags,
             ]
         )
+        self.logger.info("Cache invalidation: listings + %d changed dog page(s)", len(slug_tags))
 
     def detect_language(self, text):
         """Detect the language of the text.
@@ -765,8 +808,10 @@ class BaseScraper(ABC):
                 # Update counts
                 if action == "added":
                     processing_stats["animals_added"] += 1
+                    self.mark_animal_changed(animal_id)
                 elif action == "updated":
                     processing_stats["animals_updated"] += 1
+                    self.mark_animal_changed(animal_id)
                 elif action == "no_change":
                     processing_stats["animals_unchanged"] += 1
 

--- a/services/database_service.py
+++ b/services/database_service.py
@@ -29,6 +29,7 @@ from services.animal_data_preparation import (
     update_to_final_slug,
 )
 from utils.optimized_standardization import parse_age_text, standardize_size_value
+from utils.slug_generator import fetch_slugs_by_ids
 from utils.standardization import standardize_breed
 
 
@@ -568,6 +569,29 @@ class DatabaseService:
         except Exception as e:
             self.logger.error(f"Error getting existing animal URLs: {e}")
             return set()
+
+    def get_slugs_for_animals(self, animal_ids: list[int]) -> list[str]:
+        """Resolve animal IDs to their detail-page slugs in one round trip.
+
+        Backs scoped frontend cache invalidation: a scrape tracks the animal
+        IDs it changed, but the Next.js detail pages are cache-tagged by slug.
+
+        Args:
+            animal_ids: Animal IDs to resolve
+
+        Returns:
+            Slugs for the given IDs, skipping any animal without one. Empty on
+            failure — cache invalidation is best-effort and must never raise.
+        """
+        if not animal_ids:
+            return []
+
+        if not self.conn:
+            if not self.connect():
+                self.logger.error("No database connection available")
+                return []
+
+        return fetch_slugs_by_ids(self.conn, animal_ids)
 
     def _detect_animal_changes(
         self,

--- a/services/llm/database_updater.py
+++ b/services/llm/database_updater.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, Optional
 import psycopg2
 
 from config import get_database_config
+from utils.slug_generator import fetch_slugs_by_ids
 
 if TYPE_CHECKING:
     from services.connection_pool import ConnectionPoolService
@@ -74,6 +75,28 @@ class DatabaseUpdater:
         except Exception as e:
             logger.error(f"Failed to save results: {e}")
             return False
+
+    def get_slugs(self, animal_ids: list[int]) -> list[str]:
+        """Resolve animal IDs to their detail-page slugs.
+
+        Args:
+            animal_ids: Animal IDs to resolve
+
+        Returns:
+            Slugs for the given IDs, empty on failure.
+        """
+        if not animal_ids:
+            return []
+
+        if self.connection_pool:
+            with self.connection_pool.get_connection_context() as conn:
+                return fetch_slugs_by_ids(conn, animal_ids)
+
+        conn = psycopg2.connect(**get_database_config())
+        try:
+            return fetch_slugs_by_ids(conn, animal_ids)
+        finally:
+            conn.close()
 
     def _save_with_connection(self, conn, results: list[dict[str, Any]]) -> None:
         """

--- a/services/llm/dog_profiler.py
+++ b/services/llm/dog_profiler.py
@@ -305,11 +305,32 @@ class DogProfilerPipeline:
             True if successful
         """
         saved = await self.database_updater.save_results(results)
-        if saved:
-            from services.revalidation_client import invalidate
+        if not saved:
+            return False
 
-            await invalidate(tags=["animals", "animal", "enhanced"])
-        return saved
+        from services.revalidation_client import invalidate
+
+        await invalidate(tags=["animals", *self._profiled_slug_tags(results)])
+        return True
+
+    def _profiled_slug_tags(self, results: list[dict[str, Any]]) -> list[str]:
+        """Resolve profiled dogs to per-page cache tags.
+
+        Deliberately avoids the bare ``animal``/``enhanced`` tags: those are
+        attached to every dog-detail fetch, so purging them regenerates all
+        ~1,300 detail pages for the sake of a handful of profiled dogs.
+        Returns empty on failure — the listing tags still fire and stale
+        detail pages expire on their own ``revalidate`` window.
+        """
+        dog_ids = [result["dog_id"] for result in results if result.get("dog_id")]
+        if not dog_ids:
+            return []
+
+        try:
+            return self.database_updater.get_slugs(dog_ids)
+        except Exception as e:
+            logger.warning(f"Could not resolve profiled slugs for cache invalidation: {e}")
+            return []
 
     # Context manager support
     async def __aenter__(self):

--- a/tests/management/test_check_adoptions.py
+++ b/tests/management/test_check_adoptions.py
@@ -481,3 +481,67 @@ class TestMainFunction:
                         raise
 
                 mock_command.check_organization.assert_called_with({"slug": "dogstrust"}, 10)
+
+
+@pytest.mark.unit
+class TestScopedCacheInvalidation:
+    """Adoption checks purge only the detail pages they changed.
+
+    The frontend tags every dog-detail fetch ``["animal", slug]``, so purging
+    the bare ``"animal"`` tag invalidates all ~1,300 dog pages for the sake of
+    the handful of dogs whose status actually moved.
+    """
+
+    def _result(self, animal_id: int) -> AdoptionCheckResult:
+        return AdoptionCheckResult(
+            animal_id=animal_id,
+            animal_name="Max",
+            previous_status="available",
+            detected_status="adopted",
+            evidence="Page shows REHOMED",
+            confidence=0.95,
+            checked_at=datetime.now(UTC),
+            raw_response={"markdown": "test"},
+            error=None,
+        )
+
+    def test_tracks_each_updated_dog(self, mock_db_connection):
+        mock_conn, mock_cursor = mock_db_connection
+        command = CheckAdoptionsCommand(dry_run=False)
+        command.conn = mock_conn
+        command.cursor = mock_cursor
+
+        command.update_dog_status(1, self._result(1))
+        command.update_dog_status(2, self._result(2))
+
+        assert command.changed_animal_ids == [1, 2]
+
+    def test_dry_run_tracks_nothing(self, mock_db_connection):
+        mock_conn, mock_cursor = mock_db_connection
+        command = CheckAdoptionsCommand(dry_run=True)
+        command.conn = mock_conn
+        command.cursor = mock_cursor
+
+        command.update_dog_status(1, self._result(1))
+
+        assert command.changed_animal_ids == []
+
+    def test_changed_slugs_resolves_tracked_ids(self, mock_db_connection):
+        mock_conn, mock_cursor = mock_db_connection
+        command = CheckAdoptionsCommand(dry_run=False)
+        command.conn = mock_conn
+        command.cursor = mock_cursor
+        command.update_dog_status(1, self._result(1))
+
+        with patch("management.check_adoptions.fetch_slugs_by_ids", return_value=["max-lab-1"]) as mock_fetch:
+            assert command.changed_slugs() == ["max-lab-1"]
+
+        mock_fetch.assert_called_once_with(mock_conn, [1])
+
+    def test_changed_slugs_empty_when_nothing_updated(self, mock_db_connection):
+        mock_conn, mock_cursor = mock_db_connection
+        command = CheckAdoptionsCommand(dry_run=False)
+        command.conn = mock_conn
+        command.cursor = mock_cursor
+
+        assert command.changed_slugs() == []

--- a/tests/scrapers/test_base_scraper_cache_invalidation.py
+++ b/tests/scrapers/test_base_scraper_cache_invalidation.py
@@ -1,9 +1,18 @@
-"""Test cache invalidation gating on scrape completion status.
+"""Test cache invalidation gating and scoping on scrape completion.
 
-Failed and partial-failure scrapes must NOT invalidate the frontend cache —
-otherwise a Playwright timeout that produces a stale/empty result would
-trigger a refresh that replaces good data with bad. Only ``status="success"``
-should fire the invalidation hook.
+Two independent concerns are covered here:
+
+1. **Gating** — failed and partial-failure scrapes must NOT invalidate the
+   frontend cache. A Playwright timeout that produces a stale/empty result
+   would otherwise trigger a refresh that replaces good data with bad. Only
+   ``status="success"`` fires the invalidation hook.
+
+2. **Scoping** — a scrape must only invalidate the detail pages it actually
+   changed. The frontend tags every dog-detail fetch ``["animal", slug]``,
+   so purging the bare ``"animal"`` tag invalidates all ~1,300 dog pages at
+   once. With 13 orgs scraping 3x/week that produced ~150 full-site cache
+   purges per month and blew the Vercel ISR write budget by 3.5x. Instead we
+   purge the aggregate listing tags plus one per-slug tag per changed dog.
 """
 
 from unittest.mock import Mock, patch
@@ -12,6 +21,22 @@ import pytest
 
 from scrapers.base_scraper import BaseScraper
 from services.database_service import DatabaseService
+
+# Tags that must always fire — these back the listing/aggregate pages, which
+# genuinely do change whenever any dog in any org is added, updated or removed.
+AGGREGATE_TAGS = {
+    "animals",
+    "statistics",
+    "country-stats",
+    "age-stats",
+    "filter-counts",
+    "breed-stats",
+    "breed-images",
+    "organizations-enhanced",
+}
+
+# Tags that must NEVER fire — each of these fans out to every dog detail page.
+FANOUT_TAGS = {"animal", "enhanced"}
 
 
 class _StubScraper(BaseScraper):
@@ -22,10 +47,16 @@ class _StubScraper(BaseScraper):
 
 
 @pytest.fixture
-def scraper():
-    """Build a scraper with a mocked DB service so completion logging is a no-op."""
+def mock_db():
+    """DB service whose completion logging is a no-op and slug lookup is empty."""
     mock_db = Mock(spec=DatabaseService)
     mock_db.complete_scrape_log.return_value = True
+    mock_db.get_slugs_for_animals.return_value = []
+    return mock_db
+
+
+@pytest.fixture
+def scraper(mock_db):
     return _StubScraper(organization_id=1, database_service=mock_db)
 
 
@@ -36,6 +67,10 @@ def mock_invalidate_sync():
         yield mock
 
 
+def _tags_from(mock_invalidate_sync) -> list[str]:
+    return mock_invalidate_sync.call_args.kwargs["tags"]
+
+
 @pytest.mark.unit
 class TestCompleteScrapeLogCacheInvalidation:
     """``complete_scrape_log`` fires cache invalidation only on success."""
@@ -43,11 +78,7 @@ class TestCompleteScrapeLogCacheInvalidation:
     def test_fires_on_success(self, scraper, mock_invalidate_sync):
         scraper.complete_scrape_log(status="success", animals_found=10)
         mock_invalidate_sync.assert_called_once()
-        # Expect the bulk tag set so all consumer pages refresh
-        kwargs = mock_invalidate_sync.call_args.kwargs
-        assert "animals" in kwargs["tags"]
-        assert "animal" in kwargs["tags"]
-        assert "statistics" in kwargs["tags"]
+        assert AGGREGATE_TAGS.issubset(set(_tags_from(mock_invalidate_sync)))
 
     def test_skips_on_warning(self, scraper, mock_invalidate_sync):
         scraper.complete_scrape_log(status="warning", animals_found=0)
@@ -78,3 +109,66 @@ class TestCompleteScrapeLogWithMetricsCacheInvalidation:
     def test_skips_on_error(self, scraper, mock_invalidate_sync):
         scraper.complete_scrape_log_with_metrics(status="error")
         mock_invalidate_sync.assert_not_called()
+
+
+@pytest.mark.unit
+class TestInvalidationIsScopedToChangedDogs:
+    """Detail-page tags are per-slug; the fan-out tags must never be sent."""
+
+    def test_never_sends_fanout_tags(self, scraper, mock_invalidate_sync):
+        """The whole point of the change: "animal"/"enhanced" purge ~1,300 pages."""
+        scraper.complete_scrape_log(status="success", animals_found=10)
+        sent = set(_tags_from(mock_invalidate_sync))
+        assert not (sent & FANOUT_TAGS), f"fan-out tags leaked into invalidation: {sent & FANOUT_TAGS}"
+
+    def test_sends_slug_tag_for_each_changed_dog(self, scraper, mock_db, mock_invalidate_sync):
+        scraper.mark_animal_changed(101)
+        scraper.mark_animal_changed(102)
+        mock_db.get_slugs_for_animals.return_value = ["rex-terrier-101", "bella-lab-102"]
+
+        scraper.complete_scrape_log(status="success", animals_found=2)
+
+        mock_db.get_slugs_for_animals.assert_called_once_with([101, 102])
+        sent = set(_tags_from(mock_invalidate_sync))
+        assert "rex-terrier-101" in sent
+        assert "bella-lab-102" in sent
+        assert AGGREGATE_TAGS.issubset(sent)
+
+    def test_no_changed_dogs_sends_only_aggregate_tags(self, scraper, mock_db, mock_invalidate_sync):
+        """A scrape where nothing changed must not purge any detail page."""
+        scraper.complete_scrape_log(status="success", animals_found=50)
+
+        mock_db.get_slugs_for_animals.assert_not_called()
+        assert set(_tags_from(mock_invalidate_sync)) == AGGREGATE_TAGS
+
+    def test_deduplicates_repeated_animal_ids(self, scraper, mock_db, mock_invalidate_sync):
+        """An animal touched twice in one run must be requested once."""
+        scraper.mark_animal_changed(101)
+        scraper.mark_animal_changed(101)
+        mock_db.get_slugs_for_animals.return_value = ["rex-terrier-101"]
+
+        scraper.complete_scrape_log(status="success", animals_found=1)
+
+        mock_db.get_slugs_for_animals.assert_called_once_with([101])
+
+    def test_slug_lookup_failure_still_invalidates_listings(self, scraper, mock_db, mock_invalidate_sync):
+        """A broken slug lookup must not cost us the listing refresh."""
+        scraper.mark_animal_changed(101)
+        mock_db.get_slugs_for_animals.side_effect = RuntimeError("connection lost")
+
+        scraper.complete_scrape_log(status="success", animals_found=1)
+
+        mock_invalidate_sync.assert_called_once()
+        assert set(_tags_from(mock_invalidate_sync)) == AGGREGATE_TAGS
+
+    def test_changed_ids_reset_between_runs(self, scraper, mock_db, mock_invalidate_sync):
+        """Completion clears the buffer so a reused scraper can't re-purge."""
+        scraper.mark_animal_changed(101)
+        mock_db.get_slugs_for_animals.return_value = ["rex-terrier-101"]
+        scraper.complete_scrape_log(status="success", animals_found=1)
+
+        scraper._completion_logged = False
+        mock_db.get_slugs_for_animals.reset_mock()
+        scraper.complete_scrape_log(status="success", animals_found=1)
+
+        mock_db.get_slugs_for_animals.assert_not_called()

--- a/tests/services/llm/test_dog_profiler_cache_invalidation.py
+++ b/tests/services/llm/test_dog_profiler_cache_invalidation.py
@@ -1,0 +1,81 @@
+"""Test that LLM profiling scopes its frontend cache invalidation.
+
+The frontend tags every dog-detail fetch ``["animal", slug]`` and every
+enhanced-detail fetch ``["enhanced", ...]``. Purging those bare tags
+invalidates all ~1,300 dog detail pages, so a profiling batch that touched
+20 dogs used to cost a full-site ISR regeneration. Profiling must purge
+only the pages for the dogs it actually profiled.
+"""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+FANOUT_TAGS = {"animal", "enhanced"}
+
+
+@pytest.fixture
+def profiler():
+    """DogProfiler with its DB layer stubbed out."""
+    from services.llm.dog_profiler import DogProfilerPipeline
+
+    pipeline = DogProfilerPipeline.__new__(DogProfilerPipeline)
+    pipeline.database_updater = Mock()
+    pipeline.database_updater.save_results = AsyncMock(return_value=True)
+    pipeline.database_updater.get_slugs = Mock(return_value=[])
+    return pipeline
+
+
+@pytest.fixture
+def mock_invalidate():
+    with patch("services.revalidation_client.invalidate", new_callable=AsyncMock) as mock:
+        yield mock
+
+
+def _tags_from(mock_invalidate) -> list[str]:
+    return mock_invalidate.await_args.kwargs["tags"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestDogProfilerCacheInvalidation:
+    async def test_never_sends_fanout_tags(self, profiler, mock_invalidate):
+        profiler.database_updater.get_slugs.return_value = ["rex-terrier-101"]
+
+        await profiler.save_results([{"dog_id": 101}])
+
+        assert not (set(_tags_from(mock_invalidate)) & FANOUT_TAGS)
+
+    async def test_sends_slug_tag_per_profiled_dog(self, profiler, mock_invalidate):
+        profiler.database_updater.get_slugs.return_value = [
+            "rex-terrier-101",
+            "bella-lab-102",
+        ]
+
+        await profiler.save_results([{"dog_id": 101}, {"dog_id": 102}])
+
+        profiler.database_updater.get_slugs.assert_called_once_with([101, 102])
+        sent = set(_tags_from(mock_invalidate))
+        assert {"rex-terrier-101", "bella-lab-102"}.issubset(sent)
+        assert "animals" in sent
+
+    async def test_skips_results_without_a_dog_id(self, profiler, mock_invalidate):
+        await profiler.save_results([{"dog_id": 101}, {"description": "no id"}])
+
+        profiler.database_updater.get_slugs.assert_called_once_with([101])
+
+    async def test_does_not_invalidate_when_save_failed(self, profiler, mock_invalidate):
+        profiler.database_updater.save_results = AsyncMock(return_value=False)
+
+        result = await profiler.save_results([{"dog_id": 101}])
+
+        assert result is False
+        mock_invalidate.assert_not_awaited()
+
+    async def test_slug_lookup_failure_still_invalidates_listings(self, profiler, mock_invalidate):
+        profiler.database_updater.get_slugs.side_effect = RuntimeError("connection lost")
+
+        await profiler.save_results([{"dog_id": 101}])
+
+        mock_invalidate.assert_awaited_once()
+        assert _tags_from(mock_invalidate) == ["animals"]

--- a/tests/services/test_database_service_slug_lookup.py
+++ b/tests/services/test_database_service_slug_lookup.py
@@ -1,0 +1,95 @@
+"""Tests for DatabaseService.get_slugs_for_animals.
+
+Backs scoped frontend cache invalidation: a scrape knows which animal *ids*
+it changed, but the Next.js detail pages are cache-tagged by *slug*. This
+resolves ids to slugs in one round trip so the scraper can purge exactly the
+pages it touched instead of the bare "animal" tag, which fans out to every
+dog detail page on the site.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from services.database_service import DatabaseService
+
+
+@pytest.fixture
+def db_config():
+    return {
+        "host": "localhost",
+        "user": "test_user",
+        "database": "test_db",
+        "password": "test_pass",
+    }
+
+
+@pytest.fixture
+def service_with_cursor(db_config):
+    """DatabaseService with a mocked live connection; yields (service, cursor)."""
+    service = DatabaseService(db_config, logger=Mock())
+    mock_conn = Mock()
+    mock_cursor = Mock()
+    mock_conn.cursor.return_value = mock_cursor
+    service.conn = mock_conn
+    return service, mock_cursor
+
+
+@pytest.mark.unit
+class TestGetSlugsForAnimals:
+    def test_returns_slugs_for_given_ids(self, service_with_cursor):
+        service, cursor = service_with_cursor
+        cursor.fetchall.return_value = [("rex-terrier-101",), ("bella-lab-102",)]
+
+        result = service.get_slugs_for_animals([101, 102])
+
+        assert result == ["rex-terrier-101", "bella-lab-102"]
+
+    def test_queries_with_a_single_round_trip(self, service_with_cursor):
+        """One ANY(%s) query, not one SELECT per animal."""
+        service, cursor = service_with_cursor
+        cursor.fetchall.return_value = [("rex-terrier-101",)]
+
+        service.get_slugs_for_animals([101, 102, 103])
+
+        cursor.execute.assert_called_once()
+        sql, params = cursor.execute.call_args[0]
+        assert "ANY" in sql.upper()
+        assert params == ([101, 102, 103],)
+
+    def test_empty_input_skips_the_query(self, service_with_cursor):
+        service, cursor = service_with_cursor
+
+        result = service.get_slugs_for_animals([])
+
+        assert result == []
+        cursor.execute.assert_not_called()
+
+    def test_drops_null_slugs(self, service_with_cursor):
+        """An animal mid-way through two-phase slug assignment has no slug yet."""
+        service, cursor = service_with_cursor
+        cursor.fetchall.return_value = [("rex-terrier-101",), (None,)]
+
+        assert service.get_slugs_for_animals([101, 102]) == ["rex-terrier-101"]
+
+    def test_closes_the_cursor(self, service_with_cursor):
+        service, cursor = service_with_cursor
+        cursor.fetchall.return_value = []
+
+        service.get_slugs_for_animals([101])
+
+        cursor.close.assert_called_once()
+
+    def test_returns_empty_on_query_error(self, service_with_cursor):
+        """Cache invalidation is best-effort; a failed lookup must not raise."""
+        service, cursor = service_with_cursor
+        cursor.execute.side_effect = Exception("connection lost")
+
+        assert service.get_slugs_for_animals([101]) == []
+
+    def test_returns_empty_when_no_connection_available(self, db_config):
+        service = DatabaseService(db_config, logger=Mock())
+        service.conn = None
+        service.connect = Mock(return_value=False)
+
+        assert service.get_slugs_for_animals([101]) == []

--- a/utils/slug_generator.py
+++ b/utils/slug_generator.py
@@ -89,6 +89,40 @@ def generate_animal_slug(
     return slug
 
 
+def fetch_slugs_by_ids(connection, animal_ids: list[int]) -> list[str]:
+    """
+    Look up detail-page slugs for a set of animal IDs in one round trip.
+
+    Backs scoped frontend cache invalidation: callers track the animal IDs
+    they changed, but the Next.js detail pages are cache-tagged by slug.
+
+    Args:
+        connection: Database connection
+        animal_ids: Animal IDs to resolve
+
+    Returns:
+        Slugs for the given IDs, skipping any animal without one. Empty on
+        failure — cache invalidation is best-effort and must never raise.
+    """
+    if not animal_ids:
+        return []
+
+    if not connection:
+        logger.warning("No database connection provided for slug lookup")
+        return []
+
+    try:
+        cursor = connection.cursor()
+        cursor.execute("SELECT slug FROM animals WHERE id = ANY(%s)", (animal_ids,))
+        results = cursor.fetchall()
+        cursor.close()
+
+        return [row[0] for row in results if row[0]]
+    except Exception as e:
+        logger.error(f"Error fetching slugs by ids: {e}")
+        return []
+
+
 def ensure_unique_slug(base_slug: str, connection, exclude_id: int | None = None) -> str:
     """
     Ensure slug is unique by checking database and adding suffix if needed.


### PR DESCRIPTION
## Problem

The project is over its Vercel Hobby limits on three resources:

| Resource | Usage | Limit | |
|---|---|---|---|
| **ISR Writes** | 706K | 200K | **3.5× over** |
| **Fluid Active CPU** | 5h33m | 4h | 1.4× over |
| **Fast Origin Transfer** | 12.37 GB | 10 GB | 1.24× over |

_(Jul 20 – Aug 19)_

The diagnostic signal is that **ISR Writes (706K) ≈ ISR Reads (698K)**. A healthy ISR cache writes once and reads many times; a 1:1 ratio means nearly every read is a miss that triggers a regeneration.

## Root cause

`serverAnimalsService.ts:926` tags every dog-detail fetch `["animal", slug]`. `base_scraper.py` purged the bare `"animal"` tag, which fans out to **all ~1,300 dog detail pages**. That purge fired **once per organization** (`complete_scrape_log` / `complete_scrape_log_with_metrics`), so each cron day triggered 13 full-site purges.

The arithmetic matches the observed number closely:

```
1,343 dog pages × ~3.5 write units   ≈ 4,700 units per full purge cycle
706K ÷ 4,700                         ≈ 150 purge cycles / month
actual: 13 cron days × 12 orgs       = 156 purges / month
```

## Change

Scrapers, LLM profiling, and adoption checks now track the animal IDs they changed, resolve them to slugs in one `id = ANY(%s)` query, and purge **one tag per changed page** alongside the aggregate listing tags. `"animal"` and `"enhanced"` are no longer sent by anything.

- `utils/slug_generator.py` — new shared `fetch_slugs_by_ids(connection, ids)`
- `scrapers/base_scraper.py` — `mark_animal_changed()` on add/update; scoped `_invalidate_frontend_cache()`
- `services/llm/dog_profiler.py` + `database_updater.py` — same for profiling batches
- `management/check_adoptions.py` — same for adoption status changes

Slug lookup is best-effort. On failure the aggregate listing tags still fire and stale detail pages expire on their own `revalidate` window, so a broken lookup degrades freshness rather than breaking the run.

## Deliberately not changed

`revalidateTag(tag, "max")` in `src/app/api/revalidate/route.ts` stays as-is. I had originally planned to drop the `"max"` profile, but per the Next.js docs `"max"` gives stale-while-revalidate, whereas **omitting** the profile is deprecated and forces immediate expiry with a *blocking* cache miss — strictly worse for both ISR writes and latency.

## Deferred

Batching invalidation across all 13 orgs into a single call at the end of the cron run is **not** in this PR. Per-slug scoping alone should bring writes well under budget; batching adds coupling between the runner and the scrapers for an estimated further ~50K units. Worth revisiting in Phase 2 once the post-fix number is visible on the usage graph.

## Testing

TDD — tests written first and confirmed failing before implementation.

- 45 targeted tests across 4 files, including explicit assertions that the fan-out tags never leak
- Full backend tier: **1509 passed, 4 skipped**
- `ruff check` / `ruff format` clean

## Verification after merge

Watch the usage graph across a Mon/Thu/Sat cycle — the ISR write spikes on cron days should flatten, and writes should drop well below reads.