### PR TITLE
fix(breeds): point the breed commands at the database they are meant to change

### DIFF
--- a/docs/features/breed-standardization.md
+++ b/docs/features/breed-standardization.md
@@ -71,9 +71,14 @@ After any change to the registry or resolver, re-resolve the stored rows from
 the organisation's original text:
 
 ```bash
+export RAILWAY_DATABASE_URL="<the Railway Postgres connection string>"
 uv run python management/breed_commands.py restandardize             # dry run
 uv run python management/breed_commands.py restandardize --apply     # write
 ```
+
+Both `restandardize` and `reconcile` use `RAILWAY_DATABASE_URL` when it is set
+and the local database otherwise, matching how migrations are applied. The
+command prints which target it chose before doing anything.
 
 It reads `breed_raw`, falling back to `breed`, and rewrites the derived columns.
 The dry run prints what would change so the rewrite can be reviewed first.

--- a/management/breed_commands.py
+++ b/management/breed_commands.py
@@ -27,6 +27,24 @@ from management.breed_restandardize import DERIVED_FIELDS, AnimalBreedRow, Breed
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
+
+def _connect():
+    """Connect to the database this command is meant to act on.
+
+    Migrations target production through RAILWAY_DATABASE_URL, so this follows
+    the same convention. Without it the command silently reads the local
+    database, which is not where the rows needing repair live.
+    """
+    database_url = os.getenv("RAILWAY_DATABASE_URL")
+    if database_url:
+        return psycopg2.connect(database_url)
+    return psycopg2.connect(**DB_CONFIG)
+
+
+def describe_target() -> str:
+    return "production (RAILWAY_DATABASE_URL)" if os.getenv("RAILWAY_DATABASE_URL") else f"local ({DB_CONFIG.get('database')})"
+
+
 DISTINCT_BREED_QUERY = """
     SELECT COALESCE(breed_raw, breed) AS raw,
            MIN(primary_breed) AS stored_primary,
@@ -41,7 +59,7 @@ DISTINCT_BREED_QUERY = """
 
 def fetch_breed_rows(available_only: bool) -> list[BreedRow]:
     clause = "AND status = 'available'" if available_only else ""
-    with psycopg2.connect(**DB_CONFIG) as conn, conn.cursor() as cursor:
+    with _connect() as conn, conn.cursor() as cursor:
         cursor.execute(DISTINCT_BREED_QUERY.format(available_only=clause))
         return [BreedRow(raw, primary, slug, count) for raw, primary, slug, count in cursor.fetchall()]
 
