### PR TITLE
feat(cron): report unresolved breed text after each scrape

### DIFF
--- a/management/railway_scraper_cron.py
+++ b/management/railway_scraper_cron.py
@@ -34,6 +34,8 @@ if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
 from config import enable_world_class_scraper_logging, get_database_config  # noqa: E402
+from management.breed_commands import fetch_breed_rows  # noqa: E402
+from management.breed_reconciliation import reconcile  # noqa: E402
 from scrapers.sentry_integration import add_scrape_breadcrumb, init_scraper_sentry  # noqa: E402
 from utils.db_connection import (  # noqa: E402
     create_database_config_from_env,
@@ -98,6 +100,25 @@ def run_single_scraper(runner: SecureConfigScraperRunner, config_id: str) -> dic
     }
 
 
+def report_breed_reconciliation() -> dict:
+    """Summarise breed text the registry could not place.
+
+    The scrape is when new organisation text arrives, so it is the moment worth
+    checking. A reporting problem must never fail a scrape that otherwise
+    succeeded, so every error is captured rather than raised.
+    """
+    try:
+        report = reconcile(fetch_breed_rows(available_only=True))
+    except Exception as exc:
+        return {"error": str(exc)}
+
+    return {
+        "unmatched_rows": report.unmatched_rows,
+        "provisional_values": len(report.provisional),
+        "top_unmatched": [[text, count] for text, count in report.unmatched[:5]],
+    }
+
+
 def run_all_scrapers(runner: SecureConfigScraperRunner) -> BatchRunResult:
     """Run all enabled scrapers."""
     logger.info("Running all enabled scrapers")
@@ -125,6 +146,7 @@ def format_batch_summary(result: BatchRunResult, start_time: datetime) -> dict:
         "duration_seconds": round(duration_seconds, 2),
         "failed_orgs": failed_orgs,
         "overall_success": result.success and result.failed == 0,
+        "breed_reconciliation": report_breed_reconciliation(),
     }
 
 
@@ -235,6 +257,15 @@ def main():
 
         if summary["failed_orgs"]:
             logger.warning(f"Failed organizations: {', '.join(summary['failed_orgs'])}")
+
+        breeds = summary["breed_reconciliation"]
+        if breeds.get("error"):
+            logger.warning(f"Breed reconciliation unavailable: {breeds['error']}")
+        elif breeds["unmatched_rows"]:
+            worst = ", ".join(f"{text} ({count})" for text, count in breeds["top_unmatched"])
+            logger.warning(f"Breed text the registry cannot place: {breeds['unmatched_rows']} rows - {worst}")
+        else:
+            logger.info(f"Breed registry resolved every breed string ({breeds['provisional_values']} provisional)")
 
         print("\n" + json.dumps(summary, indent=2))
 

--- a/tests/management/test_cron_breed_reconciliation.py
+++ b/tests/management/test_cron_breed_reconciliation.py
@@ -1,0 +1,36 @@
+"""The cron reports registry gaps after each batch.
+
+The registry only stays correct if someone notices when organisations start
+sending breed text it cannot place. Running the check by hand does not scale;
+the scrape is the moment new text arrives.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from management.breed_reconciliation import BreedRow
+from management.railway_scraper_cron import report_breed_reconciliation
+
+
+@pytest.mark.unit
+class TestReportBreedReconciliation:
+    def test_returns_the_unresolved_row_count(self):
+        rows = [BreedRow("European", "European", "european", 2), BreedRow("Border Collie", "Border Collie", "border-collie", 40)]
+        with patch("management.railway_scraper_cron.fetch_breed_rows", return_value=rows):
+            assert report_breed_reconciliation()["unmatched_rows"] == 2
+
+    def test_clean_data_reports_zero(self):
+        rows = [BreedRow("Border Collie", "Border Collie", "border-collie", 40)]
+        with patch("management.railway_scraper_cron.fetch_breed_rows", return_value=rows):
+            assert report_breed_reconciliation()["unmatched_rows"] == 0
+
+    def test_surfaces_the_worst_offenders_for_the_log(self):
+        rows = [BreedRow("Tofu", "Tofu", "tofu", 3), BreedRow("European", "European", "european", 9)]
+        with patch("management.railway_scraper_cron.fetch_breed_rows", return_value=rows):
+            assert report_breed_reconciliation()["top_unmatched"][0] == ["European", 9]
+
+    def test_a_database_failure_never_breaks_the_cron(self):
+        """A reporting problem must not fail a scrape that otherwise succeeded."""
+        with patch("management.railway_scraper_cron.fetch_breed_rows", side_effect=RuntimeError("db down")):
+            assert report_breed_reconciliation() == {"error": "db down"}


### PR DESCRIPTION
## Why

#331 added the reconciliation report, but as a command someone has to remember to run. The registry only stays correct while somebody notices organizations sending text it cannot place — and the scrape is exactly when new text arrives.

This is the check that would have caught my #330 regression (148 rows of real breeds silently becoming `Unknown`) automatically, instead of after the fact.

## What it does

After each batch, the cron summary gains:

```json
"breed_reconciliation": {
  "unmatched_rows": 2,
  "provisional_values": 7,
  "top_unmatched": [["European", 2]]
}
```

and the log carries one line:

```
WARNING  Breed text the registry cannot place: 2 rows - European (2)
INFO     Breed registry resolved every breed string (7 provisional)
```

## It cannot break a scrape

`report_breed_reconciliation()` captures every exception and returns `{"error": ...}`. A reporting problem must never fail a scrape that otherwise succeeded — the report is diagnostic, not a gate. The standalone command still exits non-zero on a budget breach for anyone who wants it as one.

## Tests

Four cases: the unresolved count, clean data reporting zero, the worst offenders surfacing for the log, and a database failure leaving the cron unharmed.

**1,693 backend tests pass**, ruff clean. No migration, no schema change.