### PR TITLE
fix(rean): recover the dropped dog and stop naming dogs after page copy

### DIFF
--- a/scrapers/rean/dogs_scraper.py
+++ b/scrapers/rean/dogs_scraper.py
@@ -30,6 +30,44 @@ from utils.shared_extraction_patterns import (  # noqa: E402
     extract_weight_from_text as shared_extract_weight,
 )
 
+# Words that appear where a name would sit but never name a dog: calls to
+# action, navigation, and the charity's own copy.
+NON_NAME_WORDS = frozenset(
+    {
+        "rean",
+        "please",
+        "apply",
+        "contact",
+        "message",
+        "email",
+        "donate",
+        "home",
+        "adopt",
+        "sponsor",
+        "foster",
+        "updated",
+        "click",
+        "read",
+        "more",
+        "all",
+        "our",
+        "the",
+        "this",
+        "dogs",
+        "puppies",
+        # Sentence words that can sit where the heading name would be, as in
+        # "is 2 years old and looking for a home".
+        "is",
+        "was",
+        "are",
+        "and",
+        "for",
+        "she",
+        "he",
+        "they",
+    }
+)
+
 
 class REANScraper(BaseScraper):
     """REAN (Rescuing European Animals in Need) scraper for Romania and UK foster dogs."""
@@ -1256,6 +1294,32 @@ class REANScraper(BaseScraper):
         Returns:
             Extracted name or None
         """
+        if not text:
+            return None
+
+        # The site heading carries the name: "Louis- 4 years old - in Romania".
+        # It is sometimes lowercase in the markup, which the capitalised-word
+        # scan below cannot see, so read it here first.
+        heading = re.match(r"\s*([A-Za-z]+)\s*-?\s*\d+(?:[./]\d+)?\s*(?:months?|years?)\s+old", text)
+        if heading:
+            candidate = heading.group(1).strip().title()
+            if self._is_plausible_dog_name(candidate):
+                return candidate
+
+        candidate = self._extract_name_candidate(text)
+        return candidate if candidate and self._is_plausible_dog_name(candidate) else None
+
+    @staticmethod
+    def _is_plausible_dog_name(name: str) -> bool:
+        """Reject page furniture that reads like a name.
+
+        Container text often begins with a call to action, and "Please message
+        us..." previously produced seven dogs named "Please".
+        """
+        return name.lower() not in NON_NAME_WORDS
+
+    def _extract_name_candidate(self, text: str) -> str | None:
+        """Pattern-match a name out of the entry prose."""
         if not text:
             return None
 

--- a/tests/scrapers/rean/test_rean_scraper.py
+++ b/tests/scrapers/rean/test_rean_scraper.py
@@ -1026,3 +1026,54 @@ class TestREANIntegration:
             scraper.scrape_animals()
 
             assert mock_sleep.called
+
+
+@pytest.mark.unit
+class TestExtractNameFromLiveLayout:
+    """Names as the REAN site actually renders them.
+
+    Container text repeats the heading before the prose, so the name has to be
+    read from the heading form "Name- N years old - in Location". One dog was
+    being dropped because that heading is lowercase in the markup.
+    """
+
+    @pytest.fixture
+    def scraper(self):
+        from scrapers.rean.dogs_scraper import REANScraper
+
+        return object.__new__(REANScraper)
+
+    def test_lowercase_heading_still_yields_a_name(self):
+        from scrapers.rean.dogs_scraper import REANScraper
+
+        scraper = object.__new__(REANScraper)
+        text = "louis- 4 years old - in Romanialouis- 4 years old - in Romania Louis is one of the survivors"
+        assert scraper.extract_name(text) == "Louis"
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("Alexa - 6 months old - in Romania Alexa is a rescue pup", "Alexa"),
+            ("Annie 1 year old - in RomaniaAnnie is around 1 year old", "Annie"),
+            ("Daphne 3/4 year old - in RomaniaDaphne is a 3/4 years old", "Daphne"),
+            ("Danny -1 year old - NewmarketDanny is a rescue pup", "Danny"),
+            ("Freddie - 4.5 years old - NorfolkFreddie has been stuck", "Freddie"),
+        ],
+        ids=["spaced-hyphen", "no-hyphen", "fraction-age", "tight-hyphen", "decimal-age"],
+    )
+    def test_heading_forms_seen_on_the_site(self, scraper, text, expected):
+        assert scraper.extract_name(text) == expected
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Please message us with the following information if you would like to apply to adopt",
+            "Apply to adopt this dog today",
+            "Contact us for more information about our dogs",
+            "To donate £10 please text REAN to 70191HomeAdopt a Dog",
+        ],
+        ids=["please-cta", "apply-cta", "contact-cta", "site-chrome"],
+    )
+    def test_call_to_action_text_is_not_a_dog_name(self, scraper, text):
+        """Seven dogs named "Please" reached production from this text."""
+        assert scraper.extract_name(text) is None


### PR DESCRIPTION
## What I found

You were right that REAN has dogs. It also turned out **not** to be broken in the way its stale `last_scraped_at` suggested — today's cron ran it fine and found 12. Two narrower defects were losing data.

### 1. One dog dropped on every run

The site heading carries the name — `Louis- 4 years old - in Romania` — but in the markup that heading is **lowercase**, and `extract_name` only accepted a word starting with a capital:

```python
if word[0].isupper() and word.isalpha() and len(word) > 2:
```

So `louis-` was skipped, and container 2 logged `did not yield valid dog data` every run. The Romania page lists 8 dogs; the scraper returned 7.

### 2. Seven dogs in production are named "Please"

Where a container began with a call to action, that same scan took the first capitalised word it found:

```
"Please message us with the following information if you would like to apply to adopt"
                                    ↓
                             name = "Please"
```

Production holds 7 such rows (created 2025-12-06, `status='unknown'`, not available). They date from an older page layout and are not being recreated — but nothing prevented a recurrence.

## Fix

- Read the heading form directly and case-insensitively, covering every variant on the live pages: `Louis- 4 years`, `Alexa - 6 months`, `Annie 1 year`, `Danny -1 year`, `Daphne 3/4 year`, `Freddie - 4.5 years`
- Route every return through one `_is_plausible_dog_name` check that rejects page furniture (`please`, `apply`, `contact`, `donate`, `adopt`…) and sentence words (`is`, `was`, `she`…), so no future pattern can leak copy into a name

## Verified against the live site

```
romania:   8 dogs -> ['Louis', 'Annie', 'Lindsey', 'Athena', 'Sunny', 'Daphne', 'Rocco', 'Alexa']
uk_foster: 5 dogs -> ['Freddie', 'Danny', 'George', 'Stanley', 'Owen']
TOTAL: 13
```

13 vs the 12 today's cron reported — Louis recovered.

## Not fixed here

- The **7 legacy "Please" rows** still sit in production as `status='unknown'`. They're invisible to users; deleting production rows felt like your call rather than something to slip into a scraper fix. Say the word and I'll clean them up.
- `extract_dog_content_from_html`, the older text-block path, is genuinely broken: it splits blocks on `updated MM/DD/YY` markers the site no longer publishes, so it returns **one 74,114-character block**. The DOM path supersedes it and is what production uses, so I left it alone rather than widen this PR — but it is dead weight worth removing.

## Tests

12 new cases: the lowercase heading, all five heading forms seen live, and four call-to-action strings that must never become names.

**All 85 REAN tests pass**, 1,693 backend tests overall, ruff clean.