### PR TITLE
fix(breeds): remove sighthound from breed_type and unify designer groups

### DIFF
--- a/api/models/requests.py
+++ b/api/models/requests.py
@@ -58,7 +58,7 @@ class AnimalFilterRequest(BaseModel):
     primary_breed: str | None = Field(default=None, description="Filter by primary breed")
     breed_type: str | None = Field(
         default=None,
-        description="Filter by breed type (purebred, mixed, crossbreed, unknown, sighthound)",
+        description="Filter by breed type (purebred, mixed, crossbreed, unknown)",
     )
 
     # Physical characteristics
@@ -152,7 +152,7 @@ class AnimalFilterRequest(BaseModel):
     def validate_breed_type_field(cls, v):
         """Validate breed_type field."""
         if not validate_breed_type(v):
-            raise ValueError(f"Invalid breed_type value: {v}. Must be one of: purebred, mixed, crossbreed, unknown, sighthound")
+            raise ValueError(f"Invalid breed_type value: {v}. Must be one of: purebred, mixed, crossbreed, unknown")
         return v
 
     @field_validator("energy_level")
@@ -295,7 +295,7 @@ class AnimalFilterCountRequest(BaseModel):
     def validate_breed_type_field(cls, v):
         """Validate breed_type field."""
         if not validate_breed_type(v):
-            raise ValueError(f"Invalid breed_type value: {v}. Must be one of: purebred, mixed, crossbreed, unknown, sighthound")
+            raise ValueError(f"Invalid breed_type value: {v}. Must be one of: purebred, mixed, crossbreed, unknown")
         return v
 
     @field_validator("energy_level")

--- a/api/models/responses.py
+++ b/api/models/responses.py
@@ -118,7 +118,7 @@ class QualifyingBreed(BaseModel):
     breed_slug: str = Field(..., description="URL-friendly breed slug")
     breed_type: str | None = Field(
         None,
-        description="Breed type (purebred, mixed, crossbreed, unknown, sighthound)",
+        description="Breed type (purebred, mixed, crossbreed, unknown)",
     )
     breed_group: str | None = Field(None, description="Breed group classification")
     count: int = Field(..., description="Total number of dogs of this breed", ge=0)

--- a/api/services/animal_service.py
+++ b/api/services/animal_service.py
@@ -2075,7 +2075,6 @@ class AnimalService:
             "mixed": "Mixed",
             "crossbreed": "Crossbreed",
             "unknown": "Unknown",
