### PR TITLE
feat(llm): route model selection through OpenRouter's auto-router

### DIFF
--- a/configs/llm_organizations.yaml
+++ b/configs/llm_organizations.yaml
@@ -7,7 +7,6 @@ organizations:
     prompt_file: "tierschutzverein_europa.yaml"
     source_language: "de"
     target_language: "en"
-    model_preference: "google/gemini-3-flash-preview"
     enabled: true
 
   12:
@@ -15,7 +14,6 @@ organizations:
     prompt_file: "daisyfamilyrescue.yaml"
     source_language: "de"
     target_language: "en"
-    model_preference: "google/gemini-3-flash-preview"
     enabled: true
 
   13:
@@ -23,7 +21,6 @@ organizations:
     prompt_file: "misisrescue.yaml"
     source_language: "en"
     target_language: "en"
-    model_preference: "google/gemini-3-flash-preview"
     enabled: true
 
   27:
@@ -31,7 +28,6 @@ organizations:
     prompt_file: "many_tears.yaml"
     source_language: "en"
     target_language: "en"
-    model_preference: "google/gemini-3-flash-preview"
     enabled: true # Configured and ready for testing
 
   28:
@@ -39,7 +35,6 @@ organizations:
     prompt_file: "dogs_trust.yaml"
     source_language: "en"
     target_language: "en"
-    model_preference: "google/gemini-3-flash-preview"
     enabled: true # Configured and ready for testing
 
   29:
@@ -47,7 +42,6 @@ organizations:
     prompt_file: "furry_rescue_italy.yaml"
     source_language: "it"
     target_language: "en"
-    model_preference: "google/gemini-3-flash-preview"
     enabled: false # Not yet configured - needs separate prompt development
 
   26:
@@ -55,7 +49,6 @@ organizations:
     prompt_file: "santerpawsbulgarianrescue.yaml"
     source_language: "en"
     target_language: "en"
-    model_preference: "google/gemini-3-flash-preview"
     enabled: true # Configured and ready for testing
 
   25:
@@ -63,7 +56,6 @@ organizations:
     prompt_file: "galgosdelsol.yaml"
     source_language: "en"
     target_language: "en"
-    model_preference: "google/gemini-3-flash-preview"
     enabled: true # Configured and ready for testing
 
   5:
@@ -71,7 +63,6 @@ organizations:
     prompt_file: "rean.yaml"
     source_language: "en"
     target_language: "en"
-    model_preference: "google/gemini-3-flash-preview"
     enabled: true # Configured and ready for testing
 
   15:
@@ -79,7 +70,6 @@ organizations:
     prompt_file: "animalrescuebosnia.yaml"
     source_language: "en"
     target_language: "en"
-    model_preference: "google/gemini-3-flash-preview"
     enabled: true # Configured and ready for testing
 
   14:
@@ -87,7 +77,6 @@ organizations:
     prompt_file: "theunderdog.yaml"
     source_language: "en"
     target_language: "en"
-    model_preference: "google/gemini-3-flash-preview"
     enabled: true # Configured and ready for testing
 
   17:
@@ -95,11 +84,4 @@ organizations:
     prompt_file: "woof-project.yaml"
     source_language: "en"
     target_language: "en"
-    model_preference: "google/gemini-3-flash-preview"
     enabled: true # Configured and ready for testing
-
-# Model configuration
-models:
-  default: "google/gemini-3-flash-preview"
-  fallback: "openai/gpt-3.5-turbo"
-  high_quality: "openai/gpt-4"

--- a/docs/features/llm-data-enrichment.md
+++ b/docs/features/llm-data-enrichment.md
@@ -129,7 +129,7 @@ Enriched profiles stored in PostgreSQL JSONB column:
   "special_needs": ["needs secure fencing", "may pull on leash"],
   "ideal_home": "Active family with yard and time for training",
   "profiled_at": "2024-08-20T10:30:00Z",
