### PR TITLE
perf(frontend): make /dogs statically cacheable

### DIFF
--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,61 +1,30 @@
 # Robots.txt for Rescue Dog Aggregator
+#
+# NOTE ON STRUCTURE: a crawler obeys exactly ONE user-agent group — the most
+# specific one matching its name — and ignores every other group, including
+# "*". Named agents are therefore grouped together so they share one rule set;
+# splitting them into per-agent groups would silently exempt each named
+# crawler from the Disallow rules below.
 
-# === SEARCH ENGINES - Full Access ===
+# === SEARCH ENGINES, SOCIAL PREVIEWS, AI CRAWLERS, AND EVERYONE ELSE ===
+# Full access apart from the sensitive and low-value paths listed below.
 User-agent: Googlebot
-Allow: /
-
 User-agent: Googlebot-Image
-Allow: /
-
 User-agent: Bingbot
-Allow: /
-
 User-agent: DuckDuckBot
-Allow: /
-
 User-agent: Slurp
-Allow: /
-
-# === SOCIAL MEDIA - Full Access for Link Previews ===
 User-agent: facebookexternalhit
-Allow: /
-
 User-agent: Twitterbot
-Allow: /
-
 User-agent: LinkedInBot
-Allow: /
-
 User-agent: WhatsApp
-Allow: /
-
 User-agent: Pinterest
-Allow: /
-
-# === AI & LLM CRAWLERS - Full Access ===
 User-agent: GPTBot
-Allow: /
-
 User-agent: ChatGPT-User
-Allow: /
-
 User-agent: anthropic-ai
-Allow: /
-
 User-agent: Claude-Web
-Allow: /
-
 User-agent: PerplexityBot
-Allow: /
-
 User-agent: CCBot
-Allow: /
-
 User-agent: Google-Extended
-Allow: /
-
-# === ALL OTHER LEGITIMATE CRAWLERS ===
-# Allow everything by default, only block sensitive paths
 User-agent: *
 Allow: /
 
@@ -70,6 +39,13 @@ Disallow: /_next/data/
 Disallow: /.git/
 Disallow: /config/
 Disallow: /private/
+
+# Filter and tracking permutations are not distinct content — the canonical
+# for the listing is https://www.rescuedogs.me/dogs and filtered views render
+# client-side, so crawling every combination multiplies requests without
+# adding anything indexable. Clean /dogs and /dogs/<slug> URLs stay crawlable.
+Disallow: /dogs?*
+Disallow: /dogs/*?*
 
 # === AGGRESSIVE BOTS - Block with Rate Limit ===
 User-agent: AhrefsBot

--- a/frontend/src/__tests__/robots/robots.test.js
+++ b/frontend/src/__tests__/robots/robots.test.js
@@ -166,3 +166,97 @@ describe("Static Robots.txt File", () => {
     });
   });
 });
+
+/**
+ * Query-string crawl control.
+ *
+ * /dogs reads no searchParams server-side, so every filter/tracking
+ * permutation renders the same page. Letting crawlers walk those
+ * combinations multiplied Vercel edge requests and CPU without producing
+ * anything indexable.
+ *
+ * The subtlety these tests guard: a crawler obeys exactly ONE user-agent
+ * group. If Googlebot or GPTBot get their own group containing only
+ * "Allow: /", they never see the Disallow rules at all.
+ */
+describe("Robots.txt query-string crawl control", () => {
+  let robotsTxtContent;
+
+  beforeAll(() => {
+    const robotsTxtPath = path.join(__dirname, "../../../public/robots.txt");
+    robotsTxtContent = fs.readFileSync(robotsTxtPath, "utf8");
+  });
+
+  /** Rules that apply to a given crawler: its own group, else the "*" group. */
+  const rulesFor = (content, agent) => {
+    const groups = [];
+    let current = null;
+    let expectingAgents = false;
+
+    for (const raw of content.split("\n")) {
+      const line = raw.trim();
+      if (!line || line.startsWith("#")) continue;
+
+      const [rawKey, ...rest] = line.split(":");
+      const key = rawKey.trim().toLowerCase();
+      const value = rest.join(":").trim();
+
+      if (key === "user-agent") {
+        if (!expectingAgents) {
+          current = { agents: [], rules: [] };
+          groups.push(current);
+          expectingAgents = true;
+        }
+        current.agents.push(value.toLowerCase());
+        continue;
+      }
+
+      if (key === "allow" || key === "disallow") {
+        expectingAgents = false;
+        if (current) current.rules.push(`${key}:${value}`);
+      }
+    }
+
+    const named = groups.find((g) => g.agents.includes(agent.toLowerCase()));
+    const wildcard = groups.find((g) => g.agents.includes("*"));
+    return (named ?? wildcard)?.rules ?? [];
+  };
+
+  const CRAWLERS = [
+    "Googlebot",
+    "Bingbot",
+    "GPTBot",
+    "PerplexityBot",
+    "ChatGPT-User",
+    "anthropic-ai",
+    "CCBot",
+    "SomeUnknownBot",
+  ];
+
+  test.each(CRAWLERS)("%s is told not to crawl /dogs query permutations", (agent) => {
+    const rules = rulesFor(robotsTxtContent, agent);
+    expect(rules).toContain("disallow:/dogs?*");
+  });
+
+  test.each(CRAWLERS)("%s still has the sensitive-path blocks", (agent) => {
+    const rules = rulesFor(robotsTxtContent, agent);
+    expect(rules).toContain("disallow:/admin/");
+    expect(rules).toContain("disallow:/api/internal/");
+  });
+
+  test.each(CRAWLERS)("%s can still crawl the site root", (agent) => {
+    expect(rulesFor(robotsTxtContent, agent)).toContain("allow:/");
+  });
+
+  test("aggressive bots stay fully blocked", () => {
+    expect(rulesFor(robotsTxtContent, "AhrefsBot")).toContain("disallow:/");
+    expect(rulesFor(robotsTxtContent, "SemrushBot")).toContain("disallow:/");
+    expect(rulesFor(robotsTxtContent, "MJ12bot")).toContain("disallow:/");
+  });
+
+  test("clean listing and detail URLs are not disallowed", () => {
+    const rules = rulesFor(robotsTxtContent, "Googlebot");
+    expect(rules).not.toContain("disallow:/dogs");
+    expect(rules).not.toContain("disallow:/dogs/");
+  });
+});

