### PR TITLE
fix(scrapers): preserve organization breed text in breed_raw

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -42,6 +42,7 @@ CREATE TABLE IF NOT EXISTS animals (
 
     -- Core searchable fields
     breed VARCHAR(255),
+    breed_raw VARCHAR(255),
     breed_group VARCHAR(100),
     standardized_breed VARCHAR(100),
     age_text VARCHAR(100),

--- a/migrations/railway/versions/b3f7c9d1e204_add_breed_raw_column.py
+++ b/migrations/railway/versions/b3f7c9d1e204_add_breed_raw_column.py
@@ -1,0 +1,39 @@
+"""Add breed_raw column to animals
+
+Preserves the organization's original breed text, which standardization
+previously overwrote in place, making the input unrecoverable.
+
+Revision ID: b3f7c9d1e204
+Revises: 45c123f68726
+Create Date: 2026-08-20 09:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers
+revision = "b3f7c9d1e204"
+down_revision = "45c123f68726"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("animals", sa.Column("breed_raw", sa.String(length=255), nullable=True))
+
+    # Recover the original text for the organizations that happened to keep a
+    # copy in properties. The remainder repopulates on the next scrape.
+    op.execute(
+        """
+        UPDATE animals
+        SET breed_raw = properties->>'breed'
+        WHERE breed_raw IS NULL
+          AND properties->>'breed' IS NOT NULL
+          AND properties->>'breed' <> ''
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("animals", "breed_raw")

--- a/scrapers/base_scraper.py
+++ b/scrapers/base_scraper.py
@@ -465,6 +465,9 @@ class BaseScraper(ABC):
             # Apply field normalization first (trimming, boolean conversion, defaults)
             processed_data = self.standardizer.apply_field_normalization(processed_data)
 
+            # Preserve the organization's own breed text before standardization rewrites it
+            processed_data["breed_raw"] = processed_data.get("breed")
+
             # Log standardization for breed if present
             original_breed = animal_data.get("breed")
             if original_breed:

--- a/services/animal_data_preparation.py
+++ b/services/animal_data_preparation.py
@@ -22,6 +22,7 @@ class PreparedAnimalData:
     """Standardized animal data ready for database insertion."""
 
     language: str
+    breed_raw: str | None
     standardized_breed: str
     breed_group: str
     final_size: str | None
@@ -65,6 +66,7 @@ def prepare_animal_data(animal_data: dict[str, Any]) -> PreparedAnimalData:
 
     return PreparedAnimalData(
         language=language,
+        breed_raw=animal_data.get("breed_raw") or animal_data.get("breed"),
         standardized_breed=final_standardized_breed,
         breed_group=final_breed_group,
         final_size=final_size,

--- a/services/database_service.py
+++ b/services/database_service.py
@@ -189,14 +189,14 @@ class DatabaseService:
             INSERT INTO animals (
                 name, organization_id, animal_type, external_id,
                 primary_image_url, original_image_url, adoption_url, status,
-                breed, standardized_breed, breed_group, age_text, age_min_months, age_max_months,
+                breed, breed_raw, standardized_breed, breed_group, age_text, age_min_months, age_max_months,
                 sex, size, standardized_size, language, properties, slug,
                 created_at, updated_at, last_scraped_at, last_seen_at,
                 consecutive_scrapes_missing, availability_confidence, active,
                 breed_type, primary_breed, secondary_breed, breed_slug, breed_confidence
             ) VALUES (
                 %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
-                %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+                %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
             )
             RETURNING id
             """,
@@ -210,6 +210,7 @@ class DatabaseService:
                 animal_data.get("adoption_url"),
                 animal_data.get("status", "available"),
                 animal_data.get("breed"),
+                prepared.breed_raw,
                 prepared.standardized_breed,
                 prepared.breed_group,
                 animal_data.get("age_text"),
@@ -269,7 +270,8 @@ class DatabaseService:
                 """
                 SELECT name, breed, age_text, sex, primary_image_url, status,
                        standardized_breed, age_min_months, age_max_months, standardized_size, properties,
-                       breed_type, primary_breed, secondary_breed, breed_slug, breed_confidence
+                       breed_type, primary_breed, secondary_breed, breed_slug, breed_confidence,
+                       breed_raw
                 FROM animals WHERE id = %s
                 """,
                 (animal_id,),
@@ -297,6 +299,7 @@ class DatabaseService:
                 current_secondary_breed,
                 current_breed_slug,
                 current_breed_confidence,
+                current_breed_raw,
             ) = current_data
 
             # Process the properties (sanitize to remove null bytes that PostgreSQL rejects)
@@ -329,6 +332,7 @@ class DatabaseService:
             new_secondary_breed = animal_data.get("secondary_breed")
             new_breed_slug = animal_data.get("breed_slug")
             new_breed_confidence = animal_data.get("breed_confidence")
+            new_breed_raw = animal_data.get("breed_raw") or animal_data.get("breed")
 
             # Check if there are actual changes
             has_changes = (
@@ -348,6 +352,7 @@ class DatabaseService:
                 or new_secondary_breed != current_secondary_breed
                 or new_breed_slug != current_breed_slug
                 or str(new_breed_confidence) != current_breed_confidence
+                or new_breed_raw != current_breed_raw
             )
 
             if not has_changes:
@@ -361,7 +366,7 @@ class DatabaseService:
             cursor.execute(
                 """
                 UPDATE animals
-                SET name = %s, breed = %s, standardized_breed = %s, breed_group = %s,
+                SET name = %s, breed = %s, breed_raw = %s, standardized_breed = %s, breed_group = %s,
                     age_text = %s, age_min_months = %s, age_max_months = %s, sex = %s,
                     primary_image_url = %s, original_image_url = %s, status = %s,
                     size = %s, standardized_size = %s, properties = %s,
@@ -375,6 +380,7 @@ class DatabaseService:
                 (
                     animal_data.get("name"),
                     animal_data.get("breed"),
+                    new_breed_raw,
                     final_standardized_breed,
                     final_breed_group,
                     animal_data.get("age_text"),

--- a/tests/scrapers/test_base_scraper_unified_standardization.py
+++ b/tests/scrapers/test_base_scraper_unified_standardization.py
@@ -241,3 +241,82 @@ class TestBasScraperUnifiedStandardization:
         assert processed["breed"] == "Unknown"
         assert processed.get("primary_breed") == "Unknown"
         assert processed.get("breed_category") == "Unknown"
+
+
+@pytest.mark.unit
+class TestBaseScraperRawBreedPreservation:
+    """process_animal() must not destroy the organization's original breed string."""
+
+    @pytest.fixture
+    def scraper(self):
+        with patch("scrapers.base_scraper.psycopg2"):
+            scraper = ConcreteTestScraper(organization_id=1)
+            scraper.database_service = Mock()
+            scraper.conn = Mock()
+            scraper.cursor = Mock()
+            scraper.image_processing_service = Mock()
+            scraper.metrics_collector = Mock()
+            return scraper
+
+    def test_raw_breed_kept_when_standardization_rewrites_breed(self, scraper):
+        """The pre-standardization breed text survives in breed_raw."""
+        scraper.use_unified_standardization = True
+
+        processed = scraper.process_animal(
+            {
+                "name": "Buddy",
+                "breed": "Staffordshire Bull Terrier Cross",
+                "external_id": "dog-123",
+                "organization_id": 1,
+            }
+        )
+
+        assert processed["breed_raw"] == "Staffordshire Bull Terrier Cross"
+        assert processed["breed"] == "Staffordshire Bull Terrier Mix"
+        assert processed["breed_raw"] != processed["breed"]
+
+    def test_raw_breed_kept_when_breed_collapses_to_mixed_breed(self, scraper):
+        """Crossbreed -> Mixed Breed is the lossiest rewrite; raw must still survive."""
+        scraper.use_unified_standardization = True
+
+        processed = scraper.process_animal(
+            {
+                "name": "Nala",
+                "breed": "Crossbreed",
+                "external_id": "dog-456",
+                "organization_id": 1,
+            }
+        )
+
+        assert processed["breed_raw"] == "Crossbreed"
+        assert processed["breed"] == "Mixed Breed"
+
+    def test_raw_breed_none_when_organization_supplied_no_breed(self, scraper):
+        """A missing breed must not become the string 'Unknown' in breed_raw."""
+        scraper.use_unified_standardization = True
+
+        processed = scraper.process_animal(
+            {
+                "name": "Ghost",
+                "external_id": "dog-789",
+                "organization_id": 1,
+            }
+        )
+
+        assert processed["breed_raw"] is None
+        assert processed["breed"] == "Unknown"
+
+    def test_standardization_disabled_leaves_breed_untouched(self, scraper):
+        """With the flag off nothing rewrites breed, so it still holds the raw value."""
+        scraper.use_unified_standardization = False
+
+        processed = scraper.process_animal(
+            {
+                "name": "Max",
+                "breed": "Lurcher Cross",
+                "external_id": "dog-999",
+                "organization_id": 1,
+            }
+        )
+
+        assert processed["breed"] == "Lurcher Cross"

--- a/tests/services/test_animal_data_preparation.py
+++ b/tests/services/test_animal_data_preparation.py
@@ -163,3 +163,33 @@ class TestSanitizeProperties:
         parsed = json.loads(result)
         assert parsed["tags"] == ["goodboy", "playful"]
         assert "\x00" not in result
+
+
+@pytest.mark.unit
+class TestPrepareAnimalDataRawBreed:
+    """breed_raw must reach the insert layer so the original text is never lost."""
+
+    def test_breed_raw_passed_through_when_scraper_supplied_it(self):
+        animal_data = {
+            "name": "Luna",
+            "breed": "Mixed Breed",
+            "breed_raw": "Mischling",
+            "age_text": "2 years",
+        }
+        result = prepare_animal_data(animal_data)
+        assert result.breed_raw == "Mischling"
+
+    def test_breed_raw_falls_back_to_breed_when_absent(self):
+        """Without standardization, breed still holds the organization's own text."""
+        animal_data = {
+            "name": "Rex",
+            "breed": "Lurcher Cross",
+            "age_text": "4 years",
+        }
+        result = prepare_animal_data(animal_data)
+        assert result.breed_raw == "Lurcher Cross"
+
+    def test_breed_raw_none_when_no_breed_anywhere(self):
+        animal_data = {"name": "Ghost", "age_text": "1 year"}
+        result = prepare_animal_data(animal_data)
+        assert result.breed_raw is None

--- a/tests/services/test_database_service.py
+++ b/tests/services/test_database_service.py
@@ -219,3 +219,94 @@ class TestDatabaseServiceWithConnectionPool:
 
             assert result == (123, "Test Dog", datetime(2024, 1, 15))
             assert db_service.conn == mock_connection
+
+
+@pytest.mark.slow
+@pytest.mark.database
+class TestDatabaseServiceRawBreedPersistence:
+    """Both write paths must persist breed_raw or the original text is lost on disk."""
+
+    def _pooled_service(self, fetchone_side_effect):
+        from services.database_service import DatabaseService
+
+        mock_pool_service = Mock(spec=ConnectionPoolService)
+        mock_connection = Mock()
+        mock_cursor = Mock()
+
+        mock_context = Mock()
+        mock_context.__enter__ = Mock(return_value=mock_connection)
+        mock_context.__exit__ = Mock(return_value=None)
+        mock_pool_service.get_connection_context.return_value = mock_context
+        mock_connection.cursor.return_value = mock_cursor
+        mock_cursor.fetchone.side_effect = fetchone_side_effect
+
+        db_service = DatabaseService(
+            db_config={"host": "localhost", "user": "test", "database": "test_db"},
+            connection_pool=mock_pool_service,
+        )
+        return db_service, mock_cursor
+
+    def test_create_animal_inserts_breed_raw(self):
+        db_service, mock_cursor = self._pooled_service([(0,), (456,)])
+
+        db_service.create_animal(
+            {
+                "name": "New Dog",
+                "external_id": "new-123",
+                "organization_id": 1,
+                "breed": "Mixed Breed",
+                "breed_raw": "Crossbreed",
+                "age_text": "3 years",
+                "status": "available",
+            }
+        )
+
+        insert_call = next(c for c in mock_cursor.execute.call_args_list if "INSERT INTO animals" in c[0][0])
+        assert "breed_raw" in insert_call[0][0]
+        assert "Crossbreed" in insert_call[0][1]
+
+    def test_update_animal_persists_breed_raw(self):
+        from services.database_service import DatabaseService
+
+        mock_conn = Mock()
+        mock_cursor = Mock()
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.fetchone.return_value = (
+            "Old Dog",
+            "Mixed Breed",
+            "3 years",
+            "Male",
+            "http://img",
+            "available",
+            "Mixed Breed",
+            36,
+            48,
+            "Medium",
+            None,
+            "mixed",
+            "Mixed Breed",
+            None,
+            "mixed-breed",
+            "0.5",
+            None,
+        )
+
+        db_service = DatabaseService(db_config={"host": "localhost", "user": "test", "database": "test_db"})
+        db_service.conn = mock_conn
+
+        db_service.update_animal(
+            123,
+            {
+                "name": "Old Dog",
+                "breed": "Mixed Breed",
+                "breed_raw": "Crossbreed",
+                "age_text": "3 years",
+                "sex": "Male",
+                "primary_image_url": "http://img",
+                "status": "available",
+            },
+        )
+
+        update_call = next(c for c in mock_cursor.execute.call_args_list if "UPDATE animals" in c[0][0] and "SET" in c[0][0])
+        assert "breed_raw" in update_call[0][0]
+        assert "Crossbreed" in update_call[0][1]


### PR DESCRIPTION
## Problem

`process_animal` overwrites `animal_data["breed"]` with the standardized name before insert (`base_scraper.py:481` → `database_service.py:212`), so the organization's original string never reaches the database.

Measured on production: `breed = standardized_breed` for **1,581 of 1,608** available dogs with a breed. **744 dogs across 7 organizations** have no recoverable original text anywhere — including Tierschutzverein (380 dogs, the second-largest source). The six organizations that *do* still have it keep a copy in `properties.breed` by accident, not design.

Two consequences:

- `management/backfill_standardization.py:262` re-standardizes the already-standardized value, so improving the breed mapping can never repair existing rows — it only re-derives from its own prior output.
- Any future work on breed normalization is capped by input that no longer exists.

This is the precondition for the rest of the breed-normalizer work; nothing downstream is safely fixable while the input is being destroyed.

## Change

Capture the pre-standardization value into a new nullable `breed_raw` column, written on **both** write paths:

- `base_scraper.process_animal` — records the value after field normalization (trimmed, empty→`None`) and before standardization rewrites it
- `animal_data_preparation.prepare_animal_data` — carries it through, falling back to `breed` when absent (the value is already raw when standardization is off)
- `database_service` — persists on INSERT and UPDATE, and includes it in change detection

`breed` keeps its current normalized value. This PR is purely additive: no existing column changes meaning, and no read path is touched.

## Recovery

The migration backfills from `properties->>'breed'` (~888 rows). The remainder repopulates by scraping — `save_animal` runs `process_animal` on updates too, so every currently-listed dog gets `breed_raw` within one cron cycle. Dogs that delist before then are not recoverable, which is why this is worth landing promptly.

## Deployment ordering ⚠️

Both write paths reference `breed_raw`. **The migration must be applied to production before this merges**, or the next scraper run (Mon/Thu/Sat 15:00 UTC) fails on every animal.

The column is nullable and additive, so applying it early is harmless:

```
uv run alembic -c migrations/railway/alembic.ini upgrade head
```

Since #326 reconciled the revision graph, prod is at `45c123f68726` and `upgrade head` applies exactly `b3f7c9d1e204`. Note `start.sh` runs no migrations, so this is a manual step.

## Tests

8 new, all failing before the change:

- raw text survives when standardization rewrites `breed` (`Staffordshire Bull Terrier Cross` → `... Mix`)
- raw text survives the lossiest rewrite (`Crossbreed` → `Mixed Breed`)
- a missing breed yields `None`, not the string `"Unknown"`
- with standardization disabled, `breed` is left untouched
- `prepare_animal_data` passes through, falls back to `breed`, and yields `None` when absent
- INSERT and UPDATE both carry the column and the value

1525 backend tests pass, ruff and tsc clean.