### PR TITLE
feat(breeds): re-resolve stored rows from the original breed text

### DIFF
--- a/docs/features/breed-standardization.md
+++ b/docs/features/breed-standardization.md
@@ -62,9 +62,21 @@ parents stay in the registry rather than being copied onto every row.
 
 ## Repairing stored values
 
-`breed_slug`, `primary_breed` and the rest are recomputed on every scrape and are
-covered by change detection, so stored rows correct themselves within one cron
-cycle (Mon/Thu/Sat 15:00 UTC). No backfill migration is needed.
+**Scrapes do not repair existing rows.** Most organisations run with
+`skip_existing_animals: true`, and `filter_existing_animals` drops dogs that are
+already stored *before* `save_animal`, so an existing animal never reaches
+`process_animal` again. Only newly listed dogs get current standardization.
+
+After any change to the registry or resolver, re-resolve the stored rows from
+the organisation's original text:
+
+```bash
+uv run python management/breed_commands.py restandardize             # dry run
+uv run python management/breed_commands.py restandardize --apply     # write
+```
+
+It reads `breed_raw`, falling back to `breed`, and rewrites the derived columns.
+The dry run prints what would change so the rewrite can be reviewed first.
 
 ## Keeping the registry current
 

--- a/management/breed_commands.py
+++ b/management/breed_commands.py
@@ -22,6 +22,7 @@ from rich.table import Table  # noqa: E402
 
 from config import DB_CONFIG  # noqa: E402
 from management.breed_reconciliation import BreedReconciliation, BreedRow, reconcile  # noqa: E402
+from management.breed_restandardize import DERIVED_FIELDS, AnimalBreedRow, BreedUpdate, plan_restandardization  # noqa: E402
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
@@ -43,6 +44,54 @@ def fetch_breed_rows(available_only: bool) -> list[BreedRow]:
     with psycopg2.connect(**DB_CONFIG) as conn, conn.cursor() as cursor:
         cursor.execute(DISTINCT_BREED_QUERY.format(available_only=clause))
         return [BreedRow(raw, primary, slug, count) for raw, primary, slug, count in cursor.fetchall()]
+
+
+STORED_BREED_QUERY = """
+    SELECT id, breed_raw, breed, primary_breed, secondary_breed, breed_slug, breed_type, breed_group
+    FROM animals
+    {available_only}
+"""
+
+
+def fetch_animal_breed_rows(available_only: bool) -> list[AnimalBreedRow]:
+    clause = "WHERE status = 'available'" if available_only else ""
+    with psycopg2.connect(**DB_CONFIG) as conn, conn.cursor() as cursor:
+        cursor.execute(STORED_BREED_QUERY.format(available_only=clause))
+        return [AnimalBreedRow(*row) for row in cursor.fetchall()]
+
+
+def apply_updates(updates: list[BreedUpdate]) -> int:
+    """Write the planned fields. Returns the number of rows changed."""
+    assignments = ", ".join(f"{name} = %s" for name in DERIVED_FIELDS)
+    statement = f"UPDATE animals SET {assignments} WHERE id = %s"
+
+    with psycopg2.connect(**DB_CONFIG) as conn, conn.cursor() as cursor:
+        for update in updates:
+            cursor.execute(statement, [update.fields[name] for name in DERIVED_FIELDS] + [update.animal_id])
+        conn.commit()
+    return len(updates)
+
+
+def render_plan(updates: list[BreedUpdate], console: Console, limit: int) -> None:
+    if not updates:
+        console.print("\n[green]Every stored row already matches the registry.[/green]\n")
+        return
+
+    table = Table(title=f"{len(updates)} rows resolve differently today", title_justify="left")
+    table.add_column("organisation text")
+    table.add_column("stored")
+    table.add_column("becomes")
+    table.add_column("slug")
+    for update in updates[:limit]:
+        table.add_row(
+            (update.source_text or "")[:38],
+            str(update.was["primary_breed"])[:30],
+            str(update.fields["primary_breed"])[:30],
+            str(update.fields["breed_slug"])[:30],
+        )
+    console.print(table)
+    if len(updates) > limit:
+        console.print(f"[dim]... and {len(updates) - limit} more[/dim]")
 
 
 def render(report: BreedReconciliation, console: Console, limit: int) -> None:
@@ -83,8 +132,9 @@ def render(report: BreedReconciliation, console: Console, limit: int) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Breed registry operations")
-    parser.add_argument("command", choices=["reconcile"])
+    parser.add_argument("command", choices=["reconcile", "restandardize"])
     parser.add_argument("--all-statuses", action="store_true", help="Include adopted and delisted dogs")
+    parser.add_argument("--apply", action="store_true", help="restandardize: write the changes (default is a dry run)")
     parser.add_argument("--limit", type=int, default=25, help="Rows shown per table")
     parser.add_argument(
         "--unmatched-budget",
@@ -94,8 +144,19 @@ def main() -> int:
     )
     args = parser.parse_args()
 
+    console = Console()
+
+    if args.command == "restandardize":
+        updates = plan_restandardization(fetch_animal_breed_rows(available_only=not args.all_statuses))
+        render_plan(updates, console, args.limit)
+        if not args.apply:
+            logger.info("Dry run - pass --apply to write these %s rows", len(updates))
+            return 0
+        logger.info("Updated %s rows", apply_updates(updates))
+        return 0
+
     report = reconcile(fetch_breed_rows(available_only=not args.all_statuses))
-    render(report, Console(), args.limit)
+    render(report, console, args.limit)
 
     if not report.is_clean(args.unmatched_budget):
         logger.error("%s unmatched rows exceeds the budget of %s", report.unmatched_rows, args.unmatched_budget)

--- a/management/breed_restandardize.py
+++ b/management/breed_restandardize.py
@@ -1,0 +1,110 @@
+"""Re-resolve stored breed fields from the organisation's original text.
+
+A scrape cannot repair these rows. Most organisations run with
+`skip_existing_animals: true`, and filter_existing_animals drops existing dogs
+before save_animal, so an existing animal never reaches process_animal again.
+Only newly listed dogs get current standardization; everything already stored
+keeps whatever the resolver produced on the day it was first seen.
+
+The planning step is pure so the rewrite can be reviewed before it is applied.
+"""
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+from utils.breed_registry import resolve_breed
+from utils.breed_utils import generate_breed_slug
+
+DERIVED_FIELDS = (
+    "primary_breed",
+    "secondary_breed",
+    "breed_slug",
+    "breed_type",
+    "breed_group",
+    "standardized_breed",
+    "breed_confidence",
+)
+
+
+@dataclass(frozen=True)
+class AnimalBreedRow:
+    """One stored animal's breed columns."""
+
+    id: int
+    breed_raw: str | None
+    breed: str | None
+    primary_breed: str | None
+    secondary_breed: str | None
+    breed_slug: str | None
+    breed_type: str | None
+    breed_group: str | None
+
+
+@dataclass(frozen=True)
+class BreedUpdate:
+    """A row that resolves differently today than what is stored."""
+
+    animal_id: int
+    source_text: str
+    fields: dict[str, Any]
+    was: dict[str, Any]
+
+
+def _display_name(identity) -> str:
+    if identity.parents:
+        return identity.primary
+    if identity.secondary:
+        return f"{identity.primary} x {identity.secondary}"
+    return f"{identity.primary} Cross" if identity.is_cross else identity.primary
+
+
+def _resolved_fields(source: str) -> dict[str, Any]:
+    identity = resolve_breed(source)
+
+    if identity.primary is None:
+        name = "Mixed Breed" if identity.breed_type == "mixed" else "Unknown"
+        return {
+            "primary_breed": name,
+            "secondary_breed": None,
+            "breed_slug": identity.slug or generate_breed_slug(name),
+            "breed_type": identity.breed_type,
+            "breed_group": identity.group,
+            "standardized_breed": name,
+            "breed_confidence": identity.confidence,
+        }
+
+    return {
+        "primary_breed": identity.primary,
+        "secondary_breed": identity.secondary,
+        "breed_slug": identity.slug,
+        "breed_type": identity.breed_type,
+        "breed_group": identity.group,
+        "standardized_breed": _display_name(identity),
+        "breed_confidence": identity.confidence,
+    }
+
+
+def plan_restandardization(rows: Iterable[AnimalBreedRow]) -> list[BreedUpdate]:
+    """Return the rows whose stored breed fields disagree with the registry."""
+    updates: list[BreedUpdate] = []
+
+    for row in rows:
+        source = row.breed_raw or row.breed
+        if not source:
+            continue
+
+        fields = _resolved_fields(source)
+        stored = {
+            "primary_breed": row.primary_breed,
+            "secondary_breed": row.secondary_breed,
+            "breed_slug": row.breed_slug,
+            "breed_type": row.breed_type,
+            "breed_group": row.breed_group,
+        }
+        if all(fields[key] == stored[key] for key in stored):
+            continue
+
+        updates.append(BreedUpdate(animal_id=row.id, source_text=source, fields=fields, was=stored))
+
+    return updates