--- a/frontend/src/app/dogs/__tests__/page.cacheable.test.jsx
+++ b/frontend/src/app/dogs/__tests__/page.cacheable.test.jsx
@@ -1,0 +1,125 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import DogsPage, { revalidate } from "../page";
+import {
+  getAnimals,
+  getAllMetadata,
+} from "../../../services/serverAnimalsService";
+
+/**
+ * /dogs must render identically for every request so the CDN can cache it.
+ *
+ * Reading searchParams opts an App Router page into dynamic rendering, which
+ * made /dogs return `cache-control: no-store` and MISS on every hit — every
+ * bot request re-rendered the page and re-queried the backend. That drove the
+ * Fluid Active CPU and Fast Origin Transfer overages on Vercel.
+ *
+ * Dropping the server-side filter read is safe because the client already
+ * discards `initialDogs` whenever the URL carries filters
+ * (useDogsPagination.ts) and reads every filter value straight from
+ * useSearchParams (useDogsFilters.ts). The server fetch for a filtered URL
+ * was work the client threw away.
+ */
+
+jest.mock("../../../services/serverAnimalsService", () => ({
+  getAnimals: jest.fn(),
+  getAllMetadata: jest.fn(),
+}));
+
+jest.mock("../../../components/layout/Layout", () => {
+  return function MockLayout({ children }) {
+    return <div data-testid="layout">{children}</div>;
+  };
+});
+
+jest.mock("../DogsPageClientSimplified", () => {
+  return function MockDogsPageClient({ initialDogs, initialParams }) {
+    return (
+      <div data-testid="dogs-client">
+        <span data-testid="initial-dogs-count">{initialDogs?.length ?? 0}</span>
+        <span data-testid="initial-params">{JSON.stringify(initialParams)}</span>
+      </div>
+    );
+  };
+});
+
+const FILTERLESS_QUERY = { limit: 20, offset: 0 };
+
+describe("DogsPage is cacheable", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getAnimals.mockResolvedValue([{ id: 1, name: "Rex", slug: "rex-1" }]);
+    getAllMetadata.mockResolvedValue({ organizations: [] });
+  });
+
+  it("fetches the unfiltered first page when no params are present", async () => {
+    render(await DogsPage({ searchParams: Promise.resolve({}) }));
+
+    await waitFor(() => expect(getAnimals).toHaveBeenCalledTimes(1));
+    expect(getAnimals).toHaveBeenCalledWith(FILTERLESS_QUERY);
+  });
+
+  it("issues the identical query when the URL carries filters", async () => {
+    render(
+      await DogsPage({
+        searchParams: Promise.resolve({
+          breed: "Labrador",
+          size: "Small",
+          age: "puppy",
+          sex: "Male",
+          search: "friendly",
+          organization_id: "7",
+          breed_group: "Sporting",
+          location_country: "UK",
+          available_country: "DE",
+          available_region: "Bavaria",
+        }),
+      }),
+    );
+
+    await waitFor(() => expect(getAnimals).toHaveBeenCalledTimes(1));
+    expect(getAnimals).toHaveBeenCalledWith(FILTERLESS_QUERY);
+  });
+
+  it("issues the identical query for arbitrary tracking params", async () => {
+    // utm_*/fbclid/bot-probed junk must not fork the render either.
+    render(
+      await DogsPage({
+        searchParams: Promise.resolve({
+          utm_source: "newsletter",
+          fbclid: "abc123",
+          probe: "9999",
+        }),
+      }),
+    );
+
+    await waitFor(() => expect(getAnimals).toHaveBeenCalledTimes(1));
+    expect(getAnimals).toHaveBeenCalledWith(FILTERLESS_QUERY);
+  });
+
+  it("never seeds the client with URL-derived filter params", async () => {
+    // useDogsFilters reads searchParams itself and takes precedence over
+    // initialParams, so echoing the URL back through props is dead weight.
+    const { getByTestId } = render(
+      await DogsPage({
+        searchParams: Promise.resolve({ age: "puppy", location_country: "UK" }),
+      }),
+    );
+
+    expect(JSON.parse(getByTestId("initial-params").textContent)).toEqual({});
+  });
+
+  it("still passes the fetched dogs through to the client", async () => {
+    const { getByTestId } = render(
+      await DogsPage({ searchParams: Promise.resolve({}) }),
+    );
+
+    expect(getByTestId("initial-dogs-count")).toHaveTextContent("1");
+  });
+
+  it("keeps a finite revalidate window so listings stay fresh", async () => {
+    expect(typeof revalidate).toBe("number");
+    expect(revalidate).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/app/dogs/page.tsx
+++ b/frontend/src/app/dogs/page.tsx
@@ -9,10 +9,6 @@ import DogCardSkeletonOptimized from "../../components/ui/DogCardSkeletonOptimiz
 import Layout from "../../components/layout/Layout";
 import "../../styles/animations.css";
 
-interface DogsPageProps {
-  searchParams: Promise<Record<string, string | string[] | undefined>>;
-}
-
 export const revalidate = 21600;
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -49,38 +45,18 @@ function LoadingFallback(): React.JSX.Element {
   );
 }
 
-export default async function DogsPageOptimized(props: DogsPageProps): Promise<React.JSX.Element> {
-  const searchParams = await props.searchParams;
-
-  const toStr = (v: string | string[] | undefined): string | undefined => {
-    if (Array.isArray(v)) return v[0];
-    return v || undefined;
-  };
-
-  const apiParams = {
-    limit: 20,
-    offset: 0,
-    search: toStr(searchParams?.search),
-    size: toStr(searchParams?.size),
-    age: toStr(searchParams?.age),
-    sex: toStr(searchParams?.sex),
-    organization_id: toStr(searchParams?.organization_id),
-    breed: toStr(searchParams?.breed),
-    breed_group: toStr(searchParams?.breed_group),
-    location_country: toStr(searchParams?.location_country),
-    available_to_country: toStr(searchParams?.available_country),
-    available_to_region: toStr(searchParams?.available_region),
-  };
-
-  const initialParams = {
-    age_category: toStr(searchParams?.age),
-    location_country: toStr(searchParams?.location_country),
-    available_country: toStr(searchParams?.available_country),
-  };
-
-  // Fetch initial data server-side (cached and deduplicated)
+export default async function DogsPageOptimized(): Promise<React.JSX.Element> {
+  // Deliberately independent of searchParams so this route stays statically
+  // cacheable. Reading them opts the page into dynamic rendering, which made
+  // every request — overwhelmingly bots — re-render and re-query the backend.
+  //
+  // Nothing is lost: the client discards initialDogs whenever the URL carries
+  // filters (useDogsPagination) and reads each filter value from
+  // useSearchParams (useDogsFilters), which already takes precedence over
+  // initialParams. The server-side filtered fetch was work the client threw
+  // away.
   const [initialDogs, metadata] = await Promise.all([
-    getAnimals(apiParams),
+    getAnimals({ limit: 20, offset: 0 }),
     getAllMetadata(),
   ]);
 
@@ -102,7 +78,7 @@ export default async function DogsPageOptimized(props: DogsPageProps): Promise<R
         <DogsPageClientSimplified
           initialDogs={initialDogs}
           metadata={metadata}
-          initialParams={initialParams}
+          initialParams={{}}
         />
       </Suspense>
       <section className="container mx-auto px-4 py-12 lg:pl-[calc(16rem+2rem+1rem)]">


### PR DESCRIPTION
Phase 2 of the Vercel usage work. Phase 1 was #315.

## Problem

`/dogs` read 11 filter params from `searchParams`, which opts an App Router page into dynamic rendering. Measured in production:

```
cache-control: private, no-cache, no-store, max-age=0, must-revalidate
x-vercel-cache: MISS   ← on every hit, including identical repeats
```

Every one of ~733K monthly edge requests re-rendered the page and re-queried the Railway backend. With ~100 real users/week, that traffic is essentially all bots. This is what drove two of the three overages:

| Resource | Usage | Limit |
|---|---|---|
| Fluid Active CPU | 5h33m | 4h |
| Fast Origin Transfer | 12.37 GB | 10 GB |

## Why removing the server-side filter read is behaviour-neutral

The filtered server fetch was **already** being thrown away by the client:

- `useDogsPagination.ts:53-62` — `initialDogs` is discarded whenever the URL carries any filter param; the client starts empty and fetches.
- `useDogsFilters.ts:52-71` — every filter reads `searchParams.get(...)`, which takes precedence over `initialParams`. On `/dogs`, `initialParams` was just an echo of the same URL.

So for a filtered URL we paid a full render plus a backend query for a result the client immediately replaced. The existing test `DogsPageClientSimplified.ssr-cache.test.jsx:170` already asserts this contract.

`/dogs/puppies`, `/dogs/senior` and `/dogs/country/[code]` pass hardcoded `initialParams` and are untouched.

Build output confirms the flip:

```
├ ○ /dogs      6h    1y      ← was ƒ (Dynamic)
```

## robots.txt

Adds `Disallow: /dogs?*` so crawlers stop walking filter and tracking permutations that render identical content.

Doing this correctly required restructuring the file. **A crawler obeys exactly one user-agent group** — the most specific match — and ignores all others including `*`. The old file gave Googlebot, GPTBot, PerplexityBot and friends their own groups containing only `Allow: /`, so a `Disallow` in the `*` group would never have reached them. Verified against the old file:

```
Googlebot        rules: ["allow:/"]
GPTBot           rules: ["allow:/"]
SomeUnknownBot   rules: ["allow:/", ..., "disallow:/admin/", "disallow:/api/internal/"]
```

Pre-existing bug: those named crawlers were never receiving the `/admin/` or `/api/internal/` blocks either. Named agents now share one rule set. Clean `/dogs` and `/dogs/<slug>` URLs remain crawlable; aggressive-bot blocks unchanged.

## Dropped from the plan

Caching the sitemaps was in the Phase 2 plan. Measurement says it is unnecessary — they are already CDN-cached despite `force-dynamic`, because the route sets `s-maxage=86400` on the response:

```
/sitemap.xml       age: 1222  x-vercel-cache: HIT
/sitemap-dogs.xml  age: 1223  x-vercel-cache: HIT
```

My earlier `MISS` readings were cold entries my own probes warmed. No change made.

## Testing

TDD — tests written first and confirmed failing.

- 6 new tests asserting `/dogs` issues an identical query regardless of filter params, tracking params (`utm_*`, `fbclid`), or bot-probed junk
- 26 new robots.txt tests that resolve rules per crawler using real group-exclusivity semantics; verified they fail against the old file
- Full frontend suite: **3572 passed**, 20 skipped, 269 suites
- `tsc --noEmit` clean, `pnpm lint` 0 errors, `pnpm build` succeeds

## Verification after deploy

```
curl -sI https://www.rescuedogs.me/dogs | grep -i x-vercel-cache   # expect HIT on repeat
```