### PR TITLE
feat(breeds): add breed reconciliation reporting

### DIFF
--- a/docs/features/breed-standardization.md
+++ b/docs/features/breed-standardization.md
@@ -54,3 +54,26 @@ parents stay in the registry rather than being copied onto every row.
 `breed_slug`, `primary_breed` and the rest are recomputed on every scrape and are
 covered by change detection, so stored rows correct themselves within one cron
 cycle (Mon/Thu/Sat 15:00 UTC). No backfill migration is needed.
+
+## Keeping the registry current
+
+```bash
+uv run python management/breed_commands.py reconcile
+```
+
+Reports three things against live data:
+
+- **Unresolved breed text** — organisation text the registry cannot resolve and
+  that is not a known sentinel such as `Unknown` or `N/A`. This is the only
+  section that needs a human.
+- **Candidates for the registry** — clean names kept at confidence `0.4` because
+  nothing matched. Each is a breed or alias worth adding to the YAML.
+- **Stored values behind the resolver** — rows not yet rescraped. These clear
+  themselves on the next cron run and need no action.
+
+Exits non-zero when unresolved rows exceed `--unmatched-budget` (default 50), so
+it can gate a scheduled run. Pass `--all-statuses` to include adopted and
+delisted dogs.
+
+This is the check that catches a resolver change silently dropping breeds: the
+test suite was fully green while 148 production rows were becoming `Unknown`.

