### PR TITLE
perf(images): resize via Cloudflare instead of Vercel's optimizer

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -160,7 +160,11 @@ const nextConfig = {
         pathname: '/**',
       }
     ],
-    formats: ['image/webp', 'image/avif'],
+    // Resize via Cloudflare (/cdn-cgi/image/) instead of Vercel's metered
+    // optimizer — images.rescuedogs.me already does resizing and Accept-based
+    // format negotiation. See src/utils/cloudflareImageLoader.ts.
+    loader: 'custom',
+    loaderFile: './src/utils/cloudflareImageLoader.ts',
     minimumCacheTTL: 31536000,
     dangerouslyAllowSVG: false,
     contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",

--- a/frontend/src/utils/__tests__/cloudflareImageLoader.test.ts
+++ b/frontend/src/utils/__tests__/cloudflareImageLoader.test.ts
@@ -1,0 +1,112 @@
+import cloudflareImageLoader from "../cloudflareImageLoader";
+
+/**
+ * next/image sends every image through Vercel's optimizer (/_next/image),
+ * which is metered. Our dog images already live behind Cloudflare on
+ * images.rescuedogs.me, where /cdn-cgi/image/ does the same resizing and
+ * format negotiation for free:
+ *
+ *   origin JPEG                                     144,893 bytes
+ *   /cdn-cgi/image/width=640,format=auto + Accept    32,523 bytes (avif)
+ *
+ * This loader routes R2 images to Cloudflare and leaves everything else
+ * untouched, taking Vercel image transformations to ~zero.
+ */
+
+const R2 = "https://images.rescuedogs.me";
+const PATH = "rescue_dogs/woof_project/rou_19c9cf1f.jpg";
+
+const parseTransforms = (url: string): Record<string, string> => {
+  const match = url.match(/\/cdn-cgi\/image\/([^/]+)\//);
+  if (!match) throw new Error(`no cdn-cgi transform segment in: ${url}`);
+  return Object.fromEntries(
+    match[1].split(",").map((pair) => {
+      const [k, v] = pair.split("=");
+      return [k, v];
+    }),
+  );
+};
+
+describe("cloudflareImageLoader", () => {
+  describe("R2-hosted images", () => {
+    it("routes through the Cloudflare image endpoint", () => {
+      const out = cloudflareImageLoader({ src: `${R2}/${PATH}`, width: 640 });
+
+      expect(out).toBe(
+        `${R2}/cdn-cgi/image/width=640,quality=75,format=auto/${PATH}`,
+      );
+    });
+
+    it("passes the requested width through", () => {
+      const out = cloudflareImageLoader({ src: `${R2}/${PATH}`, width: 1920 });
+
+      expect(parseTransforms(out).width).toBe("1920");
+    });
+
+    it("honours an explicit quality", () => {
+      const out = cloudflareImageLoader({
+        src: `${R2}/${PATH}`,
+        width: 640,
+        quality: 90,
+      });
+
+      expect(parseTransforms(out).quality).toBe("90");
+    });
+
+    it("defaults quality to 75 when unspecified", () => {
+      const out = cloudflareImageLoader({ src: `${R2}/${PATH}`, width: 640 });
+
+      expect(parseTransforms(out).quality).toBe("75");
+    });
+
+    it("always requests format=auto", () => {
+      // This zone ignores explicit format=webp/avif and only negotiates via
+      // Accept when format=auto is used — verified against production.
+      const out = cloudflareImageLoader({ src: `${R2}/${PATH}`, width: 640 });
+
+      expect(parseTransforms(out).format).toBe("auto");
+    });
+
+    it("does not stack transforms on an already-transformed URL", () => {
+      const preTransformed = `${R2}/cdn-cgi/image/width=256,quality=60/${PATH}`;
+
+      const out = cloudflareImageLoader({ src: preTransformed, width: 640 });
+
+      expect(out.match(/cdn-cgi/g)).toHaveLength(1);
+      expect(parseTransforms(out).width).toBe("640");
+      expect(out.endsWith(PATH)).toBe(true);
+    });
+  });
+
+  describe("non-R2 sources are left alone", () => {
+    it.each([
+      ["local asset", "/placeholder_dog.svg"],
+      ["local png", "/og-image.png"],
+      ["flag CDN", "https://flagcdn.com/w40/gb.png"],
+      ["third-party host", "https://img1.wsimg.com/isteam/photo.jpg"],
+    ])("returns %s unchanged", (_label, src) => {
+      expect(cloudflareImageLoader({ src, width: 640 })).toBe(src);
+    });
+
+    it("never emits a Vercel optimizer URL", () => {
+      const out = cloudflareImageLoader({
+        src: "https://flagcdn.com/w40/gb.png",
+        width: 640,
+      });
+
+      expect(out).not.toContain("/_next/image");
+    });
+  });
+
+  describe("degenerate input", () => {
+    it("returns an empty src unchanged rather than throwing", () => {
+      expect(cloudflareImageLoader({ src: "", width: 640 })).toBe("");
+    });
+
+    it("survives a width of zero", () => {
+      expect(() =>
+        cloudflareImageLoader({ src: `${R2}/${PATH}`, width: 0 }),
+      ).not.toThrow();
+    });
+  });
+});

--- a/frontend/src/utils/cloudflareImageLoader.ts
+++ b/frontend/src/utils/cloudflareImageLoader.ts
@@ -1,0 +1,44 @@
+import { extractOriginalPath, isR2Url } from "./imageUtils";
+
+/**
+ * next/image loader that resizes via Cloudflare instead of Vercel.
+ *
+ * Dog images are served from images.rescuedogs.me, a Cloudflare zone with
+ * Image Resizing enabled, so /cdn-cgi/image/ already does everything
+ * Vercel's metered optimizer would do. Routing R2 images there takes Vercel
+ * image transformations to ~zero and keeps the bytes off Vercel entirely.
+ *
+ * Anything not on R2 — local assets, flag icons, third-party hosts — is
+ * returned untouched, so it is served as-is rather than through /_next/image.
+ */
+
+const R2_CUSTOM_DOMAIN =
+  process.env.NEXT_PUBLIC_R2_CUSTOM_DOMAIN || "images.rescuedogs.me";
+
+const DEFAULT_QUALITY = 75;
+
+interface ImageLoaderParams {
+  src: string;
+  width: number;
+  quality?: number;
+}
+
+export default function cloudflareImageLoader({
+  src,
+  width,
+  quality,
+}: ImageLoaderParams): string {
+  if (!src || !isR2Url(src)) {
+    return src;
+  }
+
+  // Strip any transform the caller already applied so widths don't stack.
+  const original = extractOriginalPath(src);
+  const imagePath = original.replace(`https://${R2_CUSTOM_DOMAIN}/`, "");
+
+  // format=auto is required: this zone ignores explicit format=webp/avif and
+  // only negotiates from the Accept header when auto is used.
+  const transforms = `width=${width},quality=${quality ?? DEFAULT_QUALITY},format=auto`;
+
+  return `https://${R2_CUSTOM_DOMAIN}/cdn-cgi/image/${transforms}/${imagePath}`;
+}


### PR DESCRIPTION
Phase 3 of the Vercel usage work. Phases 1 and 2 were #315 and #316.

## Problem

Image Optimization transformations sat at **4K / 5K** of the Hobby allowance for Jul 20 – Aug 19, with a full crawl of ~1,343 dog pages still to come.

The work was redundant. Dog images are served from `images.rescuedogs.me`, a Cloudflare zone with Image Resizing **already enabled** — and the codebase already builds `/cdn-cgi/image/` URLs elsewhere (`buildSecureCloudflareUrl`, `getCatalogCardImage`, `getDetailHeroImage`, `extractOriginalPath`). `next/image` was sending those same images through Vercel's metered optimizer on top.

Measured against production:

```
origin JPEG                                     144,893 bytes
/cdn-cgi/image/width=640,format=auto + Accept    32,523 bytes  → image/avif
```

## Change

A custom `next/image` loader routes R2 images to Cloudflare and returns everything else (local assets, `flagcdn.com`, `img1.wsimg.com`) untouched. **No call sites change** — the loader sits under the existing `NextImage` wrapper and every other `next/image` usage.

Two details worth knowing:

- **`format=auto` is mandatory.** This zone ignores explicit `format=webp` / `format=avif` and only negotiates from the `Accept` header when `auto` is used. Verified directly against production; there's a test pinning it.
- **`images.formats` is dropped** — it only applies to the built-in optimizer and is inert under a custom loader. `deviceSizes` / `imageSizes` are kept since Next still uses them to pick widths.

The loader calls `extractOriginalPath()` first so an already-transformed src doesn't stack a second `/cdn-cgi/image/` segment.

## Verification against a real build

Not just unit tests — booted the production build and inspected rendered markup:

```
src="https://images.rescuedogs.me/cdn-cgi/image/width=1920,quality=75,format=auto/rescue_dogs/organizations/org-logo-harley-before.jpg"

$ grep -c "_next/image"     → 0
$ curl -I <that URL> -H "Accept: image/avif,..."
  HTTP/2 200
  content-type: image/avif
```

## Dropped from the plan

Two Phase 3 items turned out to need no work:

1. **Batching dependabot into a weekly grouped PR** — `.github/dependabot.yml` already does exactly this (weekly, grouped, `open-pull-requests-limit: 3`). The ~20 prod deploys in 23 days were mostly hand-pushed iteration, not dependabot.
2. **Reducing `STATIC_PARAMS_LIMIT` 500 → 100** — deliberately skipped. Pages dropped from the prerender set still get an ISR write on first request, so this mostly *moves* writes from build time to request time rather than removing them, while adding real TTFB cost for long-tail dogs. Worth revisiting only if the post-Phase-1 numbers say ISR writes are still tight.

## Testing

TDD — 13 tests written first and confirmed failing (module didn't exist).

- Covers width/quality passthrough, the `format=auto` guarantee, non-stacking of transforms, non-R2 passthrough, and that no `/_next/image` URL is ever emitted
- Full frontend suite: **3585 passed**, 20 skipped, 270 suites
- `tsc --noEmit` clean, `pnpm build` compiles

## Rollback

Delete the `loader` / `loaderFile` lines in `next.config.js`; `remotePatterns` is left intact so the built-in optimizer resumes immediately.