--- a/tests/management/test_breed_restandardize.py
+++ b/tests/management/test_breed_restandardize.py
@@ -1,0 +1,66 @@
+"""Re-resolving stored rows from the organisation's original text.
+
+Scrapes cannot repair these rows: most organisations run with
+skip_existing_animals, so an existing dog never reaches process_animal again.
+Only new dogs get current standardization, which is why a backfill is needed
+rather than optional.
+"""
+
+import pytest
+
+from management.breed_restandardize import AnimalBreedRow, plan_restandardization
+
+
+def _row(animal_id, raw, primary, slug, breed_type="purebred", group="Unknown", secondary=None):
+    return AnimalBreedRow(
+        id=animal_id,
+        breed_raw=raw,
+        breed=raw,
+        primary_breed=primary,
+        secondary_breed=secondary,
+        breed_slug=slug,
+        breed_type=breed_type,
+        breed_group=group,
+    )
+
+
+@pytest.mark.unit
+class TestPlanRestandardization:
+    def test_row_already_correct_is_not_updated(self):
+        rows = [_row(1, "Border Collie", "Border Collie", "border-collie", "purebred", "Herding")]
+        assert plan_restandardization(rows) == []
+
+    def test_cross_suffix_row_is_rewritten_to_its_root(self):
+        rows = [_row(2, "Border Collie Cross", "Border Collie Cross", "border-collie-cross", "crossbreed", "Mixed")]
+        plan = plan_restandardization(rows)
+        assert len(plan) == 1
+        assert plan[0].animal_id == 2
+        assert plan[0].fields["primary_breed"] == "Border Collie"
+        assert plan[0].fields["breed_slug"] == "border-collie"
+
+    def test_designer_breed_regains_its_own_identity(self):
+        rows = [_row(3, "Cockapoo", "Cocker Spaniel", "cocker-spaniel", "crossbreed", "Designer/Hybrid")]
+        plan = plan_restandardization(rows)
+        assert plan[0].fields["primary_breed"] == "Cockapoo"
+        assert plan[0].fields["breed_slug"] == "cockapoo"
+
+    def test_sighthound_becomes_a_real_breed_type(self):
+        rows = [_row(4, "Lurcher", "Lurcher", "lurcher", "sighthound", "Hound")]
+        plan = plan_restandardization(rows)
+        assert plan[0].fields["breed_type"] == "purebred"
+
+    def test_falls_back_to_breed_when_raw_is_missing(self):
+        row = AnimalBreedRow(id=5, breed_raw=None, breed="Lurcher Cross", primary_breed="Lurcher Cross", secondary_breed=None, breed_slug="lurcher-cross", breed_type="sighthound", breed_group="Hound")
+        plan = plan_restandardization([row])
+        assert plan[0].fields["primary_breed"] == "Lurcher"
+
+    def test_row_with_no_breed_text_is_skipped(self):
+        row = AnimalBreedRow(id=6, breed_raw=None, breed=None, primary_breed="Unknown", secondary_breed=None, breed_slug="unknown", breed_type="unknown", breed_group="Unknown")
+        assert plan_restandardization([row]) == []
+
+    def test_plan_carries_every_derived_field(self):
+        rows = [_row(7, "Terrier (Staffordshire Bull) Cross", "Staffordshire Bull Terrier Mix", "staffordshire-bull-terrier-mix", "crossbreed", "Mixed")]
+        fields = plan_restandardization(rows)[0].fields
+        assert set(fields) == {"primary_breed", "secondary_breed", "breed_slug", "breed_type", "breed_group", "standardized_breed", "breed_confidence"}
+        assert fields["primary_breed"] == "Staffordshire Bull Terrier"
+        assert fields["breed_group"] == "Terrier"


