### PR TITLE
fix(breeds): transliterate accents in breed slugs instead of dropping them

### DIFF
--- a/tests/utils/test_breed_utils.py
+++ b/tests/utils/test_breed_utils.py
@@ -1,0 +1,79 @@
+"""Tests for breed slug generation.
+
+Slugs become URL path segments on /breeds/[slug], so any character that
+survives into the output has to be safe there.
+"""
+
+import pytest
+
+from utils.breed_utils import generate_breed_slug
+
+
+@pytest.mark.unit
+class TestGenerateBreedSlugAscii:
+    """Accented and non-ASCII breed names must transliterate, not lose characters."""
+
+    @pytest.mark.parametrize(
+        ("breed", "expected"),
+        [
+            ("Galgo Español", "galgo-espanol"),
+            ("Schäferhundmix", "schaferhundmix"),
+            ("Vermutlich Grand Basset Griffon Vendéen", "vermutlich-grand-basset-griffon-vendeen"),
+            ("Pyrenäenberghund", "pyrenaenberghund"),
+            ("Rumänischer Hirtenhund", "rumanischer-hirtenhund"),
+            ("Labrador + Bretón Español Mix", "labrador-breton-espanol-mix"),
+        ],
+    )
+    def test_accents_transliterate_to_ascii(self, breed, expected):
+        assert generate_breed_slug(breed) == expected
+
+    def test_sharp_s_becomes_ss(self):
+        assert generate_breed_slug("Bayrischer Gebirgsschweißhund") == "bayrischer-gebirgsschweisshund"
+
+    @pytest.mark.parametrize(
+        "breed",
+        [
+            "Galgo Español",
+            'Mixed Breed "quoted“ name',
+            "​​spanischer Water Dog",
+            "Yugoslavian Shepherd Dog Â Sharplanina",
+            "Mixed Breed (körperbau Ist Der Eines Podencos)",
+        ],
+    )
+    def test_output_is_always_url_safe(self, breed):
+        """Only lowercase alphanumerics and single hyphens may reach a URL."""
+        slug = generate_breed_slug(breed)
+        assert slug.isascii(), f"non-ascii survived: {slug!r}"
+        assert all(c.islower() or c.isdigit() or c == "-" for c in slug), f"unsafe char in {slug!r}"
+        assert not slug.startswith("-") and not slug.endswith("-")
+        assert "--" not in slug
+
+    def test_quotes_are_stripped_not_passed_through(self):
+        assert generate_breed_slug('"mini“ Border Collie Mix') == "mini-border-collie-mix"
+
+    def test_zero_width_characters_removed(self):
+        assert generate_breed_slug("​​spanischer Water Dog") == "spanischer-water-dog"
+
+
+@pytest.mark.unit
+class TestGenerateBreedSlugUnchangedBehaviour:
+    """Existing ASCII behaviour must not regress."""
+
+    @pytest.mark.parametrize(
+        ("breed", "expected"),
+        [
+            ("Collie Mix", "collie-mix"),
+            ("German Shepherd", "german-shepherd"),
+            ("Jack Russell Terrier", "jack-russell-terrier"),
+            ("Staffordshire Bull Terrier", "staffordshire-bull-terrier"),
+            ("Mixed Breed", "mixed-breed"),
+        ],
+    )
+    def test_ascii_breeds_unchanged(self, breed, expected):
+        assert generate_breed_slug(breed) == expected
+
+    def test_empty_input_returns_empty_string(self):
+        assert generate_breed_slug("") == ""
+
+    def test_name_that_reduces_to_nothing_returns_empty_string(self):
+        assert generate_breed_slug("###") == ""

--- a/utils/breed_utils.py
+++ b/utils/breed_utils.py
@@ -1,6 +1,7 @@
 # utils/breed_utils.py
 
 import re
+import unicodedata
 
 
 def generate_breed_slug(primary_breed: str) -> str:
@@ -21,8 +22,10 @@ def generate_breed_slug(primary_breed: str) -> str:
     if not primary_breed:
         return ""
 
-    # Convert to lowercase
-    slug = primary_breed.lower()
+    # Casefold first so ligatures expand (German sharp s becomes "ss"), then
+    # decompose accents and drop the combining marks, leaving ASCII letters.
+    decomposed = unicodedata.normalize("NFKD", primary_breed.casefold())
+    slug = "".join(char for char in decomposed if not unicodedata.combining(char))
 
     # Handle special case of "Mix" suffix - preserve it with hyphen
     slug = re.sub(r"\s+mix$", "-mix", slug, flags=re.IGNORECASE)


### PR DESCRIPTION
## Problem

`generate_breed_slug` lowercases, then replaces everything outside `[a-z0-9-]` with a hyphen. Any accented character is therefore destroyed rather than transliterated:

```
"Galgo Español"  ->  "galgo-espa-ol"
```

Production carries **18 such mangled values**, and the damage isn't only accents:

| `primary_breed` | stored `breed_slug` |
|---|---|
| `Galgo Español` | `galgo-espa-ol` |
| `Galgo Español` | `galgo-español` ← raw `ñ` in a URL |
| `"mini“ Border Collie Mix` | `"mini“-border-collie-mix` ← literal quotes |
| `Bayrischer Gebirgsschweißhund …` | `bayrischer-gebirgsschwei-hund-…` |
| `​​spanischer Water Dog, …` | (leading zero-width spaces) |
| `Yugoslavian Shepherd Dog Â Sharplanina` | mojibake `Â` |

Note `Galgo Español` has **two different slugs**, so those dogs are split across two identities.

## Change

Casefold first so the German sharp s expands to `ss`, then NFKD-decompose and drop combining marks, leaving ASCII letters before the existing character filter runs. Six lines; the rest of the function is untouched.

Verified against every affected production value:

```
'Galgo Español'                        -> galgo-espanol
'Labrador + Bretón Español Mix'        -> labrador-breton-espanol-mix
'"mini“ Border Collie Mix'             -> mini-border-collie-mix
'Bayrischer Gebirgsschweißhund (…)'    -> bayrischer-gebirgsschweisshund-possibly-mixed-breed
'​​spanischer Water Dog, Perro de Aqua' -> spanischer-water-dog-perro-de-aqua
'Deutsche Schäferhündin'               -> deutsche-schaferhundin
```

## No URL changes

I checked this before assuming a redirect was needed. `/breeds/[slug]` resolves only against `qualifying_breeds` (15+ dogs) via `getBreedBySlug` and returns `null` otherwise, so every mangled slug currently 404s — `Galgo Español` has 6 available dogs. All 13 qualifying breeds are pure ASCII and their slugs are byte-identical before and after this change.

So this is preventive: it stops a broken URL appearing if one of these breeds crosses the threshold, which PR 6 (merging `Galgo` + `Galgo Español`) makes likely.

## Data repair

No backfill migration. `breed_slug` is written and change-detected on the update path, so stored slugs correct themselves on the next scrape — the same mechanism that repopulates `breed_raw` from #327.

## Tests

First tests for this function (there were none). 21 cases covering transliteration, URL safety as an invariant over real production inputs, quote/zero-width handling, and existing ASCII behaviour as a regression guard.

1546 backend tests pass, ruff clean.