### PR TITLE
fix(breeds): show the display label instead of the grouping key

### DIFF
--- a/frontend/src/app/dogs/[slug]/DogDetailClient.tsx
+++ b/frontend/src/app/dogs/[slug]/DogDetailClient.tsx
@@ -26,7 +26,7 @@ import {
   sanitizeText,
   safeExternalUrl,
 } from "../../../utils/security";
-import { getAgeCategory } from "../../../utils/dogHelpers";
+import { formatBreed, getAgeCategory } from "../../../utils/dogHelpers";
 import DogDetailSkeleton from "../../../components/ui/DogDetailSkeleton";
 import DogDetailErrorBoundary from "../../../components/error/DogDetailErrorBoundary";
 import { ScrollAnimationWrapper } from "../../../hooks/useScrollAnimation";
@@ -431,7 +431,7 @@ export default function DogDetailClient({ params = {}, initialDog = null }: DogD
                                     : ""
                                 }
                                 title={`Meet ${dog.name} - Available for Adoption`}
-                                text={`${dog.name} is a ${dog.primary_breed || dog.standardized_breed || dog.breed || "lovely dog"} looking for a forever home.`}
+                                text={`${dog.name} is a ${formatBreed(dog) || "lovely dog"} looking for a forever home.`}
                                 variant="ghost"
                                 size="sm"
                                 className="p-3 rounded-full hover:bg-gray-100 transition-all duration-200 hover:scale-110 hover:shadow-md focus:ring-2 focus:ring-orange-500 focus:ring-offset-2"