### PR DESCRIPTION
## I got this wrong in five merged PRs

I claimed in #328, #330, #332, #333 and #334 that *"stored rows correct themselves on the next scrape through change detection."*

**They don't.** Most organizations run `skip_existing_animals: true`, and `filter_existing_animals` (`scrapers/filtering/filtering_service.py:96-101`) drops already-stored dogs **before** `save_animal` — so an existing animal never reaches `process_animal` again. Only newly listed dogs get current standardization.

A full scrape with all that code deployed bears it out:

| Metric | Before scrape | After |
|---|---|---|
| `primary_breed` ending Cross/Mix | 289 | 243 *(turnover only)* |
| `breed_type='sighthound'` | 43 | 40 |
| Cockapoos with their own identity | 0 | **0** |

`breed_raw` rose only because new dogs were added. The code in those PRs is correct; the "no backfill needed" line was not.

`backfill_standardization.py` can't do it either — it reads the already-standardized `breed` column under narrow `WHERE` clauses, so it re-derives from its own prior output. That's the exact flaw the original audit identified.

## What this adds

```bash
uv run python management/breed_commands.py restandardize            # dry run
uv run python management/breed_commands.py restandardize --apply    # write
```

Reads `breed_raw`, falls back to `breed`, and rewrites the derived columns. Planning is a **pure function over rows**, so it's unit-tested without a database and the rewrite is reviewable before it touches anything. Dry run is the default.

## Dry run against production

**939 of 1,672 available rows would change:**

| Field | Rows | Example |
|---|---|---|
| `secondary_breed` | 871 | literal `"Mixed Breed"` → `None` |
| `breed_slug` | 312 | `podenco-mix` → `podenco` |
| `primary_breed` | 307 | `Podenco Mix` → `Podenco` |
| `breed_group` | 295 | `Mixed` → `Hound` |
| `breed_type` | 78 | `unknown` → `purebred` (e.g. `Deutsch Kurzhaar`) |

Every one is an intended effect of #330–#333. No surprises in the diff.

## Running it

This is the step that finally makes the registry work visible on the site — breed pages 13 → 19, German Shepherd Dog 17 → 55, and so on. It writes to production, so it's yours to run:

```bash
uv run python management/breed_commands.py restandardize            # review
uv run python management/breed_commands.py restandardize --apply
```

Worth running **after** #335 (`breed_confidence` numeric), since this writes that column too.

## Docs

`docs/features/breed-standardization.md` carried the same wrong claim. Corrected to explain why scrapes cannot repair existing rows and to point at this command.

**1,697 backend tests pass**, ruff clean. 7 new tests.