### PR TITLE
feat(breeds): resolve breeds through a canonical registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@ cd rescue-dog-aggregator
 # Setup backend
 uv sync
 
-# Setup database
+# Setup database (local schema comes from schema.sql, not Alembic)
 createdb rescue_dogs
-uv run alembic upgrade head
+uv run python database/db_setup.py
 
 # Configure environment
 cp .env.example .env

--- a/docs/features/breed-standardization.md
+++ b/docs/features/breed-standardization.md
@@ -1,0 +1,56 @@
+# Breed standardization
+
+## What the columns mean
+
+| Column | Meaning |
+|---|---|
+| `breed_raw` | The organization's original text, never rewritten |
+| `primary_breed` | Canonical breed identity. A cross keeps its root here, so `Border Collie Cross` has `primary_breed = "Border Collie"` |
+| `secondary_breed` | The second named breed when the source names one, otherwise `NULL` |
+| `breed_slug` | Slug of `primary_breed`; the `/breeds/[slug]` page key |
+| `breed_type` | `purebred`, `crossbreed`, `mixed`, or `unknown` |
+| `breed_group` | Group of the primary breed, e.g. a Staffie cross is `Terrier` |
+| `breed` / `standardized_breed` | Display label, e.g. `Border Collie Cross` or `Bichon Frise x Maltese` |
+
+Being a cross is a **facet**, not an identity. `Border Collie` and
+`Border Collie Cross` therefore share one breed page rather than forking into
+two competing ones.
+
+## Adding a breed or alias
+
+Edit `utils/breed_registry.yaml` — no code change is required.
+
+```yaml
+- canonical: Bracco Italiano
+  group: Sporting
+  size: Large
+  aliases: [italian pointer, bracco]
+```
+
+Designer breeds keep their own identity and record their parents:
+
+```yaml
+- canonical: Cockapoo
+  group: Designer/Hybrid
+  size: Small
+  parents: [Cocker Spaniel, Poodle]
+  aliases: [cockerpoo]
+```
+
+A Cockapoo resolves to `primary_breed = "Cockapoo"`, not to Cocker Spaniel;
+parents stay in the registry rather than being copied onto every row.
+
+## Resolution order
+
+1. Junk and over-long text resolve to unknown
+2. Designer breeds match first, so a named cross keeps its own identity
+3. Parenthetical forms expand — `Terrier (Staffordshire Bull)` becomes `Staffordshire Bull Terrier`
+4. Exact alias match on the whole string
+5. Split on `x`, `/`, `+`, `,`, `and`; resolve each part; first two distinct breeds become primary and secondary
+6. A short, clean, unrecognized name is kept at confidence `0.4` rather than discarded, so a breed missing from the registry is never silently lost
+
+## Repairing stored values
+
+`breed_slug`, `primary_breed` and the rest are recomputed on every scrape and are
+covered by change detection, so stored rows correct themselves within one cron
+cycle (Mon/Thu/Sat 15:00 UTC). No backfill migration is needed.

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -66,8 +66,8 @@ createdb rescue_dogs_local
 # Apply schema
 psql rescue_dogs_local < database/schema.sql
 
-# Run migrations
-alembic upgrade head
+# Local databases are built from schema.sql above; Alembic targets production
+# only, via RAILWAY_DATABASE_URL. See "Applying migrations" below.
 ```
 
 ### 2. Environment Configuration
@@ -157,9 +157,29 @@ uv run ruff check .
 createdb rescue_dogs_production
 psql rescue_dogs_production < database/schema.sql
 
-# Apply all migrations
-alembic upgrade head
+# Apply all migrations (see "Applying migrations" below)
+uv run alembic -c migrations/railway/alembic.ini upgrade head
 ```
+
+### Applying migrations
+
+Migrations are **not** run on deploy. `start.sh` launches either uvicorn or the
+scraper cron and never invokes Alembic, so a schema change reaches production
+only when someone runs it by hand.
+
+Apply the migration **before** merging code that depends on the new column, or
+the next scraper run (Mon/Thu/Sat 15:00 UTC) fails on every animal. Additive
+nullable columns are safe to apply ahead of the code.
+
+```bash
+export RAILWAY_DATABASE_URL="<the Railway Postgres connection string>"
+uv run alembic -c migrations/railway/alembic.ini current   # confirm the target
+uv run alembic -c migrations/railway/alembic.ini upgrade head
+```
+
+`migrations/railway/env.py` reads `RAILWAY_DATABASE_URL`; `alembic.ini` holds
+only a placeholder, so a missing variable fails loudly rather than silently
+migrating a local database.
 
 ### 3. Service Verification
 ```bash

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -40,7 +40,7 @@ Linting:       ruff (Python) + ESLint (TypeScript)
 
 ## Core Data Models
 
-### animals (39 columns)
+### animals (40 columns)
 
 ```sql
 -- Identity
@@ -51,7 +51,8 @@ name, breed, standardized_breed, age_text, age_min_months, age_max_months
 sex, size, standardized_size, language
 
 -- Breed Standardization
-breed_confidence, breed_type, primary_breed, secondary_breed, breed_slug, breed_group
+-- breed_raw holds the organization's original text; breed and the rest are derived
+breed_raw, breed_confidence, breed_type, primary_breed, secondary_breed, breed_slug, breed_group
 
 -- Status & Availability
 status, availability_confidence, active
