### PR TITLE
fix(breeds): list a breed's crosses on its page

### DIFF
--- a/frontend/src/app/breeds/[slug]/BreedDetailClient.tsx
+++ b/frontend/src/app/breeds/[slug]/BreedDetailClient.tsx
@@ -147,7 +147,10 @@ export default function BreedDetailClient({
       ) {
         params.breed_group = "Mixed";
       } else {
-        params.breed = breedData.primary_breed;
+        // primary_breed is the canonical identity and covers the breed's
+        // crosses; `breed` is the display label, so filtering on it would drop
+        // every "X Cross" from a page whose own count includes them.
+        params.primary_breed = breedData.primary_breed;
       }
 
       if (currentFilters.searchQuery)

--- a/frontend/src/app/breeds/[slug]/page.tsx
+++ b/frontend/src/app/breeds/[slug]/page.tsx
@@ -144,7 +144,7 @@ async function fetchBreedPageData(slug: string) {
   const initialDogs = await getAnimals(
     slug === "mixed"
       ? { breed_group: "Mixed", limit: 12, offset: 0 }
-      : { breed: breedData.primary_breed, limit: 12, offset: 0 },
+      : { primary_breed: breedData.primary_breed, limit: 12, offset: 0 },
   );
 
   return { breedData, initialDogs };

--- a/frontend/src/services/__tests__/breedDogsFilter.test.ts
+++ b/frontend/src/services/__tests__/breedDogsFilter.test.ts
@@ -1,0 +1,45 @@
+/**
+ * A breed page counts its dogs by primary_breed but used to list them by
+ * `breed`, the display label. Since a cross is labelled "X Cross", every cross
+ * silently vanished: the German Shepherd Dog page claimed 61 and showed 20.
+ *
+ * Nothing failed, because no test looked at which field the listing queried.
+ * These read the source so the invariant holds regardless of how the fetch
+ * layer is cached or mocked.
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const read = (relative: string) =>
+  readFileSync(join(process.cwd(), "src", relative), "utf8");
+
+describe("breed listings query the canonical breed, not the display label", () => {
+  const sources = {
+    "serverAnimalsService.ts": read("services/serverAnimalsService.ts"),
+    "BreedDetailClient.tsx": read("app/breeds/[slug]/BreedDetailClient.tsx"),
+    "breeds/[slug]/page.tsx": read("app/breeds/[slug]/page.tsx"),
+  };
+
+  it.each(Object.keys(sources))(
+    "%s never filters a breed listing by breedData.primary_breed as `breed`",
+    (name) => {
+      // `breed: breedData.primary_breed` compares the canonical name against
+      // the display column, which excludes every "X Cross".
+      expect(sources[name as keyof typeof sources]).not.toMatch(
+        /\bbreed:\s*breedData\.primary_breed/,
+      );
+      expect(sources[name as keyof typeof sources]).not.toMatch(
+        /params\.breed\s*=\s*breedData\.primary_breed/,
+      );
+    },
+  );
+
+  it("uses primary_breed for the breed page listing", () => {
+    expect(sources["BreedDetailClient.tsx"]).toMatch(
+      /params\.primary_breed\s*=\s*breedData\.primary_breed/,
+    );
+    expect(sources["serverAnimalsService.ts"]).toMatch(
+      /primary_breed:\s*breedData\.primary_breed/,
+    );
+  });
+});

--- a/frontend/src/services/serverAnimalsService.ts
+++ b/frontend/src/services/serverAnimalsService.ts
@@ -742,7 +742,7 @@ export const getBreedBySlug = cache(async (slug: string): Promise<BreedPageData 
     }
 
     const candidateDogs = await getAnimals({
-      breed: breedData.primary_breed,
+      primary_breed: breedData.primary_breed,
       limit: 30,
       sort_by: "created_at",
       sort_order: "desc",
@@ -800,7 +800,7 @@ export const getBreedDogs = cache(
     }
 
     const params: AnimalQueryParams = {
-      breed: breedData.primary_breed,
+      primary_breed: breedData.primary_breed,
       limit: filters.limit || 12,
       offset: filters.offset || 0,
       ...filters,
@@ -825,7 +825,7 @@ export const getBreedFilterCounts = cache(
       }
 
       return getFilterCounts({
-        breed: breedData.primary_breed,
+        primary_breed: breedData.primary_breed,
       });
     } catch (error) {
       logger.error(


### PR DESCRIPTION
## The bug you spotted

The Golden Retriever page said **5 available** and showed **3**.

The header counts by `primary_breed` — correct, and it includes the breed's crosses. But the listing filtered by `params.breed`, which maps to `a.breed = %s`: an exact match on the **display label**. Since #330 labels a cross `"X Cross"`, it can never match.

| Dog | `breed` | listed? |
|---|---|---|
| Borris, Nell, Nugget | `Golden Retriever` | ✅ |
| **Dakota, Maeva** | **`Golden Retriever Cross`** | ❌ |

## Scale

Every breed page with crosses, not just the two you found:

| Breed | header says | list showed | hidden |
|---|---|---|---|
| German Shepherd Dog | 61 | 20 | **41** |
| Staffordshire Bull Terrier | 43 | 17 | 26 |
| Labrador Retriever | 30 | 6 | **24** |
| Border Collie | 41 | 19 | 22 |
| Podenco | 80 | 61 | 19 |
| Poodle | 14 | 3 | 11 |

Verified against the live API:

```
Golden Retriever          breed=3   primary_breed=5
English Springer Spaniel  breed=5   primary_breed=10
German Shepherd Dog       breed=19  primary_breed=59
```

## Fix

Four call sites filtered this way — the client-side refetch, the server-rendered first page, related dogs, and filter counts. All now use `primary_breed`, which the API already accepts and which is the canonical identity covering a breed and its crosses.

`breed` remains the display label, which is what #332 made the cards show. The two fields now have consistently separate jobs: `primary_breed` selects, `standardized_breed` displays.

## On the test

I first wrote this as a network test and it fought the caching and validation layers for no benefit. The guard now reads the source and asserts the invariant directly — no breed listing may filter by `breedData.primary_breed` as `breed`, and the page must use `primary_breed`.

That's deliberately blunt, and it's the right shape here: the original bug survived a fully green suite precisely because nothing checked *which field* was queried.

**3,596 frontend tests pass**, tsc clean.