-  "model_used": "google/gemini-3-flash-preview",
+  "model_used": "google/gemini-3.7-flash",
   "quality_score": 92.5
 }
 ```
@@ -236,7 +236,6 @@ organizations:
     prompt_file: "tierschutzverein_europa.yaml"
     source_language: "de"
     target_language: "en"
-    model_preference: "google/gemini-3-flash-preview"
     enabled: true
 ```
 
@@ -261,7 +260,8 @@ extraction_prompt: |
 OPENROUTER_API_KEY=sk-or-v1-xxxxx
 
 # Optional
-LLM_MODEL_OVERRIDE=openai/gpt-4-turbo  # Override default model
+LLM_DEFAULT_MODEL=openrouter/auto  # Model or router alias
+LLM_COST_TIER=medium               # Auto-router tier: low|medium|high|xhigh|max
 ```
 
 ## Quality Assurance
@@ -270,7 +270,7 @@ LLM_MODEL_OVERRIDE=openai/gpt-4-turbo  # Override default model
 
 - **Processing Success Rate**: 97%+ (with automatic retries)
 - **Quality Score Average**: 85-95% per profile
-- **Cost per Dog**: ~$0.005 (Gemini 3 Flash via OpenRouter)
+- **Cost per Dog**: ~$0.024 (auto-router, medium cost tier)
 - **Processing Time**: 2-5 seconds per dog
 - **Batch Efficiency**: 5 dogs concurrent
 
@@ -283,12 +283,12 @@ RetryConfig(
     max_attempts=3,
     initial_delay=2.0,
     backoff_factor=2.0,
-    fallback_models=[
-        "google/gemini-3-flash-preview",
-        "openai/gpt-4-turbo-preview"
-    ]
+    fallback_models=["openrouter/auto"],
 )
 ```
+
+The auto-router already spreads requests across providers, so retries stay on
+the alias rather than falling back to a pinned model.
 
 ### Data Validation
 

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -362,7 +362,6 @@ organizations:
     prompt_file: "tierschutzverein_europa.yaml"
     source_language: "de"
     target_language: "en"
-    model_preference: "google/gemini-3-flash-preview"
     enabled: true
 ```
 

--- a/management/config_commands.py
+++ b/management/config_commands.py
@@ -99,6 +99,7 @@ class ConfigManager:
             sys.path.insert(0, project_root)
 
         from config import DB_CONFIG
+        from services.llm.config import get_llm_config
         from services.llm.dog_profiler import DogProfilerPipeline
         from services.llm.organization_config_loader import get_config_loader
 
@@ -122,7 +123,7 @@ class ConfigManager:
 
         print(f"🤖 Starting LLM profiling for {org_config.organization_name} (ID: {org_id})")
         print(f"   Source Language: {org_config.source_language}")
-        print(f"   Model: {org_config.model_preference}")
+        print(f"   Model: {get_llm_config().models.default_model}")
 
         # Connect to database
         conn = psycopg2.connect(**DB_CONFIG)

--- a/management/llm_commands.py
+++ b/management/llm_commands.py
@@ -274,7 +274,7 @@ def generate_profiles(organization: int | None, limit: int | None, batch_size: i
             continue
 
         console.print(f"\n[bold blue]Processing {org_config.organization_name} (ID: {org_id})[/bold blue]")
-        console.print(f"  Model: {org_config.model_preference}")
+        console.print(f"  Model: {get_llm_config().models.default_model}")
 
         query = """
             SELECT id, name, breed, age_text, properties

--- a/services/llm/README.md
+++ b/services/llm/README.md
@@ -60,7 +60,6 @@ organizations:
     prompt_file: "tierschutzverein_europa.yaml"
     source_language: "de"
     target_language: "en"
-    model_preference: "google/gemini-2.5-flash"
     enabled: true
 ```
 
@@ -71,7 +70,8 @@ organizations:
 OPENROUTER_API_KEY=sk-or-v1-xxxxx
 
 # Optional