-            "sighthound": "Sighthound",
         }
 
         return [

--- a/docs/features/breed-standardization.md
+++ b/docs/features/breed-standardization.md
@@ -8,13 +8,24 @@
 | `primary_breed` | Canonical breed identity. A cross keeps its root here, so `Border Collie Cross` has `primary_breed = "Border Collie"` |
 | `secondary_breed` | The second named breed when the source names one, otherwise `NULL` |
 | `breed_slug` | Slug of `primary_breed`; the `/breeds/[slug]` page key |
-| `breed_type` | `purebred`, `crossbreed`, `mixed`, or `unknown` |
+| `breed_type` | `purebred`, `crossbreed`, `mixed`, or `unknown` — how the breed was arrived at, never what kind it is |
 | `breed_group` | Group of the primary breed, e.g. a Staffie cross is `Terrier` |
 | `breed` / `standardized_breed` | Display label, e.g. `Border Collie Cross` or `Bichon Frise x Maltese` |
 
 Being a cross is a **facet**, not an identity. `Border Collie` and
 `Border Collie Cross` therefore share one breed page rather than forking into
 two competing ones.
+
+## breed_type is not a category
+
+`breed_type` records **how** a breed was arrived at. It previously also carried
+`sighthound`, a category rather than a type, which meant Lurchers were neither
+`purebred` nor `crossbreed` and the Crossbreed filter silently excluded every
+Lurcher cross. Breed *kind* belongs in `breed_group`.
+
+All designer breeds share the group `Designer/Hybrid`. Inheriting a parent's
+group made the choice arbitrary — a Puggle is no more Hound (from Beagle) than
+Toy (from Pug).
 
 ## Adding a breed or alias
 

--- a/tests/scrapers/test_furryrescueitaly_unified_standardization.py
+++ b/tests/scrapers/test_furryrescueitaly_unified_standardization.py
@@ -93,7 +93,7 @@ class TestFurryRescueItalyUnifiedStandardization:
         processed = scraper.process_animal(animal_data)
 
         assert processed["breed"] == "Cavachon"  # Standardized breed name
-        assert processed["breed_category"] == "Designer"
+        assert processed["breed_category"] == "Designer/Hybrid"  # one spelling for the group
         # Parent breeds should be in primary/secondary breed fields
         assert processed.get("primary_breed") in [
             "Cavachon",

--- a/tests/utils/test_breed_registry.py
+++ b/tests/utils/test_breed_registry.py
@@ -237,3 +237,28 @@ class TestRegistryCoversProductionBreeds:
     @pytest.mark.parametrize("qualifier", ["Vermutlich", "Wahrscheinlich", "Similar", "Possibly"])
     def test_leading_qualifier_does_not_block_the_match(self, qualifier):
         assert resolve_breed(f"{qualifier} Newfoundland").primary == "Newfoundland"
+
+
+@pytest.mark.unit
+class TestBreedTypeTaxonomy:
+    """breed_type says how the breed was arrived at, never what kind it is."""
+
+    def test_resolver_never_emits_a_category_as_a_type(self, registry):
+        """Lurchers used to carry breed_type 'sighthound', so the Crossbreed
+        filter silently excluded every Lurcher cross."""
+        for raw in ["Lurcher", "Lurcher Cross", "Greyhound", "Whippet", "Galgo"]:
+            assert resolve_breed(raw).breed_type in {"purebred", "crossbreed", "mixed", "unknown"}
+
+    def test_lurcher_cross_is_a_crossbreed(self):
+        identity = resolve_breed("Lurcher Cross")
+        assert identity.breed_type == "crossbreed"
+        assert identity.is_cross is True
+
+    def test_every_registry_group_has_one_spelling(self, registry):
+        """'Designer' and 'Designer/Hybrid' both existed for the same concept."""
+        groups = {b.group for b in registry.breeds} | {b.group for b in registry.designer_breeds}
+        assert "Designer" not in groups
+        assert "Designer/Hybrid" in groups
+
+    def test_designer_breeds_share_one_group(self, registry):
+        assert {b.group for b in registry.designer_breeds} == {"Designer/Hybrid"}

--- a/tests/utils/test_breed_utils.py
+++ b/tests/utils/test_breed_utils.py
@@ -6,7 +6,7 @@ survives into the output has to be safe there.
 
 import pytest
 
-from utils.breed_utils import generate_breed_slug
+from utils.breed_utils import generate_breed_slug, validate_breed_type
 
 
 @pytest.mark.unit
@@ -77,3 +77,29 @@ class TestGenerateBreedSlugUnchangedBehaviour:
 
     def test_name_that_reduces_to_nothing_returns_empty_string(self):
         assert generate_breed_slug("###") == ""
+
+
+@pytest.mark.unit
+class TestValidateBreedType:
+    """breed_type describes how a breed was arrived at, not what kind it is.
+
+    'sighthound' was a category smuggled into the type enum: Lurchers carried
+    it instead of purebred or crossbreed, so the Crossbreed filter silently
+    excluded every Lurcher cross.
+    """
+
+    @pytest.mark.parametrize("breed_type", ["purebred", "mixed", "crossbreed", "unknown"])
+    def test_supported_types_are_valid(self, breed_type):
+        assert validate_breed_type(breed_type) is True
+
+    def test_sighthound_is_not_a_breed_type(self):
+        assert validate_breed_type("sighthound") is False
+
+    def test_none_is_valid(self):
+        assert validate_breed_type(None) is True
+
+    def test_unrecognised_value_is_invalid(self):
+        assert validate_breed_type("hound") is False
+
+    def test_validation_is_case_insensitive(self):
+        assert validate_breed_type("Purebred") is True

--- a/tests/utils/test_unified_standardization.py
+++ b/tests/utils/test_unified_standardization.py
@@ -74,7 +74,7 @@ class TestUnifiedStandardizer:
         # Puggle (Pug + Beagle)
         result = standardizer.apply_full_standardization(breed="Puggle")
         assert result["breed"] == "Puggle"
-        assert result["breed_category"] == "Hound"  # Puggle gets Hound category
+        assert result["breed_category"] == "Designer/Hybrid"  # all designer breeds share one group
 
         # Schnoodle (Schnauzer + Poodle)
         result = standardizer.apply_full_standardization(breed="Schnoodle")

--- a/utils/breed_registry.yaml
+++ b/utils/breed_registry.yaml
@@ -693,7 +693,7 @@ breeds:
   - terrier (yorkshire)
 designer_breeds:
 - canonical: Cavachon
-  group: Designer
+  group: Designer/Hybrid
   size: Small
   parents:
   - Cavalier King Charles Spaniel
@@ -701,7 +701,7 @@ designer_breeds:
   aliases:
   - cavashon
 - canonical: Cavapoo
-  group: Toy
+  group: Designer/Hybrid
   size: Small
   parents:
   - Cavalier King Charles Spaniel
@@ -716,7 +716,7 @@ designer_breeds:
   aliases:
   - cockerpoo
 - canonical: Goldendoodle
-  group: Sporting
+  group: Designer/Hybrid
   size: Large
   parents:
   - Golden Retriever
@@ -730,7 +730,7 @@ designer_breeds:
   - Poodle
   aliases: []
 - canonical: Maltipoo
-  group: Toy
+  group: Designer/Hybrid
   size: Small
   parents:
   - Maltese
@@ -744,21 +744,21 @@ designer_breeds:
   - Siberian Husky
   aliases: []
 - canonical: Puggle
-  group: Hound
+  group: Designer/Hybrid
   size: Small
   parents:
   - Pug
   - Beagle
   aliases: []
 - canonical: Schnoodle
-  group: Non-Sporting
+  group: Designer/Hybrid
   size: Medium
   parents:
   - Schnauzer
   - Poodle
   aliases: []
 - canonical: Yorkipoo
-  group: Toy
+  group: Designer/Hybrid
   size: Tiny
   parents:
   - Yorkshire Terrier

--- a/utils/breed_utils.py
+++ b/utils/breed_utils.py
@@ -79,5 +79,5 @@ def validate_breed_type(breed_type: str | None) -> bool:
     if breed_type is None:
         return True
 
-    allowed_types = {"purebred", "mixed", "crossbreed", "unknown", "sighthound"}
+    allowed_types = {"purebred", "mixed", "crossbreed", "unknown"}
     return breed_type.lower() in allowed_types


### PR DESCRIPTION
## `sighthound` was a category in a type enum

`breed_type` records **how** a breed was arrived at — purebred, crossbreed, mixed, unknown. It also carried `sighthound`, which is a *kind* of breed, and `breed_group` already exists for that.

The consequence was a silent filter bug: Lurchers were neither `purebred` nor `crossbreed`, so **the Crossbreed filter excluded every Lurcher cross** (12 available dogs at the time of the audit).

The registry stopped emitting it in #330. This removes the leftovers:

- `utils/breed_utils.py` — the allowed-types set
- `api/models/requests.py` — two field validators and a description
- `api/models/responses.py` — field description
- `api/services/animal_service.py` — the filter label map

Rows still carrying `sighthound` correct themselves on the next scrape, the same way `breed_raw` and `breed_slug` do.

## Designer breeds had two spellings and arbitrary groups

| Breed | Group before | After |
|---|---|---|
| Cockapoo, Labradoodle, Pomsky | `Designer/Hybrid` | `Designer/Hybrid` |
| Cavachon | `Designer` | `Designer/Hybrid` |
| Goldendoodle | `Sporting` | `Designer/Hybrid` |
| Puggle | `Hound` | `Designer/Hybrid` |
| Cavapoo, Maltipoo, Yorkipoo | `Toy` | `Designer/Hybrid` |
| Schnoodle | `Non-Sporting` | `Designer/Hybrid` |

Two spellings for one concept, and where a group was inherited it was arbitrary — a Puggle is no more Hound (from Beagle) than Toy (from Pug).

**This costs nothing today**: no stored row carries these `primary_breed` values yet, because designer breeds only started resolving to their own identity in #330 and the scrapers have not run since. Confirmed by querying production.

## Tests

New coverage for `validate_breed_type` (there was none), a guard that the resolver never emits a category as a type, and a guard that the registry has one spelling per group.

**1,672 backend tests pass**, ruff clean.

## Docs

`docs/features/breed-standardization.md` now states that `breed_type` is not a category and records why designer breeds share one group.