@@ -55,7 +73,7 @@ STORED_BREED_QUERY = """
 
 def fetch_animal_breed_rows(available_only: bool) -> list[AnimalBreedRow]:
     clause = "WHERE status = 'available'" if available_only else ""
-    with psycopg2.connect(**DB_CONFIG) as conn, conn.cursor() as cursor:
+    with _connect() as conn, conn.cursor() as cursor:
         cursor.execute(STORED_BREED_QUERY.format(available_only=clause))
         return [AnimalBreedRow(*row) for row in cursor.fetchall()]
 
@@ -65,7 +83,7 @@ def apply_updates(updates: list[BreedUpdate]) -> int:
     assignments = ", ".join(f"{name} = %s" for name in DERIVED_FIELDS)
     statement = f"UPDATE animals SET {assignments} WHERE id = %s"
 
-    with psycopg2.connect(**DB_CONFIG) as conn, conn.cursor() as cursor:
+    with _connect() as conn, conn.cursor() as cursor:
         for update in updates:
             cursor.execute(statement, [update.fields[name] for name in DERIVED_FIELDS] + [update.animal_id])
         conn.commit()
@@ -77,7 +95,24 @@ def render_plan(updates: list[BreedUpdate], console: Console, limit: int) -> Non
         console.print("\n[green]Every stored row already matches the registry.[/green]\n")
         return
 
-    table = Table(title=f"{len(updates)} rows resolve differently today", title_justify="left")
+    # Summarise by what actually changes; a row whose primary breed is stable
+    # but whose secondary is being cleared otherwise reads as a no-op.
+    by_shape: dict[tuple[str, ...], list] = {}
+    for update in updates:
+        shape = tuple(sorted(key for key, old_value in update.was.items() if update.fields[key] != old_value))
+        by_shape.setdefault(shape, []).append(update)
+
+    summary = Table(title=f"{len(updates)} rows resolve differently today", title_justify="left")
+    summary.add_column("fields changing")
+    summary.add_column("rows", justify="right")
+    summary.add_column("example")
+    for shape, group in sorted(by_shape.items(), key=lambda kv: -len(kv[1])):
+        sample = group[0]
+        detail = ", ".join(f"{key}: {sample.was[key]!r}->{sample.fields[key]!r}" for key in shape)
+        summary.add_row(", ".join(shape), str(len(group)), detail[:70])
+    console.print(summary)
+
+    table = Table(title="Sample rows", title_justify="left")
     table.add_column("organisation text")
     table.add_column("stored")
     table.add_column("becomes")
@@ -85,9 +120,9 @@ def render_plan(updates: list[BreedUpdate], console: Console, limit: int) -> Non
     for update in updates[:limit]:
         table.add_row(
             (update.source_text or "")[:38],
-            str(update.was["primary_breed"])[:30],
-            str(update.fields["primary_breed"])[:30],
-            str(update.fields["breed_slug"])[:30],
+            str(update.was["primary_breed"])[:26],
+            str(update.fields["primary_breed"])[:26],
+            str(update.fields["breed_slug"])[:26],
         )
     console.print(table)
     if len(updates) > limit:
@@ -145,6 +180,7 @@ def main() -> int:
     args = parser.parse_args()
 
     console = Console()
+    console.print(f"[dim]target: {describe_target()}[/dim]")
 
     if args.command == "restandardize":
         updates = plan_restandardization(fetch_animal_breed_rows(available_only=not args.all_statuses))

--- a/tests/management/test_breed_reconciliation.py
+++ b/tests/management/test_breed_reconciliation.py
@@ -119,3 +119,44 @@ class TestKnownNonBreedsAreNotRegistryGaps:
     def test_sentinels_do_not_break_the_budget(self):
         rows = [BreedRow("Unknown", "Unknown", "unknown", 83), BreedRow("European", "European", "european", 2)]
         assert reconcile(rows).is_clean(unmatched_row_budget=10)
+
+
+@pytest.mark.unit
+class TestCommandTargetsTheRightDatabase:
+    """The rows needing repair live in production, not in a local database.
+
+    Migrations reach production through RAILWAY_DATABASE_URL. This command has
+    to follow the same convention, or it silently operates on the wrong data.
+    """
+
+    def test_railway_url_is_preferred_when_set(self, monkeypatch):
+        from management import breed_commands
+
+        monkeypatch.setenv("RAILWAY_DATABASE_URL", "postgresql://u:p@remote/railway")
+        captured = {}
+        monkeypatch.setattr(breed_commands.psycopg2, "connect", lambda *a, **k: captured.update(args=a, kwargs=k))
+
+        breed_commands._connect()
+
+        assert captured["args"] == ("postgresql://u:p@remote/railway",)
+        assert captured["kwargs"] == {}
+
+    def test_falls_back_to_local_config_when_unset(self, monkeypatch):
+        from management import breed_commands
+
+        monkeypatch.delenv("RAILWAY_DATABASE_URL", raising=False)
+        captured = {}
+        monkeypatch.setattr(breed_commands.psycopg2, "connect", lambda *a, **k: captured.update(args=a, kwargs=k))
+
+        breed_commands._connect()
+
+        assert captured["args"] == ()
+        assert captured["kwargs"]
+
+    def test_target_is_named_so_the_operator_can_see_it(self, monkeypatch):
+        from management import breed_commands
+
+        monkeypatch.setenv("RAILWAY_DATABASE_URL", "postgresql://u:p@remote/railway")
+        assert "production" in breed_commands.describe_target()
+        monkeypatch.delenv("RAILWAY_DATABASE_URL")
+        assert "local" in breed_commands.describe_target()


### PR DESCRIPTION
## Bug

`reconcile` and `restandardize` connected through `DB_CONFIG`, which resolves to the **local** database. The rows needing repair are in production.

So the command I told you to run in #338 would have rewritten a local copy — or failed outright, which is what happened when I first ran it:

```
psycopg2.errors.UndefinedColumn: column "breed_raw" does not exist
```

My local database was never migrated, so `breed_raw` isn't there. A developer whose local database *is* migrated would have silently rewritten the wrong data instead of seeing an error.

## Fix

Both commands now use `RAILWAY_DATABASE_URL` when set and fall back to the local config — the same convention migrations use — and print the target before doing anything:

```
target: production (RAILWAY_DATABASE_URL)
939 rows resolve differently today
```

## Dry run was also misleading

It grouped every row under its primary breed, so the 586 rows that only shed the literal `"Mixed Breed"` secondary rendered as:

```
Mixed Breed  |  Mixed Breed  ->  Mixed Breed     # looks like a no-op
```

It now summarises by which fields actually change, which is the whole point of reviewing before applying:

| fields changing | rows | example |
|---|---|---|
| `secondary_breed` | 586 | `'Mixed Breed'` → `None` |
| `breed_group, breed_slug, primary_breed, secondary_breed` | 262 | `podenco-mix` → `podenco` |
| `breed_type` | 29 | `'sighthound'` → `'purebred'` |
| `breed_group, breed_slug, breed_type, primary_breed` | 20 | `deutsch-kurzhaar` → `german-shorthaired-pointer` |
| `breed_slug, breed_type, primary_breed, secondary_breed` | 15 | `lurcher-cross` → `lurcher` |

Same 939 rows as #338 reported — only the presentation and the connection target changed.

## Tests

Three cases: the Railway URL is preferred when set, the local config is used otherwise, and the chosen target is named for the operator.

**1,703 backend tests pass**, ruff clean.