--- a/management/breed_commands.py
+++ b/management/breed_commands.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Breed registry operations.
+
+    uv run python management/breed_commands.py reconcile
+
+Reports organisation breed text the registry cannot resolve, clean names that
+are candidates for a registry entry, and rows whose stored values are behind the
+resolver. Exits non-zero when unmatched rows exceed the budget, so it can gate a
+scheduled run.
+"""
+
+import argparse
+import logging
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import psycopg2  # noqa: E402
+from rich.console import Console  # noqa: E402
+from rich.table import Table  # noqa: E402
+
+from config import DB_CONFIG  # noqa: E402
+from management.breed_reconciliation import BreedReconciliation, BreedRow, reconcile  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+DISTINCT_BREED_QUERY = """
+    SELECT COALESCE(breed_raw, breed) AS raw,
+           MIN(primary_breed) AS stored_primary,
+           MIN(breed_slug) AS stored_slug,
+           COUNT(*) AS count
+    FROM animals
+    WHERE COALESCE(breed_raw, breed) IS NOT NULL
+      {available_only}
+    GROUP BY 1
+"""
+
+
+def fetch_breed_rows(available_only: bool) -> list[BreedRow]:
+    clause = "AND status = 'available'" if available_only else ""
+    with psycopg2.connect(**DB_CONFIG) as conn, conn.cursor() as cursor:
+        cursor.execute(DISTINCT_BREED_QUERY.format(available_only=clause))
+        return [BreedRow(raw, primary, slug, count) for raw, primary, slug, count in cursor.fetchall()]
+
+
+def render(report: BreedReconciliation, console: Console, limit: int) -> None:
+    console.print(
+        f"\n[bold]{report.total_rows}[/bold] rows | "
+        f"[green]{report.resolved_rows} resolved[/green] | "
+        f"[red]{report.unmatched_rows} unmatched[/red] | "
+        f"[yellow]{report.drifted_rows} awaiting rescrape[/yellow]\n"
+    )
+
+    if report.unmatched:
+        table = Table(title="Unresolved breed text", title_justify="left")
+        table.add_column("organisation text")
+        table.add_column("rows", justify="right")
+        for text, count in report.unmatched[:limit]:
+            table.add_row(text, str(count))
+        console.print(table)
+
+    if report.provisional:
+        table = Table(title="Candidates for utils/breed_registry.yaml", title_justify="left")
+        table.add_column("organisation text")
+        table.add_column("kept as")
+        table.add_column("rows", justify="right")
+        for text, name, count in report.provisional[:limit]:
+            table.add_row(text, name, str(count))
+        console.print(table)
+
+    if report.drift:
+        table = Table(title="Stored values behind the resolver", title_justify="left")
+        table.add_column("organisation text")
+        table.add_column("stored")
+        table.add_column("resolves to")
+        table.add_column("rows", justify="right")
+        for text, stored, resolved, count in report.drift[:limit]:
+            table.add_row(text, str(stored), resolved, str(count))
+        console.print(table)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Breed registry operations")
+    parser.add_argument("command", choices=["reconcile"])
+    parser.add_argument("--all-statuses", action="store_true", help="Include adopted and delisted dogs")
+    parser.add_argument("--limit", type=int, default=25, help="Rows shown per table")
+    parser.add_argument(
+        "--unmatched-budget",
+        type=int,
+        default=50,
+        help="Exit non-zero above this many unmatched rows",
+    )
+    args = parser.parse_args()
+
+    report = reconcile(fetch_breed_rows(available_only=not args.all_statuses))
+    render(report, Console(), args.limit)
+
+    if not report.is_clean(args.unmatched_budget):
+        logger.error("%s unmatched rows exceeds the budget of %s", report.unmatched_rows, args.unmatched_budget)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/management/breed_reconciliation.py
+++ b/management/breed_reconciliation.py
@@ -1,0 +1,86 @@
+"""Compare stored breed values against what the registry resolves today.
+
+Three signals come out of this:
+
+- **unmatched**: organisation text the registry cannot resolve at all. These are
+  either junk or a breed the registry is missing, and they are the only signal
+  that needs a human.
+- **provisional**: a clean name kept at low confidence because no registry entry
+  matched. Each one is a candidate alias to add.
+- **drift**: rows whose stored value disagrees with the resolver, normally
+  because they have not been rescraped yet.
+"""
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from utils.breed_registry import JUNK_VALUES, _normalize, resolve_breed
+
+PROVISIONAL_CONFIDENCE = 0.4
+
+
+@dataclass(frozen=True)
+class BreedRow:
+    """Distinct organisation breed text and the values stored against it."""
+
+    raw: str
+    stored_primary: str | None
+    stored_slug: str | None
+    count: int
+
+
+@dataclass(frozen=True)
+class BreedReconciliation:
+    unmatched: list[tuple[str, int]]
+    provisional: list[tuple[str, str, int]]
+    drift: list[tuple[str, str | None, str, int]]
+    total_rows: int
+    unmatched_rows: int
+    drifted_rows: int
+
+    @property
+    def resolved_rows(self) -> int:
+        return self.total_rows - self.unmatched_rows
+
+    def is_clean(self, unmatched_row_budget: int) -> bool:
+        """Drift resolves itself on the next scrape; unmatched text will not."""
+        return self.unmatched_rows <= unmatched_row_budget
+
+
+def reconcile(rows: Iterable[BreedRow]) -> BreedReconciliation:
+    unmatched: list[tuple[str, int]] = []
+    provisional: list[tuple[str, str, int]] = []
+    drift: list[tuple[str, str | None, str, int]] = []
+    total = unmatched_rows = drifted_rows = 0
+
+    for row in rows:
+        total += row.count
+        identity = resolve_breed(row.raw)
+
+        if identity.primary is None:
+            if identity.breed_type == "mixed" or _normalize(row.raw) in JUNK_VALUES:
+                # "Mixed Breed" and "Unknown" are answers, not registry gaps.
+                continue
+            unmatched.append((row.raw, row.count))
+            unmatched_rows += row.count
+            continue
+
+        if identity.confidence <= PROVISIONAL_CONFIDENCE:
+            provisional.append((row.raw, identity.primary, row.count))
+
+        if row.stored_primary != identity.primary:
+            drift.append((row.raw, row.stored_primary, identity.primary, row.count))
+            drifted_rows += row.count
+
+    unmatched.sort(key=lambda item: -item[1])
+    provisional.sort(key=lambda item: -item[2])
+    drift.sort(key=lambda item: -item[3])
+
+    return BreedReconciliation(
+        unmatched=unmatched,
+        provisional=provisional,
+        drift=drift,
+        total_rows=total,
+        unmatched_rows=unmatched_rows,
+        drifted_rows=drifted_rows,
+    )

--- a/tests/management/test_breed_reconciliation.py
+++ b/tests/management/test_breed_reconciliation.py
@@ -1,0 +1,121 @@
+"""Tests for breed reconciliation.
+
+A green test suite once hid 148 production rows whose breed silently became
+Unknown, because nothing compared the resolver against real organisation text.
+This report is that missing feedback loop.
+"""
+
+import pytest
+
+from management.breed_reconciliation import BreedRow, reconcile
+
+
+@pytest.mark.unit
+class TestUnmatchedDetection:
+    def test_text_that_resolves_to_no_breed_is_reported(self):
+        report = reconcile([BreedRow("Unlisted", "Unknown", "unknown", 4)])
+        assert report.unmatched == [("Unlisted", 4)]
+
+    def test_recognised_breed_is_not_reported_as_unmatched(self):
+        report = reconcile([BreedRow("Border Collie", "Border Collie", "border-collie", 10)])
+        assert report.unmatched == []
+
+    def test_unmatched_are_ordered_by_row_count(self):
+        report = reconcile([BreedRow("Tofu", "Tofu", "tofu", 1), BreedRow("Unlisted", "Unlisted", "unlisted", 9)])
+        assert [text for text, _ in report.unmatched] == ["Unlisted", "Tofu"]
+
+    def test_generic_mixed_breed_is_not_treated_as_unmatched(self):
+        """ "Mixed Breed" is a real answer, not a failure to resolve."""
+        report = reconcile([BreedRow("Mixed Breed", "Mixed Breed", "mixed-breed", 500)])
+        assert report.unmatched == []
+
+
+@pytest.mark.unit
+class TestProvisionalDetection:
+    def test_unregistered_clean_name_is_flagged_for_the_registry(self):
+        report = reconcile([BreedRow("Korean Jindo", "Korean Jindo", "korean-jindo", 3)])
+        assert report.provisional == [("Korean Jindo", "Korean Jindo", 3)]
+
+    def test_registered_breed_is_not_flagged(self):
+        report = reconcile([BreedRow("Newfoundland", "Newfoundland", "newfoundland", 2)])
+        assert report.provisional == []
+
+
+@pytest.mark.unit
+class TestDriftDetection:
+    def test_stored_value_behind_the_resolver_is_reported(self):
+        """Rows awaiting a rescrape, or a genuine resolver regression."""
+        report = reconcile([BreedRow("Border Collie Cross", "Border Collie Cross", "border-collie-cross", 14)])
+        assert report.drift == [("Border Collie Cross", "Border Collie Cross", "Border Collie", 14)]
+
+    def test_agreeing_row_is_not_drift(self):
+        report = reconcile([BreedRow("Border Collie Cross", "Border Collie", "border-collie", 14)])
+        assert report.drift == []
+
+    def test_drift_counts_rows_not_distinct_values(self):
+        report = reconcile(
+            [
+                BreedRow("Lurcher Cross", "Lurcher Cross", "lurcher-cross", 12),
+                BreedRow("Poodle Mix", "Poodle Mix", "poodle-mix", 11),
+            ]
+        )
+        assert report.drifted_rows == 23
+
+
+@pytest.mark.unit
+class TestTotals:
+    def test_totals_count_rows(self):
+        report = reconcile(
+            [
+                BreedRow("Border Collie", "Border Collie", "border-collie", 10),
+                BreedRow("Tofu", "Tofu", "tofu", 2),
+            ]
+        )
+        assert report.total_rows == 12
+        assert report.unmatched_rows == 2
+        assert report.resolved_rows == 10
+
+    def test_empty_input_is_a_clean_report(self):
+        report = reconcile([])
+        assert report.total_rows == 0
+        assert report.unmatched == []
+        assert report.is_clean(unmatched_row_budget=0)
+
+
+@pytest.mark.unit
+class TestCleanliness:
+    def test_report_is_dirty_when_unmatched_exceeds_the_budget(self):
+        report = reconcile([BreedRow("Tofu", "Tofu", "tofu", 50)])
+        assert not report.is_clean(unmatched_row_budget=10)
+
+    def test_report_is_clean_within_the_budget(self):
+        report = reconcile([BreedRow("Tofu", "Tofu", "tofu", 5)])
+        assert report.is_clean(unmatched_row_budget=10)
+
+    def test_drift_alone_does_not_make_a_report_dirty(self):
+        """Drift clears itself on the next scrape; unmatched text does not."""
+        report = reconcile([BreedRow("Poodle Mix", "Poodle Mix", "poodle-mix", 99)])
+        assert report.is_clean(unmatched_row_budget=0)
+
+
+@pytest.mark.unit
+class TestKnownNonBreedsAreNotRegistryGaps:
+    """ "Unknown" and friends are deliberate sentinels, not missing entries.
+
+    Counting them as unmatched buries the two rows of genuinely unrecognised
+    text under a hundred rows of organisations saying "we don't know".
+    """
+
+    @pytest.mark.parametrize("sentinel", ["Unknown", "Can be the only dog", "N/A", "TBC", "not specified"])
+    def test_sentinel_is_not_reported_as_unmatched(self, sentinel):
+        report = reconcile([BreedRow(sentinel, "Unknown", "unknown", 83)])
+        assert report.unmatched == []
+        assert report.unmatched_rows == 0
+
+    def test_genuinely_unrecognised_text_is_still_reported(self):
+        report = reconcile([BreedRow("European", "European", "european", 2)])
+        assert report.unmatched == [("European", 2)]
+
+    def test_sentinels_do_not_break_the_budget(self):
+        rows = [BreedRow("Unknown", "Unknown", "unknown", 83), BreedRow("European", "European", "european", 2)]
+        assert reconcile(rows).is_clean(unmatched_row_budget=10)

--- a/utils/breed_registry.py
+++ b/utils/breed_registry.py
@@ -27,18 +27,18 @@ QUALIFIER_WORDS = frozenset({"vermutlich", "wahrscheinlich", "similar", "possibl
 PARTICLES = frozenset({"de", "del", "la", "el", "von", "van", "der", "du", "di", "y"})
 GENERIC_BREED_WORDS = frozenset({"breed", "dog", "puppy", "pup"})
 SEPARATOR_PATTERN = re.compile(r"\s+x\s+|[/+,]|\s+and\s+")
-JUNK_VALUES = frozenset(
-    {
-        "n/a",
-        "na",
-        "tbc",
-        "breed tbc",
-        "not specified",
-        "pending",
-        "unknown",
-        "can be the only dog",
-        "",
-    }
+# Written as they appear in source data; normalised below so the comparison
+# against normalised text actually matches ("n/a" folds to "n a").
+JUNK_LITERALS = (
+    "n/a",
+    "na",
+    "tbc",
+    "breed tbc",
+    "not specified",
+    "pending",
+    "unknown",
+    "can be the only dog",
+    "",
 )
 # Single words that appear in the breed field but never name a breed.
 NON_BREED_WORDS = frozenset({"unlisted", "european", "tofu", "yorkshire", "pinscher", "shepherd", "spitz", "hound", "terrier", "spaniel", "poodle", "collie", "retriever"})
@@ -133,6 +133,9 @@ def _normalize(text: str) -> str:
     """Fold to ASCII and reduce punctuation to single spaces for matching."""
     folded = fold_to_ascii(text)
     return re.sub(r"\s+", " ", re.sub(r"[^a-z0-9]+", " ", folded)).strip()
+
+
+JUNK_VALUES = frozenset(_normalize(value) for value in JUNK_LITERALS)
 
 
 def _find_word(haystack: str, needle: str) -> int | None:

--- a/utils/breed_registry.yaml
+++ b/utils/breed_registry.yaml
@@ -115,6 +115,7 @@ breeds:
   group: Herding
   size: Medium
   aliases:
+  - bordercollie
   - collie (border)
 - canonical: Border Terrier
   group: Terrier
@@ -299,8 +300,11 @@ breeds:
   group: Herding
   size: Large
   aliases:
+  - deutscher schaferhund
   - german shepherd
   - german shepherd dog
+  - schaeferhund
+  - schaferhund
 - canonical: German Shorthaired Pointer
   group: Sporting
   size: Large
@@ -396,7 +400,8 @@ breeds:
 - canonical: Livestock Guardian Dog
   group: Working
   size: Large
-  aliases: []
+  aliases:
+  - herdenschutzhund
 - canonical: Lurcher
   group: Hound
   size: Large
@@ -455,6 +460,10 @@ breeds:
   size: XLarge
   aliases:
   - neufundlaender
+- canonical: Norwegian Elkhound
+  group: Hound
+  size: Medium
+  aliases: []
 - canonical: Nova Scotia Duck Tolling Retriever
   group: Sporting
   size: Medium
@@ -604,6 +613,11 @@ breeds:
   group: Working
   size: XLarge
   aliases: []
+- canonical: Spinone Italiano
+  group: Sporting
+  size: Large
+  aliases:
+  - spinone
 - canonical: Spitz
   group: Non-Sporting
   size: Medium


### PR DESCRIPTION
## Why

The registry rewrite in #330 passed a **fully green test suite** while silently turning **148 production rows** of real breeds — `Schnauzer`, `Newfoundland`, `Bullmastiff`, `Deerhound` — into `Unknown`. Only diffing the resolver against live organisation text caught it, and nothing did that on an ongoing basis.

This is that missing feedback loop, which the original audit called out as absent.

## What it reports

```bash
uv run python management/breed_commands.py reconcile
```

| Section | Meaning | Action |
|---|---|---|
| **Unresolved breed text** | Text the registry cannot place, excluding known sentinels | needs a human |
| **Candidates for the registry** | Clean names kept at confidence `0.4` because nothing matched | add to YAML |
| **Stored values behind the resolver** | Rows not yet rescraped | none; clears on next cron |

Exits non-zero when unresolved rows exceed `--unmatched-budget` (default 50), so it can gate a scheduled run.

## It earned its keep immediately

First run against production surfaced these, now all added to the registry:

```
Bordercollie              -> Border Collie
Norwegian Elkhound        -> Norwegian Elkhound   (breed was missing)
Simil spinone             -> Spinone Italiano     (breed was missing)
Schäferhundmix            -> German Shepherd Dog + cross
Herdenschutzhundmischling -> Livestock Guardian Dog + cross
```

## Sentinels are not registry gaps

The first version counted `Unknown` (83 rows) and `Can be the only dog` (15) as unresolved, which buried the two rows of genuinely unrecognised text and tripped the budget on a healthy run. Those are deliberate sentinels — an organisation saying "we don't know" is an answer. Unresolved is now 2 rows, which is a signal worth acting on.

## Bug fixed along the way

`JUNK_VALUES` held unnormalised literals. Matching happens on normalised text, where `"n/a"` folds to `"n a"` — so several entries could never match and part of the junk list had been dead since #330. The literals are now normalised at definition.

## Design

`reconcile()` takes rows and returns a report, with database access in the CLI wrapper only, so the logic is tested without a database. 20 tests covering unmatched detection, provisional detection, drift, totals, budget behaviour, and sentinel handling.

**1,660 backend tests pass**, ruff clean.