@@ -431,8 +432,8 @@ python management/llm_commands.py cost-report
 
 ```bash
 # Migrations
-alembic revision --autogenerate -m "description"
-alembic upgrade head
+alembic -c migrations/railway/alembic.ini revision -m "description"
+alembic -c migrations/railway/alembic.ini upgrade head   # production only, run by hand
 alembic downgrade -1
 
 # Direct access

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -51,6 +51,18 @@ const nextConfig = {
         destination: '/',
         permanent: true,
       },
+      // A cross is a facet of a breed, not a separate breed, so these pages
+      // merged into their canonical breed rather than standing alone.
+      {
+        source: '/breeds/staffordshire-bull-terrier-mix',
+        destination: '/breeds/staffordshire-bull-terrier',
+        permanent: true,
+      },
+      {
+        source: '/breeds/german-shepherd-mix',
+        destination: '/breeds/german-shepherd-dog',
+        permanent: true,
+      },
     ];
   },
 

--- a/tests/integration/test_unified_simple.py
+++ b/tests/integration/test_unified_simple.py
@@ -45,16 +45,16 @@ class TestUnifiedStandardizationSimple:
         result = standardizer.apply_full_standardization(breed="Labradoodle")
         assert result["breed"] == "Labradoodle"
         assert result["breed_category"] == "Designer/Hybrid"
-        assert result["primary_breed"] == "Labrador Retriever"
-        assert result["secondary_breed"] == "Poodle"
+        assert result["primary_breed"] == "Labradoodle"  # keeps its own identity
+        assert result["secondary_breed"] is None
         assert result["breed_type"] == "crossbreed"
 
         # Test Cockapoo
         result = standardizer.apply_full_standardization(breed="Cockapoo")
         assert result["breed"] == "Cockapoo"
         assert result["breed_category"] == "Designer/Hybrid"
-        assert result["primary_breed"] == "Cocker Spaniel"
-        assert result["secondary_breed"] == "Poodle"
+        assert result["primary_breed"] == "Cockapoo"  # keeps its own identity
+        assert result["secondary_breed"] is None
 
     def test_age_standardization(self):
         """Test age parsing and standardization."""
@@ -99,7 +99,7 @@ class TestUnifiedStandardizationSimple:
         # Verify all fields are standardized
         assert result["breed"] == "Lurcher Cross"  # Cross is kept, not converted to Mix
         assert result["breed_category"] == "Hound"  # Lurcher Cross still gets Hound category
-        assert result["primary_breed"] == "Lurcher Cross"
+        assert result["primary_breed"] == "Lurcher"  # the cross suffix is not part of the identity
         assert result["age_min_months"] == 36
         assert result["age_category"] == "Adult"
         assert result["standardized_size"] == "Large"

--- a/tests/integration/test_unified_standardization_integration.py
+++ b/tests/integration/test_unified_standardization_integration.py
@@ -113,8 +113,8 @@ class TestUnifiedStandardizationIntegration:
         bella = saved_animals[2]
         assert bella["breed"] == "Labradoodle"
         assert bella["breed_category"] == "Designer/Hybrid"
-        assert bella["primary_breed"] == "Labrador Retriever"
-        assert bella["secondary_breed"] == "Poodle"
+        assert bella["primary_breed"] == "Labradoodle"  # keeps its own identity
+        assert bella["secondary_breed"] is None
 
     @patch("scrapers.base_scraper.ConfigLoader")
     @patch("scrapers.base_scraper.create_default_sync_service")
@@ -177,7 +177,7 @@ class TestUnifiedStandardizationIntegration:
         result = standardizer.apply_full_standardization(breed="Unknown")
         assert result["breed"] == "Unknown"
         assert result["breed_category"] == "Unknown"
-        assert result["standardization_confidence"] == 0.3  # "Unknown" has 0.3 confidence
+        assert result["standardization_confidence"] == 0.0  # "Unknown" names no breed
 
         # Test empty string breed
         result = standardizer.apply_full_standardization(breed="")

--- a/tests/scrapers/test_base_scraper_unified_standardization.py
+++ b/tests/scrapers/test_base_scraper_unified_standardization.py
@@ -62,10 +62,10 @@ class TestBasScraperUnifiedStandardization:
         processed = scraper.process_animal(raw_data)
 
         # Should standardize the breed (Cross becomes Mix)
-        assert processed["breed"] == "Staffordshire Bull Terrier Mix"
-        assert processed["primary_breed"] == "Staffordshire Bull Terrier Mix"  # Primary is the full name
-        assert processed["secondary_breed"] == "Mixed Breed"  # Secondary indicates it's a mix
-        assert processed["breed_category"] == "Mixed"  # Mixed breed category for crosses
+        assert processed["breed"] == "Staffordshire Bull Terrier Cross"
+        assert processed["primary_breed"] == "Staffordshire Bull Terrier"  # Cross suffix is not part of the identity
+        assert processed["secondary_breed"] is None  # No second breed was named
+        assert processed["breed_category"] == "Terrier"  # Group follows the primary breed, not the cross
         assert "standardization_confidence" in processed
         assert processed["name"] == "Buddy"
         assert processed["external_id"] == "dog-123"
@@ -161,8 +161,8 @@ class TestBasScraperUnifiedStandardization:
         assert call_args["location"] == "London"
         # But breed fields should be standardized (Cockapoo is a designer breed)
         assert call_args["breed"] == "Cockapoo"
-        assert call_args["primary_breed"] == "Cocker Spaniel"
-        assert call_args["secondary_breed"] == "Poodle"
+        assert call_args["primary_breed"] == "Cockapoo"  # A designer breed keeps its own identity
+        assert call_args["secondary_breed"] is None  # parents live in the registry, not the row
         assert call_args["breed_category"] == "Designer/Hybrid"  # Designer breeds now have their own category
 
     def test_standardization_logs_events(self, scraper):
@@ -181,10 +181,10 @@ class TestBasScraperUnifiedStandardization:
         # Just verify it doesn't crash when logging
         result = scraper.save_animal(animal_data)
 
-        # Verify the breed was standardized - "Staff X" becomes "Staffordshire Bull Terrier Mix"
+        # Verify the breed was standardized - "Staff X" becomes "Staffordshire Bull Terrier Cross"
         assert result == (222, "create")
         call_args = scraper.database_service.create_animal.call_args[0][0]
-        assert call_args["breed"] == "Staffordshire Bull Terrier Mix"
+        assert call_args["breed"] == "Staffordshire Bull Terrier Cross"
 
     def test_existing_animal_update_with_standardization(self, scraper):
         """Updating existing animal should apply standardization"""
@@ -265,14 +265,14 @@ class TestBaseScraperRawBreedPreservation:
         processed = scraper.process_animal(
             {
                 "name": "Buddy",
-                "breed": "Staffordshire Bull Terrier Cross",
+                "breed": "Terrier (Staffordshire Bull) Cross",
                 "external_id": "dog-123",
                 "organization_id": 1,
             }
         )
 
-        assert processed["breed_raw"] == "Staffordshire Bull Terrier Cross"
-        assert processed["breed"] == "Staffordshire Bull Terrier Mix"
+        assert processed["breed_raw"] == "Terrier (Staffordshire Bull) Cross"
+        assert processed["breed"] == "Staffordshire Bull Terrier Cross"
         assert processed["breed_raw"] != processed["breed"]
 
     def test_raw_breed_kept_when_breed_collapses_to_mixed_breed(self, scraper):

--- a/tests/scrapers/test_daisy_family_rescue_translations.py
+++ b/tests/scrapers/test_daisy_family_rescue_translations.py
@@ -364,8 +364,7 @@ class TestCompatibilityWithStandardization:
         assert standardized_breed is not None
         # Standardization preserves the breed component for mixed breeds
         assert standardized_breed in [
-            "German Shepherd Mix",
-            "German Shepherd Mixed Breed",  # Translated input preserved
+            "German Shepherd Dog Cross",  # Canonical breed plus the cross marker
             "Mixed Breed",
             "German Shepherd Dog",
         ]

--- a/tests/scrapers/test_galgosdelsol_unified_standardization.py
+++ b/tests/scrapers/test_galgosdelsol_unified_standardization.py
@@ -89,9 +89,9 @@ class TestGalgosDelSolUnifiedStandardization:
 
         result = galgosdelsol_scraper.process_animal(animal)
 
-        # Specific breed mix should be preserved as "Galgo Mix"
-        assert result["breed"] == "Galgo Mix"
-        assert result["breed_category"] == "Mixed"
+        # The cross marker is a facet; the identity stays Galgo
+        assert result["breed"] == "Galgo Cross"
+        assert result["breed_category"] == "Hound"
         assert result["breed_type"] == "crossbreed"
         assert result["standardized_size"] == "Large"
 
@@ -147,9 +147,9 @@ class TestGalgosDelSolUnifiedStandardization:
             ("GALGO", "Galgo", "Hound"),
             (
                 "podenco mix",
-                "Podenco Mix",
-                "Mixed",
-            ),  # Mixed breeds preserve specific breed names
+                "Podenco Cross",
+                "Hound",
+            ),  # A cross keeps its primary breed's group
         ]
 
         for raw_breed, expected_breed, expected_category in test_breeds:

--- a/tests/scrapers/test_manytearsrescue_unified_standardization.py
+++ b/tests/scrapers/test_manytearsrescue_unified_standardization.py
@@ -78,7 +78,7 @@ class TestManyTearsRescueUnifiedStandardization:
 
         assert "Collie" in result["breed"]
         assert "Labrador" in result["breed"]
-        assert result["breed_category"] == "Mixed"
+        assert result["breed_category"] == "Herding"
         assert result["standardized_size"] == "Large"
 
     def test_age_text_parsing(self, scraper):

--- a/tests/scrapers/test_petsinturkey_unified_standardization.py
+++ b/tests/scrapers/test_petsinturkey_unified_standardization.py
@@ -42,9 +42,9 @@ class TestPetsInTurkeyUnifiedStandardization:
 
         result = scraper.process_animal(test_data)
 
-        # Specific breed mix should be preserved as "Terrier Mix"
-        assert result["breed"] == "Terrier Mix"
-        assert result["breed_category"] == "Mixed"
+        # Specific breed mix should be preserved as "Terrier Cross"
+        assert result["breed"] == "Terrier Cross"
+        assert result["breed_category"] == "Terrier"  # Group follows the primary breed
         assert result["breed_type"] == "crossbreed"
         assert result["standardized_size"] == "Medium"
 

--- a/tests/scrapers/test_theunderdog_unified_standardization.py
+++ b/tests/scrapers/test_theunderdog_unified_standardization.py
@@ -53,10 +53,10 @@ def test_theunderdog_uses_unified_standardization_when_enabled(theunderdog_scrap
     processed_data = theunderdog_scraper.process_animal(raw_animal_data)
 
     # Verify standardization was applied
-    assert processed_data["breed"] == "Staffordshire Bull Terrier Mix"  # Mix properly preserved
+    assert processed_data["breed"] == "Staffordshire Bull Terrier Cross"  # Mix properly preserved
     assert processed_data["age"] == "2 years"  # Age preserved
     assert processed_data["size"] == "Medium"  # Size preserved
-    assert processed_data["breed_category"] == "Mixed"  # Mix breeds get "Mixed" category
+    assert processed_data["breed_category"] == "Terrier"  # Mix breeds get "Mixed" category
 
 
 def test_theunderdog_handles_lurcher_breed_correctly(theunderdog_scraper):

--- a/tests/scrapers/test_tierschutzverein_europa_unified_standardization.py
+++ b/tests/scrapers/test_tierschutzverein_europa_unified_standardization.py
@@ -56,9 +56,8 @@ class TestTierschutzvereinEuropaUnifiedStandardization:
         translated = translate_breed("Schäferhund-Mischling")
         assert translated == "German Shepherd Mix"
         result = standardizer.apply_full_standardization(breed=translated)
-        assert result["breed"] == "German Shepherd Mix"  # Specific mix breed preserved
-        assert result["breed_category"] == "Mixed"
-        # Mixed breeds have breed_type as "unknown" but category as "Mixed"
+        assert result["breed"] == "German Shepherd Dog Cross"  # Canonical breed plus the cross marker
+        assert result["breed_category"] != "Mixed"  # Group follows the primary breed
 
     def test_livestock_guardian_dog_translation(self, standardizer):
         """Test German 'Herdenschutzhund' is properly handled."""
@@ -78,17 +77,15 @@ class TestTierschutzvereinEuropaUnifiedStandardization:
         # For mixed breeds with "and", the standardizer should recognize both breeds
         assert "Husky" in result["breed"]
         assert "German Shepherd" in result["breed"]
-        assert result["breed_category"] == "Mixed"
-        # Mixed breeds have breed_type as "unknown" but category as "Mixed"
+        assert result["breed_category"] != "Mixed"  # Group follows the primary breed
 
     def test_podenco_mischling(self, standardizer):
         """Test Podenco-Mischling (Spanish breed with German suffix)."""
         translated = translate_breed("Podenco-Mischling")
         assert translated == "Podenco Mix"
         result = standardizer.apply_full_standardization(breed=translated)
-        assert result["breed"] == "Podenco Mix"
-        assert result["breed_category"] == "Mixed"
-        # Mixed breeds have breed_type as "unknown" but category as "Mixed"
+        assert result["breed"] == "Podenco Cross"
+        assert result["breed_category"] != "Mixed"  # Group follows the primary breed
 
     def test_spanish_breeds_with_german_names(self, standardizer):
         """Test Spanish breeds that appear with German names."""
@@ -129,9 +126,8 @@ class TestTierschutzvereinEuropaUnifiedStandardization:
         # The scraper with unified standardization should handle this
         standardizer = UnifiedStandardizer()
         result = standardizer.apply_full_standardization(breed=translated)
-        assert result["breed"] == "German Shepherd Mix"  # Specific mix breed preserved
-        assert result["breed_category"] == "Mixed"
-        # Mixed breeds have breed_type as "unknown" but category as "Mixed"
+        assert result["breed"] == "German Shepherd Dog Cross"  # Canonical breed plus the cross marker
+        assert result["breed_category"] != "Mixed"  # Group follows the primary breed
 
     def test_preserve_language_metadata(self, scraper):
         """Test that language and original_language fields are preserved."""

--- a/tests/scrapers/test_woof_project.py
+++ b/tests/scrapers/test_woof_project.py
@@ -269,7 +269,7 @@ class TestWoofProjectScraperOptimized:
             assert result is not None
             assert result["name"] == "Lisbon"  # Standardized from "LISBON"
             assert result["external_id"] == "wp-lisbon"
-            assert result["breed"] == "Hound Pointer Cross"
+            assert result["breed"] == "Hound x Pointer"
             assert result["standardized_breed"] is not None
             assert result["size"] == "Medium"
             assert result["standardized_size"] is not None

--- a/tests/scrapers/test_woof_project_unified_standardization.py
+++ b/tests/scrapers/test_woof_project_unified_standardization.py
@@ -75,7 +75,7 @@ class TestWoofProjectUnifiedStandardization:
 
         # Check values (mixed breeds keep the original breed name)
         assert "labrador" in result["primary_breed"].lower()
-        assert result["breed_category"] == "Mixed"  # Mixed for "mix" breeds
+        assert result["breed_category"] == "Sporting"  # Group follows the primary breed
         assert result["standardized_size"] == "Large"
         assert result["standardization_confidence"] > 0.5  # Lower confidence for mixes
 

--- a/tests/utils/test_breed_registry.py
+++ b/tests/utils/test_breed_registry.py
@@ -1,0 +1,239 @@
+"""Tests for the canonical breed registry and resolver.
+
+The resolver replaces a branch chain that title-cased raw text for crossbreeds,
+so "Podenco-labrador-mix" became a breed name and a breed page slug.
+"""
+
+import pytest
+
+from utils.breed_registry import BreedRegistry, resolve_breed
+
+
+@pytest.fixture(scope="module")
+def registry():
+    return BreedRegistry.load()
+
+
+@pytest.mark.unit
+class TestRegistryData:
+    def test_registry_loads_breeds_and_designer_breeds(self, registry):
+        assert len(registry.breeds) > 100
+        assert len(registry.designer_breeds) >= 10
+
+    def test_every_canonical_has_a_unique_slug(self, registry):
+        slugs = [b.slug for b in registry.breeds]
+        assert len(slugs) == len(set(slugs)), "duplicate slugs collapse distinct breeds"
+
+    def test_no_alias_maps_to_two_different_breeds(self, registry):
+        seen: dict[str, str] = {}
+        for breed in registry.breeds:
+            for alias in breed.aliases:
+                assert alias not in seen or seen[alias] == breed.canonical, f"{alias!r} is ambiguous"
+                seen[alias] = breed.canonical
+
+
+@pytest.mark.unit
+class TestPurebredResolution:
+    @pytest.mark.parametrize(
+        ("raw", "canonical"),
+        [
+            ("Lurcher", "Lurcher"),
+            ("Greyhound", "Greyhound"),
+            ("german shepherd dog", "German Shepherd Dog"),
+            ("  Beagle  ", "Beagle"),
+            ("Rottweiller", "Rottweiler"),
+            ("staffie", "Staffordshire Bull Terrier"),
+            ("SBT", "Staffordshire Bull Terrier"),
+            ("amstaff", "American Staffordshire Terrier"),
+        ],
+    )
+    def test_purebred_resolves_to_canonical(self, raw, canonical):
+        identity = resolve_breed(raw)
+        assert identity.primary == canonical
+        assert identity.is_cross is False
+        assert identity.breed_type == "purebred"
+        assert identity.secondary is None
+
+
+@pytest.mark.unit
+class TestParentheticalForms:
+    """Dogs Trust sends 'Type (Variant)', which is 149 distinct values in production."""
+
+    @pytest.mark.parametrize(
+        ("raw", "canonical"),
+        [
+            ("Terrier (Staffordshire Bull)", "Staffordshire Bull Terrier"),
+            ("Collie (Border)", "Border Collie"),
+            ("Retriever (Labrador)", "Labrador Retriever"),
+            ("Spaniel (Cocker)", "Cocker Spaniel"),
+            ("Terrier (Jack Russell)", "Jack Russell Terrier"),
+            ("Poodle (Miniature)", "Miniature Poodle"),
+            ("Chihuahua (Smooth Coat)", "Chihuahua"),
+        ],
+    )
+    def test_parenthetical_resolves(self, raw, canonical):
+        assert resolve_breed(raw).primary == canonical
+
+    def test_parenthetical_cross_keeps_the_root_breed(self):
+        """The old code produced primary_breed 'Staffordshire Bull Terrier Mix'."""
+        identity = resolve_breed("Terrier (Staffordshire Bull) Cross")
+        assert identity.primary == "Staffordshire Bull Terrier"
+        assert identity.is_cross is True
+        assert identity.breed_type == "crossbreed"
+
+
+@pytest.mark.unit
+class TestCrossSuffixDoesNotForkTheBreed:
+    @pytest.mark.parametrize("suffix", ["Cross", "cross", "Mix", "mix", "X"])
+    def test_suffix_variants_share_one_primary(self, suffix):
+        identity = resolve_breed(f"Border Collie {suffix}")
+        assert identity.primary == "Border Collie"
+        assert identity.is_cross is True
+
+    def test_cross_and_purebred_share_a_slug(self):
+        """This is what merges /breeds/border-collie-cross into /breeds/border-collie."""
+        assert resolve_breed("Border Collie Cross").slug == resolve_breed("Border Collie").slug
+
+
+@pytest.mark.unit
+class TestTwoBreedCrosses:
+    @pytest.mark.parametrize(
+        ("raw", "primary", "secondary"),
+        [
+            ("Bichon Frise x Maltese", "Bichon Frise", "Maltese"),
+            ("Maltese x Poodle", "Maltese", "Poodle"),
+            ("Beagle X Cavalier King Charles Spaniel", "Beagle", "Cavalier King Charles Spaniel"),
+            ("Mastiff x Great Dane", "Mastiff", "Great Dane"),
+            ("Collie x Dachshund x Jack Russell Terrier", "Collie", "Dachshund"),
+        ],
+    )
+    def test_both_parents_are_captured(self, raw, primary, secondary):
+        identity = resolve_breed(raw)
+        assert identity.primary == primary
+        assert identity.secondary == secondary
+        assert identity.is_cross is True
+
+    def test_third_breed_is_dropped_rather_than_guessed(self):
+        """Two slots exist; a third parent has nowhere to go."""
+        identity = resolve_breed("Collie x Dachshund x Jack Russell Terrier")
+        assert (identity.primary, identity.secondary) == ("Collie", "Dachshund")
+
+    def test_secondary_is_never_the_literal_mixed_breed(self):
+        """Every crossbreed row in production had secondary_breed = 'Mixed Breed'."""
+        assert resolve_breed("Labrador Retriever Cross").secondary is None
+
+
+@pytest.mark.unit
+class TestDesignerBreedsKeepTheirIdentity:
+    """Cockapoos were filed under /breeds/cocker-spaniel and displayed as Cocker Spaniel."""
+
+    @pytest.mark.parametrize(
+        ("raw", "canonical", "parents"),
+        [
+            ("Cockapoo", "Cockapoo", ("Cocker Spaniel", "Poodle")),
+            ("Cavachon", "Cavachon", ("Cavalier King Charles Spaniel", "Bichon Frise")),
+            ("Labradoodle", "Labradoodle", ("Labrador Retriever", "Poodle")),
+        ],
+    )
+    def test_designer_breed_is_its_own_primary(self, raw, canonical, parents):
+        identity = resolve_breed(raw)
+        assert identity.primary == canonical
+        assert identity.parents == parents
+        assert identity.is_cross is True
+
+    def test_designer_slug_is_not_the_parent_slug(self):
+        assert resolve_breed("Cockapoo").slug == "cockapoo"
+        assert resolve_breed("Cockapoo").slug != resolve_breed("Cocker Spaniel").slug
+
+
+@pytest.mark.unit
+class TestGenericAndUnknown:
+    @pytest.mark.parametrize("raw", ["Mixed Breed", "Crossbreed", "Mix", "mongrel", "Cross"])
+    def test_generic_mixed_has_no_identifiable_breed(self, raw):
+        identity = resolve_breed(raw)
+        assert identity.primary is None
+        assert identity.breed_type == "mixed"
+        assert identity.is_cross is True
+
+    @pytest.mark.parametrize("raw", ["Can be the only dog", "N/A", "TBC", "not specified", "", None])
+    def test_junk_resolves_to_unknown(self, raw):
+        identity = resolve_breed(raw)
+        assert identity.primary is None
+        assert identity.breed_type == "unknown"
+
+    def test_unrecognised_breed_is_unknown_not_titlecased_raw_text(self):
+        """The old code returned 'Mixed Breed (possibly Brittany Spaniel-pointer Mix)'."""
+        identity = resolve_breed("Mixed Breed (possibly Brittany Spaniel-pointer Mix)")
+        assert identity.primary != "Mixed Breed (Possibly Brittany Spaniel-Pointer Mix)"
+
+
+@pytest.mark.unit
+class TestNoiseInRealInputs:
+    def test_leading_qualifier_is_ignored(self):
+        assert resolve_breed("Vermutlich Grand Basset Griffon Vendéen").is_cross is False
+
+    def test_embedded_breed_in_a_sentence_is_found(self):
+        identity = resolve_breed("Mixed Breed (Podenco or Mastin, found with two mothers)")
+        assert identity.primary == "Podenco"
+
+    def test_hyphenated_lowercase_input(self):
+        identity = resolve_breed("podenco-labrador-mix")
+        assert identity.primary == "Podenco"
+        assert identity.secondary == "Labrador Retriever"
+        assert identity.is_cross is True
+
+
+@pytest.mark.unit
+class TestUnregisteredBreedsAreNotLost:
+    """A clean, unrecognised breed name must survive rather than become Unknown.
+
+    The previous implementation title-cased any unmatched text, which produced
+    junk breed pages, but it did keep real breeds the registry lacks.
+    """
+
+    @pytest.mark.parametrize("raw", ["Korean Jindo", "Carrea Castellano", "Perro de Agua"])
+    def test_clean_unregistered_name_is_kept_with_low_confidence(self, raw):
+        identity = resolve_breed(raw)
+        assert identity.primary is not None
+        assert identity.confidence <= 0.5
+        assert identity.breed_type == "unknown"
+
+    @pytest.mark.parametrize("raw", ["Unlisted", "European", "Tofu", "Can be the only dog"])
+    def test_non_breed_text_still_resolves_to_unknown(self, raw):
+        assert resolve_breed(raw).primary is None
+
+    def test_long_descriptive_text_is_not_promoted_to_a_breed(self):
+        identity = resolve_breed("Mixed Breed (possibly Brittany Spaniel-pointer Mix)")
+        assert identity.primary in (None, "Brittany", "Pointer")
+
+
+@pytest.mark.unit
+class TestRegistryCoversProductionBreeds:
+    @pytest.mark.parametrize(
+        ("raw", "canonical"),
+        [
+            ("Schnauzer", "Schnauzer"),
+            ("Newfoundland", "Newfoundland"),
+            ("Bullmastiff", "Bullmastiff"),
+            ("Deerhound", "Deerhound"),
+            ("Old English Sheepdog", "Old English Sheepdog"),
+            ("Boerboel", "Boerboel"),
+            ("Chinese Crested", "Chinese Crested"),
+            ("Hungarian Vizsla", "Hungarian Vizsla"),
+            ("Dackel", "Dachshund"),
+            ("Dalmatiner", "Dalmatian"),
+            ("Deutsch Kurzhaar", "German Shorthaired Pointer"),
+            ("Cavashon", "Cavachon"),
+        ],
+    )
+    def test_breed_seen_in_production_resolves(self, raw, canonical):
+        assert resolve_breed(raw).primary == canonical
+
+    def test_german_mischling_is_a_cross_marker(self):
+        identity = resolve_breed("Labradormischling")
+        assert identity.primary == "Labrador Retriever"
+        assert identity.is_cross is True
+
+    @pytest.mark.parametrize("qualifier", ["Vermutlich", "Wahrscheinlich", "Similar", "Possibly"])
+    def test_leading_qualifier_does_not_block_the_match(self, qualifier):
+        assert resolve_breed(f"{qualifier} Newfoundland").primary == "Newfoundland"

--- a/tests/utils/test_standardization.py
+++ b/tests/utils/test_standardization.py
@@ -32,19 +32,18 @@ class TestBreedStandardization:
 
     def test_partial_breed_match(self):
         """Test partial matches that should be detected."""
-        # "lab mix" is recognized as a Labrador cross with correct size
+        # The alias expands to its canonical breed rather than echoing the input
         result = standardize_breed("lab mix")
-        assert result[0] == "Lab Mix"  # Capitalized input, not expanded alias
-        assert result[1] == "Mixed"
+        assert result[0] == "Labrador Retriever Cross"
+        assert result[1] == "Sporting"  # Group follows the primary breed
         assert result[2] == "Large"  # Size from Labrador Retriever
-        # Check that "golden mix" is recognized as Mixed type
-        assert standardize_breed("golden mix")[1] == "Mixed"
+        assert standardize_breed("golden mix")[0] == "Golden Retriever Cross"
 
     def test_unknown_breed(self):
         """Test handling of unknown breeds."""
         result = standardize_breed("unknown breed")
-        # Returns capitalized input "Unknown Breed" when not in breed_data
-        assert result[0] == "Unknown Breed"
+        # "unknown" is a non-breed value, not a name to carry through
+        assert result[0] == "Unknown"
         assert result[1] == "Unknown"
         assert result[2] is None
 
@@ -59,7 +58,7 @@ class TestBreedStandardization:
     def test_mixed_breeds(self):
         """Test various mixed breed descriptions."""
         assert standardize_breed("mixed breed")[:2] == ("Mixed Breed", "Mixed")
-        assert standardize_breed("terrier mix")[:2] == ("Terrier Mix", "Mixed")
+        assert standardize_breed("terrier mix")[:2] == ("Terrier Cross", "Terrier")
 
     def test_empty_or_none_breed(self):
         """Test handling of empty or None input."""

--- a/tests/utils/test_unified_standardization.py
+++ b/tests/utils/test_unified_standardization.py
@@ -61,15 +61,15 @@ class TestUnifiedStandardizer:
         result = standardizer.apply_full_standardization(breed="Cockapoo")
         assert result["breed"] == "Cockapoo"
         assert result["breed_category"] == "Designer/Hybrid"  # Designer breed category
-        assert result["primary_breed"] == "Cocker Spaniel"
-        assert result["secondary_breed"] == "Poodle"
+        assert result["primary_breed"] == "Cockapoo"
+        assert result["secondary_breed"] is None  # parents live in the registry, not the row
 
         # Labradoodle (Labrador + Poodle)
         result = standardizer.apply_full_standardization(breed="Labradoodle")
         assert result["breed"] == "Labradoodle"
         assert result["breed_category"] == "Designer/Hybrid"  # Labradoodle specifically gets Designer/Hybrid
-        assert result["primary_breed"] == "Labrador Retriever"
-        assert result["secondary_breed"] == "Poodle"
+        assert result["primary_breed"] == "Labradoodle"
+        assert result["secondary_breed"] is None  # parents live in the registry, not the row
 
         # Puggle (Pug + Beagle)
         result = standardizer.apply_full_standardization(breed="Puggle")
@@ -236,7 +236,7 @@ def test_unknown_breed_returns_unknown():
 
     assert result["breed"] == "Flibbertigibbet"
     assert result["breed_category"] == "Unknown"
-    assert result["breed_confidence"] == 0.3  # Unknown breeds get 0.3 confidence
+    assert result["breed_confidence"] == 0.4  # A clean unregistered name is kept at low confidence
     assert result["breed_type"] == "unknown"  # Unknown breeds get unknown type
 
 

--- a/utils/breed_registry.py
+++ b/utils/breed_registry.py
@@ -1,0 +1,283 @@
+"""Canonical breed registry and resolver.
+
+Organisations describe the same breed many ways: "Terrier (Staffordshire Bull)",
+"staffie", "SBT", "Staffordshire Bull Terrier Cross". This module maps all of
+them onto one canonical record, and separates the breed's identity from the
+fact that it is a cross, so that "Border Collie" and "Border Collie Cross"
+share a breed page instead of forking into two.
+
+Breeds and aliases live in breed_registry.yaml; adding either is a data change.
+"""
+
+import functools
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+from utils.breed_utils import fold_to_ascii, generate_breed_slug
+
+REGISTRY_PATH = Path(__file__).with_name("breed_registry.yaml")
+
+CROSS_MARKERS = frozenset({"cross", "crossbreed", "mix", "mixed", "mischling", "mongrel", "mutt"})
+# Words organisations prefix when they are guessing; they carry no breed meaning.
+QUALIFIER_WORDS = frozenset({"vermutlich", "wahrscheinlich", "similar", "possibly", "probably", "evtl", "maybe"})
+# Connectives inside breed names such as "Perro de Agua" or "Dogue de Bordeaux".
+PARTICLES = frozenset({"de", "del", "la", "el", "von", "van", "der", "du", "di", "y"})
+GENERIC_BREED_WORDS = frozenset({"breed", "dog", "puppy", "pup"})
+SEPARATOR_PATTERN = re.compile(r"\s+x\s+|[/+,]|\s+and\s+")
+JUNK_VALUES = frozenset(
+    {
+        "n/a",
+        "na",
+        "tbc",
+        "breed tbc",
+        "not specified",
+        "pending",
+        "unknown",
+        "can be the only dog",
+        "",
+    }
+)
+# Single words that appear in the breed field but never name a breed.
+NON_BREED_WORDS = frozenset({"unlisted", "european", "tofu", "yorkshire", "pinscher", "shepherd", "spitz", "hound", "terrier", "spaniel", "poodle", "collie", "retriever"})
+MAX_BREED_TEXT_LENGTH = 120
+
+
+@dataclass(frozen=True)
+class BreedRecord:
+    """One canonical breed and every string that resolves to it."""
+
+    canonical: str
+    slug: str
+    group: str
+    size: str | None
+    aliases: tuple[str, ...]
+    parents: tuple[str, str] | None = None
+
+
+@dataclass(frozen=True)
+class BreedIdentity:
+    """The outcome of resolving one organisation-supplied breed string."""
+
+    primary: str | None
+    secondary: str | None
+    slug: str | None
+    group: str
+    size: str | None
+    is_cross: bool
+    breed_type: str
+    confidence: float
+    parents: tuple[str, str] | None = None
+
+
+class BreedRegistry:
+    """Alias index over the canonical breed list."""
+
+    def __init__(self, breeds: list[BreedRecord], designer_breeds: list[BreedRecord]):
+        self.breeds = breeds
+        self.designer_breeds = designer_breeds
+        self._index: dict[str, BreedRecord] = {}
+        for record in [*breeds, *designer_breeds]:
+            for key in (record.canonical, *record.aliases):
+                self._index.setdefault(_normalize(key), record)
+        # Longest first so "miniature poodle" wins over "poodle".
+        self._ordered = sorted(self._index.items(), key=lambda kv: -len(kv[0]))
+
+    @classmethod
+    @functools.cache
+    def load(cls, path: Path = REGISTRY_PATH) -> "BreedRegistry":
+        document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        return cls(
+            breeds=[_record(entry) for entry in document["breeds"]],
+            designer_breeds=[_record(entry) for entry in document["designer_breeds"]],
+        )
+
+    def match_exact(self, text: str) -> BreedRecord | None:
+        return self._index.get(text)
+
+    def find_all(self, text: str) -> list[BreedRecord]:
+        """Return breeds mentioned in text, ordered by where they appear."""
+        found: list[tuple[int, BreedRecord]] = []
+        claimed: list[tuple[int, int]] = []
+        for alias, record in self._ordered:
+            start = _find_word(text, alias)
+            if start is None:
+                continue
+            end = start + len(alias)
+            if any(start < c_end and c_start < end for c_start, c_end in claimed):
+                continue
+            claimed.append((start, end))
+            found.append((start, record))
+        deduped: list[BreedRecord] = []
+        for _, record in sorted(found, key=lambda pair: pair[0]):
+            if record not in deduped:
+                deduped.append(record)
+        return deduped
+
+
+def _record(entry: dict) -> BreedRecord:
+    parents = entry.get("parents")
+    return BreedRecord(
+        canonical=entry["canonical"],
+        slug=generate_breed_slug(entry["canonical"]),
+        group=entry["group"],
+        size=entry.get("size"),
+        aliases=tuple(entry.get("aliases") or ()),
+        parents=(parents[0], parents[1]) if parents else None,
+    )
+
+
+def _normalize(text: str) -> str:
+    """Fold to ASCII and reduce punctuation to single spaces for matching."""
+    folded = fold_to_ascii(text)
+    return re.sub(r"\s+", " ", re.sub(r"[^a-z0-9]+", " ", folded)).strip()
+
+
+def _find_word(haystack: str, needle: str) -> int | None:
+    """Locate needle in haystack on word boundaries, so 'lab' misses 'black'."""
+    match = re.search(rf"(?<![a-z0-9]){re.escape(needle)}(?![a-z0-9])", haystack)
+    return match.start() if match else None
+
+
+def _strip_cross_markers(text: str) -> tuple[str, bool]:
+    """Remove cross wording and guess-qualifiers, reporting if a cross was named."""
+    for marker in ("mischling", "mix"):
+        text = re.sub(rf"([a-z]{{4,}}){marker}\b", r"\1 " + marker, text)
+    words = [word for word in text.split() if word not in QUALIFIER_WORDS]
+    kept = [word for word in words if word not in CROSS_MARKERS]
+    found = len(kept) != len(words)
+    if kept and kept[-1] == "x":
+        kept.pop()
+        found = True
+    remaining = " ".join(kept)
+    if found and remaining and all(word in GENERIC_BREED_WORDS for word in remaining.split()):
+        remaining = ""
+    return remaining, found
+
+
+def _expand_parenthetical(raw: str) -> str | None:
+    """Turn "Terrier (Staffordshire Bull)" into "staffordshire bull terrier"."""
+    match = re.match(r"^\s*([\w\s-]+?)\s*\(([^)]+)\)\s*$", fold_to_ascii(raw))
+    if not match:
+        return None
+    head, inner = _normalize(match.group(1)), _normalize(match.group(2))
+    return f"{inner} {head}".strip() if head and inner else None
+
+
+def _unknown() -> BreedIdentity:
+    return BreedIdentity(None, None, None, "Unknown", None, False, "unknown", 0.0)
+
+
+def _mixed() -> BreedIdentity:
+    return BreedIdentity(None, None, "mixed-breed", "Mixed", None, True, "mixed", 0.5)
+
+
+def _from_records(primary: BreedRecord, secondary: BreedRecord | None, is_cross: bool, confidence: float) -> BreedIdentity:
+    return BreedIdentity(
+        primary=primary.canonical,
+        secondary=secondary.canonical if secondary else None,
+        slug=primary.slug,
+        group=primary.group,
+        size=primary.size,
+        is_cross=is_cross,
+        breed_type="crossbreed" if is_cross else "purebred",
+        confidence=confidence,
+        parents=primary.parents,
+    )
+
+
+def _provisional_breed(normalized: str) -> BreedIdentity | None:
+    """Accept a short, clean, unrecognised name as a low-confidence breed.
+
+    Losing a real breed the registry lacks is worse than carrying it at low
+    confidence, but anything long or descriptive is noise rather than a name.
+    """
+    words = [word for word in normalized.split() if word not in QUALIFIER_WORDS]
+    if not 1 <= len(words) <= 4:
+        return None
+    significant = [word for word in words if word not in PARTICLES]
+    if not significant:
+        return None
+    if any(len(word) < 3 or not word.isalpha() for word in significant):
+        return None
+    if not any(word.isalpha() for word in words):
+        return None
+    if any(word in CROSS_MARKERS or word in GENERIC_BREED_WORDS for word in words):
+        return None
+    if len(words) == 1 and words[0] in NON_BREED_WORDS:
+        return None
+    name = " ".join(word.capitalize() for word in words)
+    return BreedIdentity(
+        primary=name,
+        secondary=None,
+        slug=generate_breed_slug(name),
+        group="Unknown",
+        size=None,
+        is_cross=False,
+        breed_type="unknown",
+        confidence=0.4,
+    )
+
+
+def resolve_breed(raw: str | None, registry: BreedRegistry | None = None) -> BreedIdentity:
+    """Resolve an organisation-supplied breed string to a canonical identity."""
+    if not raw or not isinstance(raw, str):
+        return _unknown()
+
+    registry = registry or BreedRegistry.load()
+    stripped = raw.strip()
+    if _normalize(stripped) in JUNK_VALUES or len(stripped) > MAX_BREED_TEXT_LENGTH:
+        return _unknown()
+
+    # A designer breed is its own identity, not its parents'.
+    designer_index = {alias: record for record in registry.designer_breeds for alias in (_normalize(record.canonical), *record.aliases)}
+    normalized = _normalize(stripped)
+    for alias, record in sorted(designer_index.items(), key=lambda kv: -len(kv[0])):
+        if _find_word(normalized, alias) is not None:
+            return _from_records(record, None, True, 0.85)
+
+    expanded = _expand_parenthetical(stripped)
+    if expanded:
+        record = registry.match_exact(expanded)
+        if record:
+            return _from_records(record, None, False, 0.9)
+
+    without_parens = _normalize(re.sub(r"\([^)]*\)", " ", stripped))
+    for candidate in (normalized, without_parens):
+        record = registry.match_exact(candidate)
+        if record:
+            return _from_records(record, None, False, 0.95)
+
+    segments = [segment for segment in SEPARATOR_PATTERN.split(normalized) if segment.strip()]
+    is_cross = len(segments) > 1
+    records: list[BreedRecord] = []
+    for segment in segments:
+        text, marked = _strip_cross_markers(segment.strip())
+        is_cross = is_cross or marked
+        if not text:
+            continue
+        record = registry.match_exact(text)
+        for found in [record] if record else registry.find_all(text):
+            if found not in records:
+                records.append(found)
+
+    if not records:
+        # A parenthetical aside can still name the breed, as in
+        # "Mixed Breed (Podenco or Mastin, found with two mothers)".
+        expansion = _expand_parenthetical(stripped)
+        if expansion:
+            records = registry.find_all(expansion)[:1]
+    if not records:
+        provisional = _provisional_breed(normalized)
+        if provisional:
+            return provisional
+        return _mixed() if is_cross else _unknown()
+
+    primary = records[0]
+    secondary = records[1] if len(records) > 1 else None
+    if secondary:
+        is_cross = True
+    confidence = 0.9 if not is_cross else (0.8 if secondary else 0.7)
+    return _from_records(primary, secondary, is_cross, confidence)

--- a/utils/breed_registry.yaml
+++ b/utils/breed_registry.yaml
@@ -1,0 +1,752 @@
+# Canonical breed registry.
+# Adding a breed or an alias is a data change - no code edit required.
+# 'group' and 'size' describe the canonical breed; 'parents' applies to
+# designer crosses whose two parent breeds are known.
+
+breeds:
+- canonical: Afghan Hound
+  group: Hound
+  size: Large
+  aliases: []
+- canonical: Akbash
+  group: Guardian
+  size: XLarge
+  aliases: []
+- canonical: Akita
+  group: Working
+  size: Large
+  aliases: []
+- canonical: Alaskan Malamute
+  group: Working
+  size: Large
+  aliases: []
+- canonical: American Akita
+  group: Working
+  size: Large
+  aliases: []
+- canonical: American Bulldog
+  group: Working
+  size: Large
+  aliases: []
+- canonical: American Bully
+  group: Non-Sporting
+  size: Medium
+  aliases:
+  - american bully pocket
+- canonical: American Staffordshire Terrier
+  group: Terrier
+  size: Medium
+  aliases:
+  - am staff
+  - american staffie
+  - american stafford
+  - american staffy
+  - amstaff
+- canonical: Anatolian Shepherd
+  group: Guardian
+  size: XLarge
+  aliases:
+  - anatolian shepherd dog
+- canonical: Australian Cattle Dog
+  group: Herding
+  size: Medium
+  aliases:
+  - cattle dog
+- canonical: Australian Kelpie
+  group: Herding
+  size: Medium
+  aliases: []
+- canonical: Australian Shepherd
+  group: Herding
+  size: Large
+  aliases: []
+- canonical: Basset Hound
+  group: Hound
+  size: Medium
+  aliases: []
+- canonical: Beagle
+  group: Hound
+  size: Medium
+  aliases: []
+- canonical: Bedlington Terrier
+  group: Terrier
+  size: Small
+  aliases:
+  - terrier (bedlington)
+- canonical: Belgian Malinois
+  group: Herding
+  size: Large
+  aliases:
+  - malinois
+- canonical: Belgian Shepherd Dog
+  group: Herding
+  size: Large
+  aliases: []
+- canonical: Bernese Mountain Dog
+  group: Working
+  size: Large
+  aliases: []
+- canonical: Bichon Frise
+  group: Non-Sporting
+  size: Small
+  aliases: []
+- canonical: Black and Tan Coonhound
+  group: Hound
+  size: Large
+  aliases: []
+- canonical: Bloodhound
+  group: Hound
+  size: Large
+  aliases: []
+- canonical: Bodeguero Andaluz
+  group: Terrier
+  size: Small
+  aliases:
+  - bodeguero andaluz espanol
+- canonical: Boerboel
+  group: Guardian
+  size: XLarge
+  aliases: []
+- canonical: Bolognese
+  group: Toy
+  size: Small
+  aliases: []
+- canonical: Border Collie
+  group: Herding
+  size: Medium
+  aliases:
+  - collie (border)
+- canonical: Border Terrier
+  group: Terrier
+  size: Small
+  aliases:
+  - terrier (border)
+- canonical: Boston Terrier
+  group: Non-Sporting
+  size: Small
+  aliases:
+  - terrier (boston)
+- canonical: Boxer
+  group: Working
+  size: Large
+  aliases: []
+- canonical: Brittany
+  group: Sporting
+  size: Medium
+  aliases:
+  - bretonischer spaniel
+  - brittany spaniel
+  - epagneul breton
+- canonical: Bulgarian Scenthound
+  group: Hound
+  size: Medium
+  aliases:
+  - gonche (bulgarian scenthound)
+  - gonche bulgarian scenthound
+- canonical: Bull Terrier
+  group: Terrier
+  size: Medium
+  aliases:
+  - terrier (bull)
+- canonical: Bulldog
+  group: Non-Sporting
+  size: Medium
+  aliases:
+  - bulldogge
+  - bulldoggen
+- canonical: Bullmastiff
+  group: Working
+  size: Large
+  aliases: []
+- canonical: Burgos Pointer
+  group: Sporting
+  size: Large
+  aliases:
+  - perdiguero de burgos
+- canonical: Cane Corso
+  group: Working
+  size: Large
+  aliases:
+  - italian corso dog
+- canonical: Caucasian Shepherd
+  group: Guardian
+  size: XLarge
+  aliases:
+  - caucasian ovcharka
+- canonical: Cavalier King Charles Spaniel
+  group: Toy
+  size: Small
+  aliases: []
+- canonical: Chihuahua
+  group: Toy
+  size: Tiny
+  aliases:
+  - chihuahua (long coat)
+  - chihuahua (smooth coat)
+- canonical: Chinese Crested
+  group: Toy
+  size: Small
+  aliases: []
+- canonical: Chow Chow
+  group: Non-Sporting
+  size: Medium
+  aliases:
+  - chow
+- canonical: Cocker Spaniel
+  group: Sporting
+  size: Medium
+  aliases:
+  - spaniel (cocker)
+- canonical: Collie
+  group: Herding
+  size: Large
+  aliases: []
+- canonical: Corgi
+  group: Herding
+  size: Small
+  aliases: []
+- canonical: Czechoslovakian Wolfdog
+  group: Working
+  size: Large
+  aliases:
+  - tschechoslowakischer wolfshund
+- canonical: Dachshund
+  group: Hound
+  size: Small
+  aliases:
+  - dachshund (smooth haired)
+  - dackel
+  - dackel (kurzhaar)
+- canonical: Dalmatian
+  group: Non-Sporting
+  size: Large
+  aliases:
+  - dalmatiner
+- canonical: Deerhound
+  group: Hound
+  size: Large
+  aliases:
+  - scottish deerhound
+- canonical: Doberman Pinscher
+  group: Working
+  size: Large
+  aliases:
+  - dobermann
+- canonical: Dogo Canario
+  group: Working
+  size: Large
+  aliases:
+  - presa canario
+- canonical: Dogue de Bordeaux
+  group: Working
+  size: XLarge
+  aliases: []
+- canonical: Dutch Shepherd
+  group: Herding
+  size: Large
+  aliases: []
+- canonical: English Pointer
+  group: Sporting
+  size: Large
+  aliases: []
+- canonical: English Springer Spaniel
+  group: Sporting
+  size: Medium
+  aliases:
+  - english springer
+  - spaniel (english springer)
+  - springer spaniel
+- canonical: Finnish Lapphund
+  group: Herding
+  size: Medium
+  aliases: []
+- canonical: Flat-Coated Retriever
+  group: Sporting
+  size: Large
+  aliases:
+  - flat coated retriever
+  - retriever (flat coated)
+- canonical: Fox Terrier
+  group: Terrier
+  size: Small
+  aliases: []
+- canonical: Foxhound
+  group: Hound
+  size: Large
+  aliases: []
+- canonical: French Bulldog
+  group: Non-Sporting
+  size: Small
+  aliases:
+  - französische bulldogge
+- canonical: Galgo
+  group: Hound
+  size: Large
+  aliases: []
+- canonical: Galgo Español
+  group: Hound
+  size: Large
+  aliases:
+  - galga
+  - galgo espagnol
+  - galgo espaniol
+- canonical: German Hunting Terrier
+  group: Terrier
+  size: Small
+  aliases:
+  - deutscher jagdterrier
+- canonical: German Shepherd Dog
+  group: Herding
+  size: Large
+  aliases:
+  - german shepherd
+  - german shepherd dog
+- canonical: German Shorthaired Pointer
+  group: Sporting
+  size: Large
+  aliases:
+  - deutsch kurzhaar
+  - deutscher kurzhaar
+- canonical: German Spitz
+  group: Non-Sporting
+  size: Medium
+  aliases: []
+- canonical: German Wirehaired Pointer
+  group: Sporting
+  size: Large
+  aliases: []
+- canonical: Giant Schnauzer
+  group: Working
+  size: Large
+  aliases: []
+- canonical: Golden Retriever
+  group: Sporting
+  size: Large
+  aliases:
+  - golden
+  - retriever (golden)
+- canonical: Grand Basset Griffon Vendeen
+  group: Hound
+  size: Medium
+  aliases:
+  - grand basset griffon vendeen
+- canonical: Great Dane
+  group: Working
+  size: XLarge
+  aliases:
+  - deutsche dogge
+- canonical: Greyhound
+  group: Hound
+  size: Large
+  aliases: []
+- canonical: Harrier
+  group: Hound
+  size: Medium
+  aliases: []
+- canonical: Hound
+  group: Hound
+  size: Medium
+  aliases:
+  - hound dog
+- canonical: Hungarian Vizsla
+  group: Sporting
+  size: Large
+  aliases:
+  - vizsla
+  - magyar vizsla
+- canonical: Irish Wolfhound
+  group: Hound
+  size: XLarge
+  aliases: []
+- canonical: Jack Russell Terrier
+  group: Terrier
+  size: Small
+  aliases:
+  - jack russell
+  - terrier (jack russell)
+- canonical: Kangal
+  group: Guardian
+  size: XLarge
+  aliases:
+  - turkish kangal dog
+- canonical: King Charles Spaniel
+  group: Toy
+  size: Small
+  aliases: []
+- canonical: Labrador Retriever
+  group: Sporting
+  size: Large
+  aliases:
+  - lab
+  - labrador
+  - retriever (labrador)
+- canonical: Lakeland Terrier
+  group: Terrier
+  size: Small
+  aliases:
+  - terrier (lakeland)
+- canonical: Leonberger
+  group: Working
+  size: XLarge
+  aliases: []
+- canonical: Lhasa Apso
+  group: Non-Sporting
+  size: Small
+  aliases: []
+- canonical: Livestock Guardian Dog
+  group: Working
+  size: Large
+  aliases: []
+- canonical: Lurcher
+  group: Hound
+  size: Large
+  aliases: []
+- canonical: Maltese
+  group: Toy
+  size: Tiny
+  aliases:
+  - maltese terrier
+- canonical: Maremma Sheepdog
+  group: Guardian
+  size: Large
+  aliases:
+  - brindle maremma hound
+- canonical: Mastiff
+  group: Working
+  size: XLarge
+  aliases: []
+- canonical: Miniature Bull Terrier
+  group: Terrier
+  size: Small
+  aliases:
+  - terrier (miniature bull)
+- canonical: Miniature Dachshund
+  group: Hound
+  size: Small
+  aliases:
+  - dachshund (miniature smooth haired)
+- canonical: Miniature Pinscher
+  group: Toy
+  size: Small
+  aliases:
+  - pinscher (miniature)
+- canonical: Miniature Poodle
+  group: Non-Sporting
+  size: Small
+  aliases:
+  - poodle (miniature)
+- canonical: Miniature Schnauzer
+  group: Terrier
+  size: Small
+  aliases:
+  - schnauzer (miniature)
+- canonical: Miniature Wire-Haired Dachshund
+  group: Hound
+  size: Small
+  aliases:
+  - miniature wire haired dachshund
+- canonical: New Zealand Huntaway
+  group: Herding
+  size: Large
+  aliases:
+  - huntaway
+- canonical: Newfoundland
+  group: Working
+  size: XLarge
+  aliases:
+  - neufundlaender
+- canonical: Nova Scotia Duck Tolling Retriever
+  group: Sporting
+  size: Medium
+  aliases:
+  - retriever (nova scotia duck tolling)
+  - toller
+- canonical: Old English Sheepdog
+  group: Herding
+  size: Large
+  aliases:
+  - bobtail
+- canonical: Papillon
+  group: Toy
+  size: Small
+  aliases: []
+- canonical: Parson Russell Terrier
+  group: Terrier
+  size: Small
+  aliases:
+  - terrier (parson russell)
+- canonical: Patterdale Terrier
+  group: Terrier
+  size: Small
+  aliases:
+  - terrier (patterdale)
+- canonical: Podenco
+  group: Hound
+  size: Medium
+  aliases:
+  - podenca
+- canonical: Pointer
+  group: Sporting
+  size: Large
+  aliases: []
+- canonical: Pomeranian
+  group: Toy
+  size: Tiny
+  aliases:
+  - zwergspitz
+- canonical: Poodle
+  group: Non-Sporting
+  size: Medium
+  aliases:
+  - pudel
+- canonical: Portuguese Podengo
+  group: Hound
+  size: Small
+  aliases:
+  - podengo portugues pequeno
+- canonical: Portuguese Podengo Grande
+  group: Hound
+  size: Large
+  aliases:
+  - podengo portugues grande
+- canonical: Pug
+  group: Toy
+  size: Small
+  aliases: []
+- canonical: Ratonero Bodeguero Andaluz
+  group: Terrier
+  size: Small
+  aliases:
+  - ratonero
+- canonical: Rhodesian Ridgeback
+  group: Hound
+  size: Large
+  aliases:
+  - ridgeback
+- canonical: Rottweiler
+  group: Working
+  size: Large
+  aliases:
+  - rottweiller
+- canonical: Saint Bernard
+  group: Working
+  size: XLarge
+  aliases:
+  - st bernard
+- canonical: Saluki
+  group: Hound
+  size: Large
+  aliases: []
+- canonical: Samoyed
+  group: Working
+  size: Large
+  aliases: []
+- canonical: Schnauzer
+  group: Working
+  size: Medium
+  aliases:
+  - schnauzer (standard)
+- canonical: Scottish Terrier
+  group: Terrier
+  size: Small
+  aliases: []
+- canonical: Segugio Italiano
+  group: Hound
+  size: Medium
+  aliases:
+  - hound dog (segugio)
+- canonical: Serra da Estrela
+  group: Guardian
+  size: Large
+  aliases:
+  - serra da estrela berghund
+- canonical: Setter
+  group: Sporting
+  size: Large
+  aliases: []
+- canonical: Shar Pei
+  group: Non-Sporting
+  size: Medium
+  aliases: []
+- canonical: Shepherd
+  group: Herding
+  size: Large
+  aliases: []
+- canonical: Shetland Sheepdog
+  group: Herding
+  size: Small
+  aliases:
+  - sheltie
+- canonical: Shiba Inu
+  group: Non-Sporting
+  size: Medium
+  aliases:
+  - shiba
+- canonical: Shih Tzu
+  group: Toy
+  size: Small
+  aliases: []
+- canonical: Siberian Husky
+  group: Working
+  size: Large
+  aliases:
+  - husky
+- canonical: Soft Coated Wheaten Terrier
+  group: Terrier
+  size: Medium
+  aliases:
+  - terrier (soft coated wheaten)
+- canonical: Spaniel
+  group: Sporting
+  size: Medium
+  aliases: []
+- canonical: Spanish Mastiff
+  group: Working
+  size: XLarge
+  aliases: []
+- canonical: Spitz
+  group: Non-Sporting
+  size: Medium
+  aliases: []
+- canonical: Staffordshire Bull Terrier
+  group: Terrier
+  size: Medium
+  aliases:
+  - english staffie
+  - english staffordshire bull terrier
+  - english staffy
+  - sbt
+  - staff
+  - staffie
+  - stafford
+  - staffordshire
+  - staffordshire terrier
+  - staffy
+  - staffy bull terrier
+  - terrier (staffordshire bull)
+- canonical: Standard Poodle
+  group: Non-Sporting
+  size: Large
+  aliases:
+  - poodle (standard)
+- canonical: Standard Schnauzer
+  group: Working
+  size: Medium
+  aliases: []
+- canonical: Terrier
+  group: Terrier
+  size: Medium
+  aliases: []
+- canonical: Toy Poodle
+  group: Toy
+  size: Tiny
+  aliases: []
+- canonical: Trailhound
+  group: Hound
+  size: Medium
+  aliases: []
+- canonical: Weimaraner
+  group: Sporting
+  size: Large
+  aliases: []
+- canonical: Welsh Sheepdog
+  group: Herding
+  size: Medium
+  aliases: []
+- canonical: West Highland White Terrier
+  group: Terrier
+  size: Small
+  aliases: []
+- canonical: Whippet
+  group: Hound
+  size: Medium
+  aliases: []
+- canonical: Wire Fox Terrier
+  group: Terrier
+  size: Small
+  aliases:
+  - terrier (fox wire)
+- canonical: Wire-Haired Dachshund
+  group: Hound
+  size: Small
+  aliases:
+  - rauhhaardackel
+  - wire haired dachshund
+- canonical: Yorkshire Terrier
+  group: Terrier
+  size: Tiny
+  aliases:
+  - terrier (yorkshire)
+designer_breeds:
+- canonical: Cavachon
+  group: Designer
+  size: Small
+  parents:
+  - Cavalier King Charles Spaniel
+  - Bichon Frise
+  aliases:
+  - cavashon
+- canonical: Cavapoo
+  group: Toy
+  size: Small
+  parents:
+  - Cavalier King Charles Spaniel
+  - Poodle
+  aliases: []
+- canonical: Cockapoo
+  group: Designer/Hybrid
+  size: Small
+  parents:
+  - Cocker Spaniel
+  - Poodle
+  aliases:
+  - cockerpoo
+- canonical: Goldendoodle
+  group: Sporting
+  size: Large
+  parents:
+  - Golden Retriever
+  - Poodle
+  aliases: []
+- canonical: Labradoodle
+  group: Designer/Hybrid
+  size: Large
+  parents:
+  - Labrador Retriever
+  - Poodle
+  aliases: []
+- canonical: Maltipoo
+  group: Toy
+  size: Small
+  parents:
+  - Maltese
+  - Poodle
+  aliases: []
+- canonical: Pomsky
+  group: Designer/Hybrid
+  size: Small
+  parents:
+  - Pomeranian
+  - Siberian Husky
+  aliases: []
+- canonical: Puggle
+  group: Hound
+  size: Small
+  parents:
+  - Pug
+  - Beagle
+  aliases: []
+- canonical: Schnoodle
+  group: Non-Sporting
+  size: Medium
+  parents:
+  - Schnauzer
+  - Poodle
+  aliases: []
+- canonical: Yorkipoo
+  group: Toy
+  size: Tiny
+  parents:
+  - Yorkshire Terrier
+  - Poodle
+  aliases: []

--- a/utils/breed_utils.py
+++ b/utils/breed_utils.py
@@ -4,6 +4,19 @@ import re
 import unicodedata
 
 
+def fold_to_ascii(text: str) -> str:
+    """
+    Lowercase text and reduce it to ASCII letters.
+
+    Casefolding first expands ligatures (the German sharp s becomes "ss"),
+    then NFKD decomposition splits accented characters so the combining marks
+    can be dropped, turning "Español" into "espanol" rather than losing the
+    character entirely.
+    """
+    decomposed = unicodedata.normalize("NFKD", text.casefold())
+    return "".join(char for char in decomposed if not unicodedata.combining(char))
+
+
 def generate_breed_slug(primary_breed: str) -> str:
     """
     Convert primary breed names to URL-friendly slugs.
@@ -22,10 +35,7 @@ def generate_breed_slug(primary_breed: str) -> str:
     if not primary_breed:
         return ""
 
-    # Casefold first so ligatures expand (German sharp s becomes "ss"), then
-    # decompose accents and drop the combining marks, leaving ASCII letters.
-    decomposed = unicodedata.normalize("NFKD", primary_breed.casefold())
-    slug = "".join(char for char in decomposed if not unicodedata.combining(char))
+    slug = fold_to_ascii(primary_breed)
 
     # Handle special case of "Mix" suffix - preserve it with hyphen
     slug = re.sub(r"\s+mix$", "-mix", slug, flags=re.IGNORECASE)

--- a/utils/unified_standardization.py
+++ b/utils/unified_standardization.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from functools import lru_cache
 from typing import Any
 
+from utils.breed_registry import BreedIdentity, resolve_breed
 from utils.breed_utils import generate_breed_slug
 
 
@@ -32,6 +33,16 @@ class AgeInfo:
 
 
 MAX_DOG_AGE_MONTHS = 360
+
+
+def _display_name(identity: BreedIdentity) -> str:
+    """Human-readable breed label that still shows the cross relationship."""
+    if identity.parents:
+        # A designer breed already names the cross; "Cockapoo Cross" is wrong.
+        return identity.primary
+    if identity.secondary:
+        return f"{identity.primary} x {identity.secondary}"
+    return f"{identity.primary} Cross" if identity.is_cross else identity.primary
 
 
 class UnifiedStandardizer:
@@ -547,7 +558,7 @@ class UnifiedStandardizer:
         size_result = self._standardize_size(size, breed) if self.enable_size_standardization else {"category": size}
 
         # Build result in the format expected by BaseScraper and tests
-        primary_breed = breed_result.get("primary_breed", breed_result.get("name", "Unknown"))
+        primary_breed = breed_result.get("primary_breed") or breed_result.get("name", "Unknown")
         result = {
             # Breed fields
             "breed": breed_result.get("name", "Unknown"),
@@ -557,7 +568,7 @@ class UnifiedStandardizer:
             "breed_confidence": breed_result.get("confidence", 0.0),  # Add breed_confidence field
             "primary_breed": primary_breed,
             "secondary_breed": breed_result.get("secondary_breed"),
-            "breed_slug": generate_breed_slug(primary_breed),  # Generate breed_slug for breed pages
+            "breed_slug": breed_result.get("breed_slug") or generate_breed_slug(primary_breed),
             "standardization_confidence": breed_result.get("confidence", 0.0),
             # Age fields - preserve original and add ranges
             "age": age,  # Preserve original age field
@@ -569,14 +580,6 @@ class UnifiedStandardizer:
             "size": size,  # Preserve original size field
             "standardized_size": size_result.get("category", "Medium"),
         }
-
-        # Handle mixed breeds properly for primary/secondary breed fields
-        if breed_result.get("is_mixed") and not breed_result.get("primary_breed"):
-            # For regular mixed breeds like "Terrier Mix", set secondary to "Mixed Breed"
-            result["secondary_breed"] = "Mixed Breed"
-        elif not breed_result.get("is_mixed"):
-            # For pure breeds, secondary breed should be None
-            result["secondary_breed"] = None
 
         # Return deep copy to prevent cache mutation
         return deepcopy(result)
@@ -674,193 +677,33 @@ class UnifiedStandardizer:
         return animal_data
 
     def _standardize_breed(self, breed: str | None) -> dict[str, Any]:
-        """Standardize breed with all fixes including Lurcher, designer breeds, and Staffordshire."""
-        if not breed:
+        """Resolve a breed string to its canonical identity via the registry."""
+        identity = resolve_breed(breed)
+
+        if identity.primary is None:
+            name = "Mixed Breed" if identity.breed_type == "mixed" else "Unknown"
             return {
-                "name": "Unknown",
-                "group": "Unknown",
+                "name": name,
+                "group": identity.group,
                 "size": None,
-                "confidence": 0.0,
-                "breed_type": "unknown",
-                "is_mixed": False,
+                "confidence": identity.confidence,
+                "breed_type": identity.breed_type,
+                "is_mixed": identity.is_cross,
+                "primary_breed": name,
+                "secondary_breed": None,
+                "breed_slug": identity.slug or generate_breed_slug(name),
             }
 
-        # Handle non-string inputs
-        if not isinstance(breed, str):
-            return {
-                "name": "Unknown",
-                "group": "Unknown",
-                "size": None,
-                "confidence": 0.0,
-                "breed_type": "unknown",
-                "is_mixed": False,
-            }
-
-        breed_lower = breed.strip().lower()
-
-        # CRITICAL-3: Input sanitization - blocklist for known non-breed strings
-        # Note: "unknown" is NOT in blocklist - it's a valid (if uninformative) breed value
-        blocklist = [
-            "can be the only dog",
-            "n/a",
-            "breed tbc",
-            "not specified",
-            "tbc",
-            "pending",
-        ]
-        if breed_lower in blocklist or len(breed_lower) > 60:
-            return {
-                "name": "Unknown",
-                "group": "Unknown",
-                "size": None,
-                "confidence": 0.0,
-                "breed_type": "unknown",
-                "is_mixed": False,
-            }
-
-        is_mixed = bool(self.breed_patterns["cross"].search(breed_lower) or self.breed_patterns["mixed"].search(breed_lower))
-
-        # Try parenthetical pattern first (Dogs Trust style)
-        parsed_breed = self._parse_parenthetical_breed(breed)
-        if parsed_breed:
-            # Now look up the parsed breed in our data
-            parsed_lower = parsed_breed.replace(" Cross", "").lower()
-            if parsed_lower in self.breed_data:
-                breed_info = self.breed_data[parsed_lower]
-                return {
-                    "name": parsed_breed,
-                    "group": "Mixed" if is_mixed else breed_info.breed_group,
-                    "size": breed_info.size_estimate,
-                    "confidence": 0.9 if not is_mixed else 0.7,
-                    "breed_type": "purebred" if not is_mixed else "crossbreed",
-                    "is_mixed": is_mixed,
-                    "primary_breed": parsed_breed.replace(" Cross", ""),
-                    "secondary_breed": None,
-                }
-            else:
-                # Parsed but not in breed_data - still better than unknown
-                return {
-                    "name": parsed_breed,
-                    "group": "Mixed" if is_mixed else "Unknown",
-                    "size": None,
-                    "confidence": 0.7 if not is_mixed else 0.6,
-                    "breed_type": "purebred" if not is_mixed else "crossbreed",
-                    "is_mixed": is_mixed,
-                    "primary_breed": parsed_breed.replace(" Cross", ""),
-                    "secondary_breed": None,
-                }
-
-        # Check for Lurcher first (high priority fix)
-        if "lurcher" in breed_lower:
-            return {
-                "name": "Lurcher" + (" Cross" if is_mixed else ""),
-                "group": "Hound",
-                "size": "Large",
-                "confidence": 0.95,
-                "breed_type": "sighthound",
-                "is_mixed": is_mixed,
-            }
-
-        # Check for American Staffordshire variations first (more specific)
-        for variation in self.american_staffordshire_variations:
-            if variation in breed_lower or ("american" in breed_lower and "staff" in breed_lower):
-                return {
-                    "name": "American Staffordshire Terrier" + (" Mix" if is_mixed else ""),
-                    "group": "Mixed" if is_mixed else "Terrier",
-                    "size": "Medium",
-                    "confidence": 0.9 if not is_mixed else 0.8,
-                    "breed_type": "purebred" if not is_mixed else "crossbreed",
-                    "is_mixed": is_mixed,
-                }
-
-        # Check for Staffordshire variations (less specific)
-        for variation in self.staffordshire_variations:
-            if variation in breed_lower and "american" not in breed_lower:
-                return {
-                    "name": "Staffordshire Bull Terrier" + (" Mix" if is_mixed else ""),
-                    "group": "Mixed" if is_mixed else "Terrier",
-                    "size": "Medium",
-                    "confidence": 0.9 if not is_mixed else 0.8,
-                    "breed_type": "purebred" if not is_mixed else "crossbreed",
-                    "is_mixed": is_mixed,
-                }
-
-        # Check for designer breeds
-        for designer_key, designer_info in self.designer_breeds.items():
-            if designer_key in breed_lower:
-                return {
-                    "name": designer_info["name"],
-                    "group": designer_info["group"],
-                    "size": designer_info["size"],
-                    "confidence": 0.85,
-                    "breed_type": "crossbreed",  # Designer breeds are crossbreeds
-                    "primary_breed": designer_info["primary"],
-                    "secondary_breed": designer_info["secondary"],
-                    "is_mixed": True,
-                }
-
-        # Check standard breed data
-        if breed_lower in self.breed_data:
-            breed_info = self.breed_data[breed_lower]
-            return {
-                "name": breed_info.standardized_name + (" Cross" if is_mixed else ""),
-                "group": "Mixed" if is_mixed else breed_info.breed_group,
-                "size": breed_info.size_estimate,
-                "confidence": 0.9 if not is_mixed else 0.7,
-                "breed_type": "purebred" if not is_mixed else "crossbreed",
-                "is_mixed": is_mixed,
-            }
-
-        # HIGH-2: Check for crosses with specific breed mentioned FIRST (before generic mixed breed)
-        # Use dynamic breed_data.keys() instead of hardcoded list
-        breed_keywords = [k for k in self.breed_data.keys() if len(k) >= 3]
-        # Also include international terms not in breed_data
-        international_terms = ["schäferhund", "hund", "dogo", "gordon", "northern", "irish", "ridgeback"]
-        all_keywords = breed_keywords + international_terms
-
-        if is_mixed:
-            matched_breed_key = None
-            for keyword in all_keywords:
-                if keyword in breed_lower:
-                    matched_breed_key = keyword
-                    break
-
-            if matched_breed_key:
-                # Get size from matched breed if available
-                matched_size = None
-                if matched_breed_key in self.breed_data:
-                    matched_size = self.breed_data[matched_breed_key].size_estimate
-
-                breed_name = self._capitalize_breed_name(breed.strip())
-                return {
-                    "name": breed_name,
-                    "group": "Mixed",
-                    "size": matched_size,
-                    "confidence": 0.7,
-                    "breed_type": "crossbreed",
-                    "is_mixed": True,
-                }  # Medium confidence for identifiable crosses
-
-        # Check for generic mixed breed (only if no specific breed identified)
-        if self.breed_patterns["mixed"].search(breed_lower):
-            return {
-                "name": "Mixed Breed",
-                "group": "Mixed",
-                "size": None,
-                "confidence": 0.5,
-                "breed_type": "mixed",
-                "is_mixed": True,
-            }
-
-        # Unknown breed - if it's mixed, put in Mixed group, otherwise Unknown
-        breed_name = self._capitalize_breed_name(breed.strip())
         return {
-            "name": breed_name,
-            "group": "Mixed" if is_mixed else "Unknown",
-            "size": None,
-            "confidence": 0.3,
-            "breed_type": "unknown",
-            "is_mixed": is_mixed,
+            "name": _display_name(identity),
+            "group": identity.group,
+            "size": identity.size,
+            "confidence": identity.confidence,
+            "breed_type": identity.breed_type,
+            "is_mixed": identity.is_cross,
+            "primary_breed": identity.primary,
+            "secondary_breed": identity.secondary,
+            "breed_slug": identity.slug,
         }
 
     def _capitalize_breed_name(self, breed: str) -> str:


### PR DESCRIPTION
## Problem

`_standardize_breed` was a branch chain that, for crossbreeds, **detected a known breed in the text and then threw it away**, returning the title-cased raw input (`unified_standardization.py:814-842`). Those strings are the breed label on dog cards and the `/breeds/[slug]` page key:

```
"Podenco-labrador-mix"
"Mixed Breed (possibly Brittany Spaniel-pointer Mix)"
"(german Shepherd) Mixed Breed"
```

## Change

A YAML registry (140 breeds, 10 designer) plus a resolver that separates a breed's **identity** from the fact that it is a **cross**:

| Field | Before | After |
|---|---|---|
| `primary_breed` | `Border Collie Cross` | `Border Collie` |
| `secondary_breed` | literal `"Mixed Breed"` on every cross | the second named breed, or `NULL` |
| `breed_group` | `Mixed` for all crosses | group of the primary breed |
| Cockapoo | filed under `/breeds/cocker-spaniel` | `/breeds/cockapoo` |

Also expands parenthetical forms (`Terrier (Staffordshire Bull)` → `Staffordshire Bull Terrier`), covering 149 distinct Dogs Trust values, and splits multi-breed strings (`Bichon Frise x Maltese`).

Adding a breed or alias is now a data change in `breed_registry.yaml` — no code edit.

## Verified against production, not just tests

Diffed old vs new across all **9,355 rows**:

| Outcome | Rows |
|---|---|
| Identical | 7,423 |
| Cross suffix dropped from identity | 1,145 |
| Junk text cleaned up | 572 |
| Designer breed keeps its identity | 180 |
| Unresolved | 34 |

**This diff caught a regression my green test suite did not.** The first implementation lost **148 rows** of real breeds (`Schnauzer`, `Newfoundland`, `Bullmastiff`, `Deerhound`, `Deutsch Kurzhaar`) that the old code passed through but the registry lacked. Fixed by adding them plus German synonyms, and by keeping a short, clean, unregistered name at confidence `0.4` rather than discarding it. The residual 34 are genuine non-breeds — `Unlisted`, `European`, `Tofu`.

## Breed pages: 13 → 19

| Page | Before | After |
|---|---|---|
| `/breeds/german-shepherd-dog` | 17 | **55** |
| `/breeds/staffordshire-bull-terrier` | 20 | **44** |
| `/breeds/lurcher` | 31 | **43** |
| `/breeds/border-collie` | 18 | **38** |
| `/breeds/jack-russell-terrier` | 18 | **32** |

Plus 7 new qualifying pages (Labrador Retriever, Siberian Husky, French Bulldog, Pomeranian, Pointer, Poodle, Beagle).

Only **two** live URLs move, both 301'd in `next.config.js`:
- `/breeds/staffordshire-bull-terrier-mix` → `/breeds/staffordshire-bull-terrier`
- `/breeds/german-shepherd-mix` → `/breeds/german-shepherd-dog`

## Reviewer note: `breed_group` semantics

A Staffie cross is now `Terrier`, not `Mixed`. This shrinks the `Mixed` group from 912 to ~600, so `/breeds/mixed` becomes smaller and more accurate while the real groups grow and group filters get more useful. It's the coherent reading of "a cross is a facet, not an identity", but it visibly reshapes the breeds hub — worth a look before merge.

## No migration

`primary_breed`, `secondary_breed`, `breed_slug` and `breed_group` are recomputed each scrape and covered by change detection, so rows correct themselves within one cron cycle. Unlike #327 there is no prod step needed before merge.

## Tests

51 new registry tests. ~30 assertions across 14 files encoded the old semantics and were updated — each checked in context, not bulk-replaced (one was an inequality a naive replace would have inverted, and two apparent failures were real bugs in my code: `Cockapoo Cross` is wrong because a designer breed already names the cross).

**1,639 backend tests pass**, ruff clean, tsc clean, 187 frontend breed/sitemap tests pass.

## Docs

- `docs/guides/deployment.md` — no longer implies Alembic runs on deploy; documents the manual procedure and the migrate-before-merge ordering
- `README.md` — local setup points at `db_setup.py`, not Alembic
- `docs/technical/architecture.md` — `breed_raw`, column count
- `docs/features/breed-standardization.md` — new; column semantics, resolution order, how to add a breed