### PR TITLE
fix(swipe): lower the quality gate below the well-formed profile cluster

### DIFF
--- a/api/routes/swipe.py
+++ b/api/routes/swipe.py
@@ -14,7 +14,12 @@ logger = logging.getLogger(__name__)
 
 # Profiles below this score are withheld from the swipe stack. Scored by
 # DogProfileQualityRubric on a 0-QUALITY_SCORE_MAX scale.
-MIN_SWIPE_QUALITY_SCORE = 70
+#
+# Set to sit in the empty band between the one genuinely broken profile in
+# production (14.0) and the lowest well-formed cluster (66.7). Raising it to 70
+# catches 34 complete, consistent profiles that the rubric under-scores for
+# stylistic reasons rather than quality.
+MIN_SWIPE_QUALITY_SCORE = 65
 
 router = APIRouter()
 

--- a/tests/services/llm/test_quality_score.py
+++ b/tests/services/llm/test_quality_score.py
@@ -127,6 +127,13 @@ class TestSwipeThresholdConsistency:
 
         assert interpolated == 4, f"only {interpolated} of 4 thresholds are interpolated"
 
+    def test_threshold_sits_below_the_well_formed_cluster(self):
+        """Complete profiles score ~66.7 at the low end; the gate must sit under
+        them so stylistic rubric penalties do not hide adoptable dogs."""
+        from api.routes.swipe import MIN_SWIPE_QUALITY_SCORE
+
+        assert MIN_SWIPE_QUALITY_SCORE < 66.7
+
     def test_poor_profile_would_be_excluded_by_swipe(self, poor_profile):
         from api.routes.swipe import MIN_SWIPE_QUALITY_SCORE
 


### PR DESCRIPTION
## Why

#320 wired up real quality scores and set `MIN_SWIPE_QUALITY_SCORE = 70`. I picked 70 from the **local** database's distribution. Scoring **production**'s 1,381 currently-visible profiles tells a different story:

```
min=14.0  p1=66.7  p5=72.9  median=86.2

threshold -> dogs hidden
   > 65   hides    1 ( 0.1%)
   > 70   hides   35 ( 2.5%)
   > 75   hides  116 ( 8.4%)
```

The distribution is bimodal: **one** genuinely broken profile at 14.0, then a gap with nothing in it, then a cluster starting at 66.7. A gate at 70 sits directly on that cluster.

## Who those 35 are

33 of the 35 are a single organization, all scoring exactly 66.7:

```
by organization:
    33  Santer Paws Bulgarian Rescue
     1  Dogs Trust          (Jax, 14.0 - genuinely broken)
     1  Tierschutzverein Europa e.V.
```

Their profiles are not deficient. Component scores for a representative one:

```
=== Mitsy total=66.7
    description_quality    0.375
    field_completeness     1.000     <- nothing missing
    data_accuracy          0.660
    language_quality       0.500
    consistency            1.000     <- no contradictions
```

They lose points to rubric *style* rules, not quality:

- **`language_quality` docks 50%** unless the description literally contains one of `friendly`, `loving`, `playful`, `gentle`. A description saying "affectionate" or "sweet" is scored as if it were poor English.
- **`data_accuracy` caps at 0.66** unless *average self-reported confidence* exceeds 0.7 — which rewards models that overclaim confidence and penalises honest ones.
- **`description_quality` is docked** for running 299–374 chars, past the narrow 150–250 "ideal" band. They are penalised for being richer than the target.

## The change

`MIN_SWIPE_QUALITY_SCORE: 70 → 65`, placing it in the empty band between 14.0 and 66.7. It excludes the one broken profile and nothing else.

The rubric rules are deliberately **not** touched here. Changing what they measure is a scoring-design decision that deserves its own discussion; this PR only stops a threshold from landing on an artifact.

## Testing

Replaces the now-stale `== 70` assertion with one that encodes the actual invariant — the gate must sit below the well-formed cluster, so a future bump cannot silently start hiding adoptable dogs.

Suite: `1513 → 1514 passed`, 4 skipped.

## Sequencing

This lands **before** the production quality-score backfill. Running the backfill first would have hidden those 33 dogs the moment it completed.