@@ -451,10 +451,7 @@ export default function DogDetailClient({ params = {}, initialDog = null }: DogD
 
                     {/* Only show breed section if we have a known breed */}
                     {(() => {
-                      const breed =
-                        dog.primary_breed ||
-                        dog.standardized_breed ||
-                        dog.breed;
+                      const breed = formatBreed(dog);
                       const isUnknownBreed =
                         !breed ||
                         breed === "Unknown" ||
@@ -523,18 +520,7 @@ export default function DogDetailClient({ params = {}, initialDog = null }: DogD
                         </div>
 
                         {/* Breed Card - Only show if breed is known and not "Unknown" */}
-                        {(dog.primary_breed ||
-                          dog.standardized_breed ||
-                          dog.breed) &&
-                          !(
-                            dog.primary_breed === "Unknown" ||
-                            dog.standardized_breed === "Unknown" ||
-                            dog.breed === "Unknown" ||
-                            dog.primary_breed?.toLowerCase() === "unknown" ||
-                            dog.standardized_breed?.toLowerCase() ===
-                              "unknown" ||
-                            dog.breed?.toLowerCase() === "unknown"
-                          ) && (
+                        {formatBreed(dog) && (
                             <div
                               className="bg-green-50 dark:bg-green-900/20 rounded-lg p-4 text-center transform transition-all duration-300 hover:scale-105 hover:shadow-md border border-green-100 dark:border-green-800/30"
                               data-testid="dog-breed-card"
@@ -544,9 +530,7 @@ export default function DogDetailClient({ params = {}, initialDog = null }: DogD
                                 Breed
                               </p>
                               <p className="text-sm font-semibold text-gray-800 dark:text-gray-100">
-                                {dog.primary_breed ||
-                                  dog.standardized_breed ||
-                                  dog.breed}
+                                {formatBreed(dog)}
                               </p>
                             </div>
                           )}

--- a/frontend/src/app/dogs/[slug]/__tests__/DogDetailClient.integration.test.jsx
+++ b/frontend/src/app/dogs/[slug]/__tests__/DogDetailClient.integration.test.jsx
@@ -463,14 +463,17 @@ describe("DogDetailClient Dog Detail Integration", () => {
 });
 
 describe("Breed Display - Simplified without legacy text", () => {
-  it("should NOT show 'originally listed as' text even when primary_breed differs from breed", async () => {
+  it("should NOT show 'originally listed as' text even when the display label differs from the raw breed", async () => {
     const mockDog = {
       id: 1,
       slug: "test-dog",
       name: "Test Dog",
-      primary_breed: "German Shepherd Mix",
-      breed: "Shepherd Mix", // Different from primary_breed
-      standardized_breed: "Mixed Breed",
+      // primary_breed is the canonical identity; standardized_breed is the
+      // display label and is what the page shows.
+      primary_breed: "German Shepherd Dog",
+      standardized_breed: "German Shepherd Dog Cross",
+      breed_raw: "Shepherd Mix",
+      breed: "German Shepherd Dog Cross",
       age: "2 years",
       sex: "Male",
       weight: "50 lbs",
@@ -490,23 +493,25 @@ describe("Breed Display - Simplified without legacy text", () => {
     render(<DogDetailClient params={{ slug: "test-dog" }} />);
 
     await waitFor(() => {
-      const breedElements = screen.getAllByText("German Shepherd Mix");
+      const breedElements = screen.getAllByText("German Shepherd Dog Cross");
       expect(breedElements.length).toBeGreaterThan(0);
     });
 
     // The legacy text should NOT be present
     expect(screen.queryByText(/originally listed as/i)).not.toBeInTheDocument();
-    // The original breed value should not be shown anywhere
+    // The organisation's raw text should not be shown anywhere
     expect(screen.queryByText("Shepherd Mix")).not.toBeInTheDocument();
   });
 
-  it("should display only primary_breed when available", async () => {
+  it("should display the breed once, using the display label", async () => {
     const mockDog = {
       id: 1,
       slug: "test-dog",
       name: "Test Dog",
-      primary_breed: "Labrador Retriever Mix",
-      breed: "Lab Mix",
+      primary_breed: "Labrador Retriever",
+      standardized_breed: "Labrador Retriever Cross",
+      breed: "Labrador Retriever Cross",
+      breed_raw: "Lab Mix",
       age: "3 years",
       sex: "Female",
       weight: "60 lbs",
@@ -526,11 +531,11 @@ describe("Breed Display - Simplified without legacy text", () => {
     render(<DogDetailClient params={{ slug: "test-dog" }} />);
 
     await waitFor(() => {
-      const breedElements = screen.getAllByText("Labrador Retriever Mix");
+      const breedElements = screen.getAllByText("Labrador Retriever Cross");
       expect(breedElements.length).toBeGreaterThan(0);
     });
 
-    // Should not show the original breed value
+    // Should not show the organisation's raw text
     expect(screen.queryByText("Lab Mix")).not.toBeInTheDocument();
   });
 

--- a/frontend/src/utils/__tests__/dogHelpers.test.js
+++ b/frontend/src/utils/__tests__/dogHelpers.test.js
@@ -87,21 +87,46 @@ describe("dogHelpers", () => {
   });
 
   describe("formatBreed", () => {
-    it("prefers primary_breed over all other breed fields", () => {
+    it("shows the display label rather than the grouping key", () => {
+      // primary_breed is the canonical identity used for breed pages and
+      // filters; it deliberately omits the cross, so showing it would hide
+      // that this dog is a cross.
       const dog = {
-        breed: "Mixed Breed",
-        standardized_breed: "Mixed Breed",
-        primary_breed: "German Shepherd Mix",
+        breed: "Border Collie Cross",
+        standardized_breed: "Border Collie Cross",
+        primary_breed: "Border Collie",
       };
-      expect(formatBreed(dog)).toBe("German Shepherd Mix");
+      expect(formatBreed(dog)).toBe("Border Collie Cross");
     });
 
-    it("falls back to standardized_breed when primary_breed not available", () => {
+    it("shows both parents of a two-breed cross", () => {
       const dog = {
-        breed: "Golden Retriever Mix",
-        standardized_breed: "Golden Retriever",
+        breed: "Bichon Frise x Maltese",
+        standardized_breed: "Bichon Frise x Maltese",
+        primary_breed: "Bichon Frise",
+        secondary_breed: "Maltese",
       };
-      expect(formatBreed(dog)).toBe("Golden Retriever");
+      expect(formatBreed(dog)).toBe("Bichon Frise x Maltese");
+    });
+
+    it("shows a designer breed by its own name", () => {
+      const dog = {
+        breed: "Cockapoo",
+        standardized_breed: "Cockapoo",
+        primary_breed: "Cockapoo",
+      };
+      expect(formatBreed(dog)).toBe("Cockapoo");
+    });
+
+    it("falls back to primary_breed when no display label is present", () => {
+      expect(formatBreed({ primary_breed: "Golden Retriever" })).toBe(
+        "Golden Retriever",
+      );
+    });
+
+    it("falls back to breed when standardized_breed is absent", () => {
+      const dog = { breed: "Golden Retriever Mix", primary_breed: "Golden Retriever" };
+      expect(formatBreed(dog)).toBe("Golden Retriever Mix");
     });
 
     it("falls back to breed when primary_breed and standardized_breed not available", () => {

--- a/frontend/src/utils/dogHelpers.ts
+++ b/frontend/src/utils/dogHelpers.ts
@@ -97,7 +97,11 @@ export const getAgeCategory = (dog: DogInput | null | undefined): string => {
 };
 
 export const formatBreed = (dog: DogInput | null | undefined): string | null => {
-  const rawBreed = dog?.primary_breed || dog?.standardized_breed || dog?.breed;
+  // standardized_breed is the display label and carries the cross, e.g.
+  // "Border Collie Cross" or "Bichon Frise x Maltese". primary_breed is the
+  // canonical identity behind breed pages and filters and omits the cross, so
+  // preferring it here would hide that the dog is a cross.
+  const rawBreed = dog?.standardized_breed || dog?.breed || dog?.primary_breed;
   if (
     !rawBreed ||
     rawBreed === "Unknown" ||


### PR DESCRIPTION
## Regression this fixes

#330 made `primary_breed` the canonical identity, deliberately **without** the cross — a Border Collie Cross now has `primary_breed = "Border Collie"`. That's correct for grouping, and it's what merges the breed pages.

But `formatBreed` preferred that field:

```ts
const rawBreed = dog?.primary_breed || dog?.standardized_breed || dog?.breed;
```

So from #330 onward, **every card and detail page labelled a cross as a plain purebred**. A Border Collie Cross displayed as "Border Collie"; a Bichon Frise x Maltese displayed as "Bichon Frise". Adopters lost information they had before — my regression, introduced by that PR.

## Fix

Prefer `standardized_breed`, which is the display label and carries the cross, and keep `primary_breed` as the last resort:

| Dog | Before this PR | After |
|---|---|---|
| Border Collie Cross | Border Collie | **Border Collie Cross** |
| Bichon Frise x Maltese | Bichon Frise | **Bichon Frise x Maltese** |
| Cockapoo | Cockapoo | Cockapoo |
| Golden Retriever | Golden Retriever | Golden Retriever |

The two fields now have clearly separated jobs:

- `primary_breed` — canonical identity: breed page slug, filters, grouping. Omitting the cross is the point.
- `standardized_breed` — human label: shown to adopters, keeps the cross.

## Also removes duplicated logic

`DogDetailClient` repeated the same fallback chain inline in four places, including a nine-clause unknown-breed check:

```tsx
{(dog.primary_breed || dog.standardized_breed || dog.breed) &&
  !(dog.primary_breed === "Unknown" || dog.standardized_breed === "Unknown" ||
    dog.breed === "Unknown" || dog.primary_breed?.toLowerCase() === "unknown" ||
    ... ) && (
```

That is now `{formatBreed(dog) && (`. Same behaviour, one source of truth.

Breed **page** headings still use `primary_breed` — those pages are about the canonical breed, not one dog, so `/breeds/border-collie` correctly stays "Border Collie".

## Tests

`formatBreed` tests rewritten for the new contract: display label preferred, both parents shown for a two-breed cross, designer breeds by their own name, fallbacks intact.

Two `DogDetailClient` integration fixtures encoded the old data shape (`primary_breed: "German Shepherd Mix"` — a value the registry can no longer produce). Updated to the current model while keeping each test's original intent, including the assertion that the organisation's raw text is never rendered.

**3,588 frontend tests pass**, tsc clean, lint clean (0 errors).