### PR TITLE
fix(llm): compute quality scores and align the swipe filter to their scale

### DIFF
--- a/api/routes/swipe.py
+++ b/api/routes/swipe.py
@@ -12,6 +12,10 @@ from api.monitoring import track_slow_query
 
 logger = logging.getLogger(__name__)
 
+# Profiles below this score are withheld from the swipe stack. Scored by
+# DogProfileQualityRubric on a 0-QUALITY_SCORE_MAX scale.
+MIN_SWIPE_QUALITY_SCORE = 70
+
 router = APIRouter()
 
 
@@ -129,7 +133,7 @@ async def get_swipe_stack(
     """
     Get a stack of dogs for the swipe feature.
 
-    Returns dogs with quality LLM profiler data (quality_score > 0.7),
+    Returns dogs with quality LLM profiler data (quality_score > MIN_SWIPE_QUALITY_SCORE),
     ordered by a smart algorithm that prioritizes:
     1. New dogs (added within last 7 days)
     2. Dogs with high engagement scores
@@ -176,7 +180,7 @@ async def get_swipe_stack(
                 # make the ordering deterministic instead of random
                 if randomize:
                     query_parts = [
-                        """
+                        f"""
                         SELECT
                             a.*,
                             o.name as organization_name,
@@ -193,13 +197,13 @@ async def get_swipe_stack(
                             AND a.active = true
                             AND a.animal_type = 'dog'
                             AND a.dog_profiler_data IS NOT NULL
-                            AND (a.dog_profiler_data->>'quality_score')::float > 0.7
+                            AND (a.dog_profiler_data->>'quality_score')::float > {MIN_SWIPE_QUALITY_SCORE}
                         """
                     ]
                     params = []
                 else:
                     query_parts = [
-                        """
+                        f"""
                         SELECT DISTINCT ON (a.id)
                             a.*,
                             o.name as organization_name,
@@ -221,7 +225,7 @@ async def get_swipe_stack(
                             AND a.active = true
                             AND a.animal_type = 'dog'
                             AND a.dog_profiler_data IS NOT NULL
-                            AND (a.dog_profiler_data->>'quality_score')::float > 0.7
+                            AND (a.dog_profiler_data->>'quality_score')::float > {MIN_SWIPE_QUALITY_SCORE}
                         """
                     ]
                     params = [datetime.now(UTC) - timedelta(days=7)]
@@ -349,7 +353,7 @@ async def get_swipe_stack(
             # Check if there are more dogs available with performance tracking
             with sentry_sdk.start_span(op="db.query", description="Check for more dogs"):
                 check_more_query_parts = [
-                    """
+                    f"""
                     SELECT COUNT(*) as total
                     FROM animals a
                     INNER JOIN organizations o ON a.organization_id = o.id
@@ -357,7 +361,7 @@ async def get_swipe_stack(
                         AND a.active = true
                         AND a.animal_type = 'dog'
                         AND a.dog_profiler_data IS NOT NULL
-                        AND (a.dog_profiler_data->>'quality_score')::float > 0.7
+                        AND (a.dog_profiler_data->>'quality_score')::float > {MIN_SWIPE_QUALITY_SCORE}
                     """
                 ]
                 check_params = []
@@ -410,7 +414,7 @@ async def get_available_countries(
     """
     try:
         # Query to get all unique countries from ships_to arrays with dog counts
-        query = """
+        query = f"""
             WITH country_dogs AS (
                 SELECT
                     jsonb_array_elements_text(o.ships_to) as country,
@@ -421,7 +425,7 @@ async def get_available_countries(
                     AND a.active = true
                     AND a.animal_type = 'dog'
                     AND a.dog_profiler_data IS NOT NULL
-                    AND (a.dog_profiler_data->>'quality_score')::float > 0.7
+                    AND (a.dog_profiler_data->>'quality_score')::float > {MIN_SWIPE_QUALITY_SCORE}
                     AND o.ships_to IS NOT NULL
                     AND o.active = true
                 GROUP BY jsonb_array_elements_text(o.ships_to)

--- a/management/llm_commands.py
+++ b/management/llm_commands.py
@@ -23,6 +23,7 @@ from rich.table import Table
 # Add project root to path
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from api.routes.swipe import MIN_SWIPE_QUALITY_SCORE
 from config import DB_CONFIG
 from management.batch_processor import create_batch_processor
 from services.llm.config import get_llm_config
@@ -569,6 +570,72 @@ def stats():
 
     cursor.close()
     conn.close()
+
+
+@llm.command("backfill-quality-scores")
+@click.option("--dry-run", is_flag=True, help="Report the score distribution without writing")
+@click.option("--batch-size", default=500, type=int, help="Rows per write batch")
+def backfill_quality_scores(dry_run: bool, batch_size: int):
+    """Recompute quality_score for profiles written before scoring was wired up.
+
+    Every profile generated prior to the rubric being connected carries a
+    hardcoded 80, which makes the swipe quality filter and the average reported
+    by /api/llm/stats meaningless. This rescores them in place from the stored
+    profile JSON.
+    """
+    from services.llm.quality_rubric import DogProfileQualityRubric
+
+    conn = psycopg2.connect(**DB_CONFIG)
+    cursor = conn.cursor()
+    cursor.execute("SELECT id, dog_profiler_data FROM animals WHERE dog_profiler_data IS NOT NULL")
+    rows = cursor.fetchall()
+
+    if not rows:
+        console.print("[yellow]No profiled dogs found[/yellow]")
+        return
+
+    rubric = DogProfileQualityRubric()
+    updates = []
+    for dog_id, profile in rows:
+        profile = json.loads(profile) if isinstance(profile, str) else profile
+        updates.append((dog_id, round(rubric.calculate_quality_score(profile, {}), 2)))
+
+    scores = sorted(score for _, score in updates)
+    below = sum(1 for score in scores if score <= MIN_SWIPE_QUALITY_SCORE)
+
+    table = Table(title="Quality Score Backfill")
+    table.add_column("Metric", style="cyan")
+    table.add_column("Value", style="magenta")
+    table.add_row("Profiles", str(len(scores)))
+    table.add_row("Min", f"{scores[0]:.1f}")
+    table.add_row("Median", f"{scores[len(scores) // 2]:.1f}")
+    table.add_row("Max", f"{scores[-1]:.1f}")
+    table.add_row(
+        f"Below swipe threshold ({MIN_SWIPE_QUALITY_SCORE})",
+        f"{below} ({below / len(scores) * 100:.1f}%)",
+    )
+    console.print(table)
+
+    if dry_run:
+        console.print("[yellow]Dry run - no changes written[/yellow]")
+        return
+
+    for start in range(0, len(updates), batch_size):
+        batch = updates[start : start + batch_size]
+        cursor.executemany(
+            """
+            UPDATE animals
+            SET dog_profiler_data = jsonb_set(dog_profiler_data, '{quality_score}', %s::jsonb)
+            WHERE id = %s
+            """,
+            [(json.dumps(score), dog_id) for dog_id, score in batch],
+        )
+        conn.commit()
+        console.print(f"  Updated {min(start + batch_size, len(updates))}/{len(updates)}")
+
+    cursor.close()
+    conn.close()
+    console.print(f"[green]Backfilled {len(updates)} quality scores[/green]")
 
 
 if __name__ == "__main__":

--- a/services/llm/dog_profiler.py
+++ b/services/llm/dog_profiler.py
@@ -28,6 +28,7 @@ from services.llm.database_updater import DatabaseUpdater
 from services.llm.extracted_profile_normalizer import ExtractedProfileNormalizer
 from services.llm.llm_client import LLMClient
 from services.llm.prompt_builder import PromptBuilder
+from services.llm.quality_rubric import DogProfileQualityRubric
 from services.llm.retry_handler import RetryConfig, RetryHandler
 from services.llm.schemas.dog_profiler import DogProfilerData
 from services.llm.statistics_tracker import StatisticsTracker
@@ -65,6 +66,7 @@ class DogProfilerPipeline:
         self.normalizer = ExtractedProfileNormalizer()
         self.database_updater = DatabaseUpdater(connection_pool, dry_run)
         self.statistics = StatisticsTracker()
+        self.quality_rubric = DogProfileQualityRubric()
 
         # Setup retry handler with fallback models
         if retry_config is None:
@@ -78,6 +80,19 @@ class DogProfilerPipeline:
                 ],
             )
         self.retry_handler = RetryHandler(retry_config)
+
+    def _calculate_quality_score(self, profile: dict[str, Any], dog_data: dict[str, Any]) -> float:
+        """
+        Score a generated profile against the quality rubric.
+
+        Args:
+            profile: The normalized, schema-validated profile
+            dog_data: The original source data the profile was derived from
+
+        Returns:
+            Score between 0 and QUALITY_SCORE_MAX
+        """
+        return self.quality_rubric.calculate_quality_score(profile, dog_data)
 
     def _normalize_profile_data(self, data: dict[str, Any]) -> dict[str, Any]:
         """
@@ -217,17 +232,7 @@ class DogProfilerPipeline:
             result["breed"] = dog_data.get("breed", "Mixed Breed")
             result["external_id"] = dog_data.get("external_id")
 
-            # Calculate quality score if rubric is available
-            if hasattr(self, "quality_rubric"):
-                from .quality_rubric import DogProfileQualityRubric
-
-                if not hasattr(self, "_rubric_instance"):
-                    self._rubric_instance = DogProfileQualityRubric()
-                # Score returns 0-1, multiply by 100 for percentage
-                result["quality_score"] = self._rubric_instance.calculate_quality_score(result, dog_data) * 100
-            else:
-                # Default quality score for basic validation (80%)
-                result["quality_score"] = 80
+            result["quality_score"] = self._calculate_quality_score(result, dog_data)
 
             return result
 

--- a/services/llm/quality_rubric.py
+++ b/services/llm/quality_rubric.py
@@ -7,7 +7,12 @@ Following CLAUDE.md principles:
 - Comprehensive validation
 """
 
+import re
 from typing import Any
+
+QUALITY_SCORE_MAX = 100
+
+GERMAN_FRAGMENTS = re.compile(r"\b(hund|hunde|rüde|rüden|hündin|jahr|jahre)\b", re.IGNORECASE)
 
 
 class DogProfileQualityRubric:
@@ -124,7 +129,7 @@ class DogProfileQualityRubric:
 
         # Language quality
         lang_score = 0.0
-        if desc and not any(word in desc.lower() for word in ["hund", "rüde", "hündin", "jahr"]):
+        if desc and not GERMAN_FRAGMENTS.search(desc):
             lang_score += 0.5
         if desc and any(word in desc.lower() for word in ["friendly", "loving", "playful", "gentle"]):
             lang_score += 0.5
@@ -189,10 +194,10 @@ class DogProfileQualityRubric:
             source_data: Optional original source data
 
         Returns:
-            Float score between 0.0 and 1.0
+            Float score between 0 and QUALITY_SCORE_MAX
         """
         if source_data is None:
             source_data = {}
 
         result = self.score_profile(profile_data, source_data)
-        return result["total_score"]
+        return result["total_score"] * QUALITY_SCORE_MAX

--- a/tests/services/llm/test_quality_score.py
+++ b/tests/services/llm/test_quality_score.py
@@ -1,0 +1,140 @@
+"""Tests for quality score computation in the dog profiler pipeline.
+
+Regression coverage for the scale mismatch between the profiler (which wrote a
+hardcoded 80) and the swipe endpoint (which filtered on > 0.7), a comparison
+that admitted every profile regardless of quality.
+"""
+
+import pytest
+
+from services.llm.quality_rubric import QUALITY_SCORE_MAX, DogProfileQualityRubric
+
+
+@pytest.fixture
+def rich_profile():
+    """A profile that should score well against every rubric criterion."""
+    return {
+        "description": (
+            "Bella is a gentle and playful companion whose warm personality wins over "
+            "everyone she meets. She loves long walks and quiet evenings curled up beside "
+            "her family. She needs a patient home with someone around during the day."
+        ),
+        "tagline": "A gentle soul looking for her forever family",
+        "energy_level": "medium",
+        "trainability": "easy",
+        "sociability": "social",
+        "confidence": "confident",
+        "home_type": "house_with_garden",
+        "exercise_needs": "moderate",
+        "personality_traits": ["gentle", "playful", "loyal"],
+        "favorite_activities": ["walks", "cuddling"],
+        "confidence_scores": {"description": 0.9, "energy_level": 0.9, "trainability": 0.9},
+        "source_references": {"description": "from listing"},
+    }
+
+
+@pytest.fixture
+def poor_profile():
+    """A profile missing most fields, with a stub description."""
+    return {"description": "Dog.", "confidence_scores": {"description": 0.1}}
+
+
+class TestQualityRubricScale:
+    def test_max_constant_is_one_hundred(self):
+        assert QUALITY_SCORE_MAX == 100
+
+    def test_rich_profile_scores_high_on_zero_to_one_hundred(self, rich_profile):
+        score = DogProfileQualityRubric().calculate_quality_score(rich_profile, {})
+        assert 70 < score <= 100
+
+    def test_poor_profile_scores_below_threshold(self, poor_profile):
+        score = DogProfileQualityRubric().calculate_quality_score(poor_profile, {})
+        assert score < 70
+
+    def test_rich_profile_outscores_poor_profile(self, rich_profile, poor_profile):
+        rubric = DogProfileQualityRubric()
+        assert rubric.calculate_quality_score(rich_profile, {}) > rubric.calculate_quality_score(poor_profile, {})
+
+    def test_score_never_exceeds_max(self, rich_profile):
+        assert DogProfileQualityRubric().calculate_quality_score(rich_profile, {}) <= QUALITY_SCORE_MAX
+
+
+class TestGermanFragmentDetection:
+    """The German check matched bare substrings, so ordinary English words
+    containing them ('hundred' contains 'hund') were penalised as German."""
+
+    def test_english_word_containing_hund_is_not_flagged(self, rich_profile):
+        rich_profile["description"] = "Bella is a gentle and playful dog who is a hundred percent devoted to her family. She loves long walks and needs a patient home of her own."
+        scores = DogProfileQualityRubric.score_profile(rich_profile, {})["scores"]
+        assert scores["language_quality"] == 1.0
+
+    def test_actual_german_fragment_is_flagged(self, rich_profile):
+        rich_profile["description"] = "Dieser Hund ist ein gentle und playful Rüde, der ein Zuhause sucht."
+        scores = DogProfileQualityRubric.score_profile(rich_profile, {})["scores"]
+        assert scores["language_quality"] < 1.0
+
+
+class TestPipelineUsesRubric:
+    def test_pipeline_computes_score_rather_than_hardcoding(self, rich_profile, poor_profile):
+        """The pipeline previously stamped 80 on every profile unconditionally."""
+        from services.llm.dog_profiler import DogProfilerPipeline
+
+        pipeline = DogProfilerPipeline.__new__(DogProfilerPipeline)
+        pipeline.quality_rubric = DogProfileQualityRubric()
+
+        rich = pipeline._calculate_quality_score(rich_profile, {})
+        poor = pipeline._calculate_quality_score(poor_profile, {})
+
+        assert rich != 80
+        assert rich > poor
+        assert 0 <= poor <= QUALITY_SCORE_MAX
+
+
+class TestSwipeThresholdConsistency:
+    """The swipe filter and the profiler must agree on the score scale.
+
+    The endpoint filtered on `> 0.7` while the profiler wrote scores on a
+    0-100 scale, so the comparison admitted every profile ever written.
+    """
+
+    def test_threshold_is_on_the_rubric_scale(self):
+        from api.routes.swipe import MIN_SWIPE_QUALITY_SCORE
+
+        assert 1 < MIN_SWIPE_QUALITY_SCORE < QUALITY_SCORE_MAX
+
+    def test_no_sub_one_threshold_remains_in_swipe_sql(self):
+        """Guards against a fractional threshold creeping back in."""
+        from pathlib import Path
+
+        source = Path("api/routes/swipe.py").read_text()
+        assert "'quality_score')::float > 0." not in source
+
+    def test_every_threshold_reference_is_interpolated(self):
+        """A missing f-prefix would ship a literal brace to Postgres."""
+        import ast
+        from pathlib import Path
+
+        source = Path("api/routes/swipe.py").read_text()
+        assert source.count("{MIN_SWIPE_QUALITY_SCORE}") == 4
+
+        interpolated = 0
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, ast.JoinedStr):
+                continue
+            for part in node.values:
+                if isinstance(part, ast.FormattedValue) and isinstance(part.value, ast.Name) and part.value.id == "MIN_SWIPE_QUALITY_SCORE":
+                    interpolated += 1
+
+        assert interpolated == 4, f"only {interpolated} of 4 thresholds are interpolated"
+
+    def test_poor_profile_would_be_excluded_by_swipe(self, poor_profile):
+        from api.routes.swipe import MIN_SWIPE_QUALITY_SCORE
+
+        score = DogProfileQualityRubric().calculate_quality_score(poor_profile, {})
+        assert score <= MIN_SWIPE_QUALITY_SCORE
+
+    def test_rich_profile_would_be_admitted_by_swipe(self, rich_profile):
+        from api.routes.swipe import MIN_SWIPE_QUALITY_SCORE
+
+        score = DogProfileQualityRubric().calculate_quality_score(rich_profile, {})
+        assert score > MIN_SWIPE_QUALITY_SCORE


### PR DESCRIPTION
## The bug

Two halves of the same feature disagreed, and the disagreement cancelled the feature out.

**Writer.** `DogProfilerPipeline` gated its rubric behind `hasattr(self, "quality_rubric")` — an attribute nothing ever assigned. Every profile took the `else` branch:

```python
if hasattr(self, "quality_rubric"):   # never true
    ...
else:
    result["quality_score"] = 80      # always this
```

**Reader.** The swipe endpoint filtered on `(dog_profiler_data->>'quality_score')::float > 0.7`, a threshold written for a 0–1 scale. Against a value of 80 that is trivially true.

Net effect: the swipe "quality filter" admitted **every profile ever generated**, and `average_quality_score` in `/api/llm/stats` reported a constant.

Verified against production data — all 9,088 profiled dogs carry the identical hardcoded value:

```
 quality_score | count
---------------+-------
 80            |  9088
 (null)        |     2
```

## The fix

- Rubric wired in unconditionally via `_calculate_quality_score`; the dead `hasattr` branch is gone.
- Settled on the **0–100 scale**, which is what the stored data, `enhanced_animals`' `average_quality_score`, and the rubric's own `* 100` already assumed. `QUALITY_SCORE_MAX` names it.
- Swipe threshold is now `MIN_SWIPE_QUALITY_SCORE = 70`, shared by all four query sites instead of four copies of a magic number.

## Why 70, and what it costs

I scored the 5,302 profiles in the local DB through the rubric before picking a threshold:

| | |
|---|---|
| median | 89.4 |
| mean | 88.3 |
| min | **14.0** |
| below 70 | 71 profiles (1.3%) |

So the filter now removes the genuinely broken tail rather than nothing. Existing rows stay at 80 and continue to pass, confirmed against prod:

```
 pass_70 | pass_old | total
---------+----------+-------
    1380 |     1380 |  1381
```

**Zero dogs change visibility on merge.** New profiles get real scores from here on.

## Backfill

Existing rows keep a meaningless 80 until deliberately rescored, so `llm backfill-quality-scores` recomputes them from the stored profile JSON — no LLM calls, no cost. It defaults to reporting only:

```
$ uv run python -m management.llm_commands backfill-quality-scores --dry-run
 Profiles                   │ 5302
 Min                        │ 14.0
 Median                     │ 89.4
 Below swipe threshold (70) │ 71 (1.3%)
```

**Not run against production in this PR** — that is a deliberate operator action, since it is the point at which ~1.3% of dogs leave the swipe stack.

## Also fixed

The rubric's German-fragment detector matched bare substrings, so `"hund" in "a hundred percent"` flagged fluent English as German and docked 0.075 off the total. Now word-boundary anchored.

## Testing

13 new tests in `tests/services/llm/test_quality_score.py` covering the scale, the writer/reader agreement, the substring bug, and rank ordering. Suite: `1497 → 1510 passed`, 4 skipped.

One of them earned its keep immediately: `test_every_threshold_reference_is_interpolated` caught that only 3 of the 4 SQL blocks had picked up the required `f` prefix, so the fourth would have shipped a literal `{MIN_SWIPE_QUALITY_SCORE}` to Postgres.