-LLM_MODEL_OVERRIDE=openai/gpt-4-turbo-preview  # Override model selection
+LLM_DEFAULT_MODEL=openrouter/auto  # Model or router alias
+LLM_COST_TIER=medium               # Auto-router tier: low|medium|high|xhigh|max
 ```
 
 ## Usage
@@ -256,10 +256,7 @@ RetryConfig(
     max_attempts=3,
     initial_delay=2.0,
     backoff_factor=2.0,
-    fallback_models=[
-        "google/gemini-2.5-flash",
-        "openai/gpt-4-turbo-preview"
-    ]
+    fallback_models=["openrouter/auto"],
 )
 ```
 
@@ -360,7 +357,6 @@ organizations:
     prompt_file: "new_rescue.yaml"
     source_language: "es"
     target_language: "en"
-    model_preference: "google/gemini-2.5-flash"
     enabled: true
 ```
 

--- a/services/llm/config.py
+++ b/services/llm/config.py
@@ -47,6 +47,7 @@ class LLMModelConfig(BaseModel):
 
     Attributes:
         default_model: The default LLM model identifier (uses OpenRouter's auto-selection)
+        cost_tier: Auto-router cost tier - low, medium, high, xhigh or max
         temperature_ranges: Processing-type specific temperature ranges for optimal results
         max_tokens: Optional token limit per request to control costs and response length
 
@@ -57,7 +58,8 @@ class LLMModelConfig(BaseModel):
     Complexity: O(1) for all operations - simple configuration data structure
     """
 
-    default_model: str = Field(default="google/gemini-3-flash-preview", description="Default model to use")
+    default_model: str = Field(default="openrouter/auto", description="Default model to use")
+    cost_tier: str = Field(default="medium", description="OpenRouter auto-router cost tier")
     temperature_ranges: dict[str, tuple] = Field(
         default_factory=lambda: {
             "description_cleaning": (0.2, 0.4),
@@ -351,13 +353,15 @@ class LLMConfigLoader:
             LLMModelConfig: Validated model configuration
 
         Environment Variables:
-            LLM_DEFAULT_MODEL: Override default model (default: "google/gemini-3-flash-preview")
+            LLM_DEFAULT_MODEL: Override default model (default: "openrouter/auto")
+            LLM_COST_TIER: Auto-router cost tier (default: "medium")
             LLM_MAX_TOKENS: Maximum tokens per request (default: unlimited)
 
         Complexity: O(1) - simple environment variable reads and construction
         """
         return LLMModelConfig(
-            default_model=os.getenv("LLM_DEFAULT_MODEL", "google/gemini-3-flash-preview"),
+            default_model=os.getenv("LLM_DEFAULT_MODEL", "openrouter/auto"),
+            cost_tier=os.getenv("LLM_COST_TIER", "medium"),
             max_tokens=int(os.getenv("LLM_MAX_TOKENS", "0")) or None,
         )
 

--- a/services/llm/dog_profiler.py
+++ b/services/llm/dog_profiler.py
@@ -1,10 +1,8 @@
 """
 Dog Profiler Pipeline for enriching dog data with LLM.
 
-Default Model: google/gemini-3-flash-preview
-- 2.5x faster than GPT-4
-- 85% cheaper (~$0.0015/dog vs $0.01/dog)
-- 90% success rate (with retry logic can reach 100%)
+Model selection is delegated to OpenRouter's auto-router, configured by
+LLM_DEFAULT_MODEL and LLM_COST_TIER.
 
 Following CLAUDE.md principles:
 - Pure functions, no mutations
@@ -24,6 +22,7 @@ from dotenv import load_dotenv
 if TYPE_CHECKING:
     from services.connection_pool import ConnectionPoolService
 
+from services.llm.config import get_llm_config
 from services.llm.database_updater import DatabaseUpdater
 from services.llm.extracted_profile_normalizer import ExtractedProfileNormalizer
 from services.llm.llm_client import LLMClient
@@ -68,16 +67,18 @@ class DogProfilerPipeline:
         self.statistics = StatisticsTracker()
         self.quality_rubric = DogProfileQualityRubric()
 
-        # Setup retry handler with fallback models
+        model_config = get_llm_config().models
+        self.model = model_config.default_model
+        self.cost_tier = model_config.cost_tier
+
+        # The auto-router already spreads requests across providers, so retries
+        # stay on the same alias rather than falling back to a pinned model.
         if retry_config is None:
             retry_config = RetryConfig(
                 max_attempts=3,
                 initial_delay=2.0,
                 backoff_factor=2.0,
-                fallback_models=[
-                    "google/gemini-3-flash-preview",
-                    "openai/gpt-4-turbo-preview",
-                ],
+                fallback_models=[self.model],
             )
         self.retry_handler = RetryHandler(retry_config)
 
@@ -112,7 +113,7 @@ class DogProfilerPipeline:
     async def _call_llm_api(
         self,
         dog_data: dict[str, Any],
-        model: str = "google/gemini-3-flash-preview",
+        model: str | None = None,
         timeout: float = 30.0,
         prompt_adjustment: str = "",
     ) -> dict[str, Any]:
@@ -139,10 +140,11 @@ class DogProfilerPipeline:
         # Use LLMClient to make the API call and parse response
         return await self.llm_client.call_api_and_parse(
             messages=messages,
-            model=model,
+            model=model or self.model,
             temperature=0.7,
             max_tokens=4000,
             timeout=timeout,
+            cost_tier=self.cost_tier,
         )
 
     async def process_dog(self, dog_data: dict[str, Any]) -> dict[str, Any] | None:
@@ -168,7 +170,7 @@ class DogProfilerPipeline:
             profiler_result = await self.retry_handler.execute_with_retry(
                 self._call_llm_api,
                 dog_data=dog_data,
-                model="google/gemini-3-flash-preview",
+                model=self.model,
                 timeout=30.0,
                 prompt_adjustment="",  # Start with preferred model  # Will be modified by retry handler if needed
             )
@@ -191,7 +193,7 @@ class DogProfilerPipeline:
             # Add/update metadata fields
             profile_data["profiled_at"] = datetime.now(UTC).isoformat()
             profile_data["prompt_version"] = self.prompt_builder.get_prompt_version()
-            profile_data["model_used"] = profiler_result.get("model_used", "google/gemini-3-flash-preview")
+            profile_data["model_used"] = profiler_result.get("model_used", self.model)
 
             # Add confidence scores if not present (using defaults)
             if "confidence_scores" not in profile_data:

--- a/services/llm/llm_client.py
+++ b/services/llm/llm_client.py
@@ -23,6 +23,46 @@ load_dotenv()
 
 logger = logging.getLogger(__name__)
 
+AUTO_ROUTER_MODEL = "openrouter/auto"
+AUTO_ROUTER_PLUGIN_ID = "auto-router"
+
+
+def build_request_body(
+    messages: list[dict[str, str]],
+    model: str,
+    temperature: float,
+    max_tokens: int,
+    cost_tier: str,
+) -> dict[str, Any]:
+    """
+    Build the OpenRouter chat completion payload.
+
+    Args:
+        messages: Conversation messages
+        model: Model slug, or AUTO_ROUTER_MODEL to delegate selection
+        temperature: Sampling temperature
+        max_tokens: Maximum tokens to generate
+        cost_tier: Auto-router cost tier (ignored for pinned models)
+
+    Returns:
+        Request body ready to POST
+    """
+    body: dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+        "response_format": {"type": "json_object"},
+        # Reasoning models otherwise spend the entire max_tokens budget on
+        # reasoning and return empty content.
+        "reasoning": {"enabled": False},
+    }
+
+    if model == AUTO_ROUTER_MODEL:
+        body["plugins"] = [{"id": AUTO_ROUTER_PLUGIN_ID, "cost_tier": cost_tier}]
+
+    return body
+
 
 class LLMClient:
     """Client for making HTTP requests to LLM APIs."""
@@ -44,10 +84,11 @@ class LLMClient:
     async def call_openrouter_api(
         self,
         messages: list[dict[str, str]],
-        model: str = "google/gemini-3-flash-preview",
+        model: str = AUTO_ROUTER_MODEL,
         temperature: float = 0.7,
         max_tokens: int = 4000,
         timeout: float = 30.0,
+        cost_tier: str = "medium",
     ) -> dict[str, Any]:
         """
         Make API call to OpenRouter.
@@ -83,12 +124,13 @@ class LLMClient:
                         "HTTP-Referer": "https://rescuedogs.me",
                         "X-Title": "Rescue Dog Aggregator",
                     },
-                    json={
-                        "model": model,
-                        "messages": messages,
-                        "temperature": temperature,
-                        "max_tokens": max_tokens,
-                    },
+                    json=build_request_body(
+                        messages=messages,
+                        model=model,
+                        temperature=temperature,
+                        max_tokens=max_tokens,
+                        cost_tier=cost_tier,
+                    ),
                     timeout=timeout,
                 )
 
@@ -152,13 +194,19 @@ class LLMClient:
 
         return "\n".join(json_lines)
 
-    def parse_json_response(self, content: str, model: str = None) -> dict[str, Any]:
+    def parse_json_response(
+        self,
+        content: str,
+        model: str = None,
+        response_data: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
         """
         Parse JSON content and add metadata.
 
         Args:
             content: JSON content string
-            model: Model name to add to result
+            model: Model requested, used when the response does not name one
+            response_data: Raw API response, which names the model actually used
 
         Returns:
             Parsed JSON with metadata
@@ -168,19 +216,22 @@ class LLMClient:
         """
         result = json.loads(content)
 
-        # Add model used to result
-        if model:
-            result["model_used"] = model
+        # Under auto-routing the requested model is an alias, so the model named
+        # in the response is the one that actually ran.
+        selected = (response_data or {}).get("model") or model
+        if selected:
+            result["model_used"] = selected
 
         return result
 
     async def call_api_and_parse(
         self,
         messages: list[dict[str, str]],
-        model: str = "google/gemini-3-flash-preview",
+        model: str = AUTO_ROUTER_MODEL,
         temperature: float = 0.7,
         max_tokens: int = 4000,
         timeout: float = 30.0,
+        cost_tier: str = "medium",
     ) -> dict[str, Any]:
         """
         Complete API call with content extraction and parsing.
@@ -191,6 +242,7 @@ class LLMClient:
             temperature: Sampling temperature
             max_tokens: Maximum tokens to generate
             timeout: Request timeout in seconds
+            cost_tier: Auto-router cost tier
 
         Returns:
             Parsed response with metadata
@@ -207,19 +259,13 @@ class LLMClient:
                 temperature=temperature,
                 max_tokens=max_tokens,
                 timeout=timeout,
+                cost_tier=cost_tier,
             )
 
             # Extract content
             content = self.extract_content_from_response(response_data)
 
-            # Parse JSON and add metadata
-            result = self.parse_json_response(content, model)
-
-            # Add model from original response if not already present
-            if "model_used" not in result and "model" in response_data:
-                result["model_used"] = response_data["model"]
-
-            return result
+            return self.parse_json_response(content, model, response_data)
 
     async def call_vision_api(
         self,

--- a/services/llm/organization_config_loader.py
+++ b/services/llm/organization_config_loader.py
@@ -8,7 +8,6 @@ Following CLAUDE.md principles:
 """
 
 import logging
-import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -36,15 +35,7 @@ class OrganizationConfig:
     prompt_file: str
     source_language: str = "en"
     target_language: str = "en"
-    model_preference: str = "google/gemini-3-flash-preview"
     enabled: bool = True
-
-    def __post_init__(self):
-        """Post-initialization validation."""
-        # Allow environment override for model
-        model_override = os.environ.get("LLM_MODEL_OVERRIDE")
-        if model_override:
-            self.model_preference = model_override
 
 
 class OrganizationConfigLoader:
@@ -99,7 +90,6 @@ class OrganizationConfigLoader:
             prompt_file=org_data["prompt_file"],
             source_language=org_data.get("source_language", "en"),
             target_language=org_data.get("target_language", "en"),
-            model_preference=org_data.get("model_preference", "google/gemini-3-flash-preview"),
             enabled=org_data.get("enabled", True),
         )
 

--- a/services/llm/schemas/dog_profiler.py
+++ b/services/llm/schemas/dog_profiler.py
@@ -181,7 +181,7 @@ class DogProfilerData(BaseModel):
                     "good_with_dogs": "verträglich mit anderen Hunden",
                 },
                 "prompt_version": "1.0.0",
-                "model_used": "google/gemini-3-flash-preview",
+                "model_used": "google/gemini-3.7-flash",
             }
         },
     )

--- a/tests/management/test_config_commands_llm_filter.py
+++ b/tests/management/test_config_commands_llm_filter.py
@@ -36,7 +36,6 @@ class TestLLMAvailabilityFiltering(unittest.TestCase):
         mock_config.prompt_file = "test.yaml"
         mock_config.organization_name = "Test Org"
         mock_config.source_language = "en"
-        mock_config.model_preference = "test-model"
 
         mock_loader_instance = MagicMock()
         mock_loader_instance.load_config.return_value = mock_config

--- a/tests/services/llm/test_auto_router.py
+++ b/tests/services/llm/test_auto_router.py
@@ -1,0 +1,77 @@
+"""Tests for OpenRouter auto-router request construction.
+
+The pipeline previously pinned google/gemini-3-flash-preview in eight places.
+Routing is now delegated to OpenRouter's auto-router so the model tracks the
+frontier without code changes.
+"""
+
+from services.llm.llm_client import AUTO_ROUTER_MODEL, LLMClient, build_request_body
+
+
+class TestBuildRequestBody:
+    def test_auto_router_carries_the_plugin_and_cost_tier(self):
+        body = build_request_body(messages=[], model=AUTO_ROUTER_MODEL, temperature=0.7, max_tokens=4000, cost_tier="medium")
+        assert body["plugins"] == [{"id": "auto-router", "cost_tier": "medium"}]
+
+    def test_cost_tier_is_configurable(self):
+        body = build_request_body(messages=[], model=AUTO_ROUTER_MODEL, temperature=0.7, max_tokens=4000, cost_tier="low")
+        assert body["plugins"][0]["cost_tier"] == "low"
+
+    def test_pinned_model_gets_no_router_plugin(self):
+        body = build_request_body(messages=[], model="google/gemini-3-flash-preview", temperature=0.7, max_tokens=4000, cost_tier="medium")
+        assert "plugins" not in body
+
+    def test_reasoning_is_disabled(self):
+        """Reasoning models consume the whole max_tokens budget and return no
+        content, so the router must not be allowed to spend tokens on it."""
+        body = build_request_body(messages=[], model=AUTO_ROUTER_MODEL, temperature=0.7, max_tokens=4000, cost_tier="medium")
+        assert body["reasoning"] == {"enabled": False}
+
+    def test_json_object_response_format_is_requested(self):
+        body = build_request_body(messages=[], model=AUTO_ROUTER_MODEL, temperature=0.7, max_tokens=4000, cost_tier="medium")
+        assert body["response_format"] == {"type": "json_object"}
+
+    def test_core_parameters_are_passed_through(self):
+        messages = [{"role": "user", "content": "hi"}]
+        body = build_request_body(messages=messages, model=AUTO_ROUTER_MODEL, temperature=0.3, max_tokens=1234, cost_tier="medium")
+        assert body["messages"] == messages
+        assert body["model"] == AUTO_ROUTER_MODEL
+        assert body["temperature"] == 0.3
+        assert body["max_tokens"] == 1234
+
+
+class TestModelAttribution:
+    """With auto-routing, the requested model is 'openrouter/auto'; the useful
+    value is which model the router actually picked."""
+
+    def test_selected_model_is_recorded_not_the_router_alias(self):
+        client = LLMClient(api_key="test-key")
+        response_data = {
+            "choices": [{"message": {"content": '{"name": "Bella"}'}}],
+            "model": "google/gemini-3.7-flash",
+        }
+        result = client.parse_json_response(
+            client.extract_content_from_response(response_data),
+            model=AUTO_ROUTER_MODEL,
+            response_data=response_data,
+        )
+        assert result["model_used"] == "google/gemini-3.7-flash"
+
+    def test_falls_back_to_requested_model_when_response_omits_it(self):
+        client = LLMClient(api_key="test-key")
+        response_data = {"choices": [{"message": {"content": '{"name": "Bella"}'}}]}
+        result = client.parse_json_response(
+            client.extract_content_from_response(response_data),
+            model=AUTO_ROUTER_MODEL,
+            response_data=response_data,
+        )
+        assert result["model_used"] == AUTO_ROUTER_MODEL
+
+
+class TestNoPinnedModelsRemain:
+    def test_profiler_does_not_hardcode_a_model(self):
+        from pathlib import Path
+
+        source = Path("services/llm/dog_profiler.py").read_text()
+        assert "gemini-3-flash-preview" not in source
+        assert "gpt-4-turbo-preview" not in source

--- a/tests/services/llm/test_organization_config_loader.py
+++ b/tests/services/llm/test_organization_config_loader.py
@@ -34,12 +34,10 @@ class TestOrganizationConfig:
             prompt_file="tierschutzverein_europa.yaml",
             source_language="de",
             target_language="en",
-            model_preference="google/gemini-2.5-flash",
         )
 
         assert config.organization_id == 11
         assert config.source_language == "de"
-        assert config.model_preference == "google/gemini-2.5-flash"
 
     def test_config_defaults(self):
         """Test default values."""
@@ -47,7 +45,7 @@ class TestOrganizationConfig:
 
         assert config.source_language == "en"
         assert config.target_language == "en"
-        assert config.model_preference == "google/gemini-3-flash-preview"
+        assert config.enabled is True
 
     def test_prompt_template(self):
         """Test prompt template structure."""
@@ -82,7 +80,6 @@ class TestOrganizationConfigLoader:
                 "prompt_file": "tierschutzverein_europa.yaml",
                 "source_language": "de",
                 "target_language": "en",
-                "model_preference": "google/gemini-2.5-flash",
             },
             "27": {
                 "name": "Test Organization",
@@ -109,7 +106,6 @@ class TestOrganizationConfigLoader:
             assert config.organization_id == 11
             assert config.organization_name == "Tierschutzverein Europa"
             assert config.source_language == "de"
-            assert config.model_preference == "google/gemini-2.5-flash"
 
     def test_load_config_not_found(self, loader, mock_config_data):
         """Test loading non-existent config."""
@@ -191,12 +187,11 @@ class TestOrganizationConfigLoader:
             with pytest.raises(ValueError, match="prompt_file"):
                 loader.load_config(11)
 
-    def test_environment_override(self, loader, mock_config_data):
-        """Test environment variable overrides."""
-        with patch.dict("os.environ", {"LLM_MODEL_OVERRIDE": "gpt-4"}):
-            with patch.object(loader, "_load_config_map", return_value=mock_config_data):
-                config = loader.load_config(11)
-                assert config.model_preference == "gpt-4"  # Overridden by env var
+    def test_model_selection_is_not_per_organization(self, loader, mock_config_data):
+        """Model choice moved to LLM_DEFAULT_MODEL/LLM_COST_TIER, applied globally."""
+        with patch.object(loader, "_load_config_map", return_value=mock_config_data):
+            config = loader.load_config(11)
+            assert not hasattr(config, "model_preference")
 
 
 class TestOrganizationConfigIntegration:

--- a/tests/services/llm/test_prompt_builder.py
+++ b/tests/services/llm/test_prompt_builder.py
@@ -48,7 +48,6 @@ class TestPromptBuilder:
             prompt_file: str = "test.yaml"
             source_language: str = "en"
             target_language: str = "en"
-            model_preference: str = "test-model"
 
         mock_template_content = """
         system_prompt: "Test system prompt"
@@ -82,7 +81,6 @@ class TestPromptBuilder:
             prompt_file: str = "test.yaml"
             source_language: str = "en"
             target_language: str = "en"
-            model_preference: str = "test-model"
 
         with (
             patch("pathlib.Path.exists", return_value=False),


### PR DESCRIPTION
## Summary

`google/gemini-3-flash-preview` was pinned in **eight** production call sites, so keeping the model current meant editing code. Selection now goes to `openrouter/auto`, with the cost tier as the only dial.

`LLM_DEFAULT_MODEL` and `LLM_COST_TIER` (default `medium`) are the knobs. Everything else is derived.

## What I measured before committing to this

I probed the real API rather than trusting the docs, using an actual profiling prompt for org 11. Two findings changed the design:

**1. Reasoning models silently produce nothing.** At the `low` tier the router picked `deepseek/deepseek-v4-pro`, which spent its entire 4000-token budget on reasoning:

```
AUTO low + json  → deepseek-v4-pro  reasoning=4000  completion=4000  VALID_JSON=False
```

Every one of those would have been a failed profile. With `reasoning: {"enabled": false}` the same request returns clean JSON. That parameter is not optional for this pipeline — it's load-bearing, hence a dedicated test.

**2. Cost per dog, measured not guessed:**

| Config | Model selected | Cost/dog | Valid JSON |
|---|---|---|---|
| pinned `gemini-3-flash-preview` (before) | — | $0.0032 | ✅ |
| `auto` + `low` + reasoning off | `deepseek-v4-pro` | $0.0087 | ✅ |
| **`auto` + `medium` + reasoning off** | `claude-sonnet-5` | **$0.0237** | ✅ |

Medium is ~7× the pinned model. Sized against real throughput — the DB shows **370–670 dogs profiled per month** — that is roughly **$13/month**, comfortably inside the $30/month cap on the key. Switching to `low` (~$4.80/month) is a one-variable change if that ratio is unwelcome.

One caveat worth stating: a *full* re-profile of all ~1,500 dogs at medium would run about $35 and would exceed the monthly cap in a single pass. Normal operation only profiles new dogs.

## Model attribution bug

`parse_json_response` stamped `model_used` from the **requested** model unconditionally, which made the downstream fallback unreachable:

```python
result["model_used"] = model                      # always set
...
if "model_used" not in result and "model" in response_data:   # never true
```

Under auto-routing every profile would have recorded the literal string `"openrouter/auto"`, destroying the record of what actually ran. It now prefers the model named in the response. Verified end-to-end:

```
configured model: openrouter/auto | cost_tier: medium
  Sally: OK  model_used='anthropic/claude-sonnet-5'  quality=80.4
  Alex:  OK  model_used='anthropic/claude-sonnet-5'  quality=83.5
```

## Removed

- **`model_preference`** (per-org) and the `LLM_MODEL_OVERRIDE` that fed it. All twelve organizations named the identical model, and no live path had read the field since `dog_profiler_service.py` was deleted — only two `print()` statements, now sourced from the real config.
- The `models:` block in `llm_organizations.yaml` (`fallback: openai/gpt-3.5-turbo`, `high_quality: openai/gpt-4`) — never read by the loader, and both models long deprecated.
- The retry handler's `fallback_models` list, which named `openai/gpt-4-turbo-preview`. The router already spreads across providers, so retries stay on the alias.

## Added

`response_format: {"type": "json_object"}`, which **nothing** in the codebase requested before. JSON compliance previously rested entirely on prompt wording plus a markdown-fence stripper and retries — tolerable with one pinned, tested model; not with a router that can pick anything.

## Testing

9 new tests in `tests/services/llm/test_auto_router.py` covering payload construction, cost-tier plumbing, the reasoning-disabled guarantee, model attribution in both directions, and a guard that no pinned model string returns to `dog_profiler.py`.

Suite: `1508 → 1517` collected (+9, exactly the new file). `1513 passed, 4 skipped`. Live end-to-end run against the real API confirmed above.