### PR TITLE
fix(dogs): filter by canonical breed so /dogs agrees with the breed pages

### DIFF
--- a/api/services/animal_service.py
+++ b/api/services/animal_service.py
@@ -549,15 +549,22 @@ class AnimalService:
         return Animal(**animal_dict)
 
     def get_distinct_breeds(self, breed_group: str | None = None) -> list[str]:
-        """Get distinct standardized breeds."""
+        """Get distinct canonical breeds for the breed filter.
+
+        Uses primary_breed rather than the standardized_breed display label:
+        the label distinguishes "Border Collie" from "Border Collie Cross", so
+        listing it would offer both and split one breed's dogs across two
+        options, disagreeing with the breed pages, which cover a breed together
+        with its crosses.
+        """
         try:
             query = """
-                SELECT DISTINCT standardized_breed
+                SELECT DISTINCT primary_breed
                 FROM animals
-                WHERE standardized_breed IS NOT NULL
-                  AND standardized_breed != ''
-                  AND standardized_breed NOT IN ('Yes', 'No', 'Unknown')
-                  AND LENGTH(standardized_breed) > 1
+                WHERE primary_breed IS NOT NULL
+                  AND primary_breed != ''
+                  AND primary_breed NOT IN ('Yes', 'No', 'Unknown')
+                  AND LENGTH(primary_breed) > 1
                   AND status = 'available'
                   AND active = true
             """
@@ -567,10 +574,10 @@ class AnimalService:
                 query += " AND breed_group = %s"
                 params.append(breed_group)
 
-            query += " ORDER BY standardized_breed"
+            query += " ORDER BY primary_breed"
 
             self.cursor.execute(query, tuple(params))
-            return [row["standardized_breed"] for row in self.cursor.fetchall()]
+            return [row["primary_breed"] for row in self.cursor.fetchall()]
 
         except Exception as e:
             logger.error(f"Error in get_distinct_breeds: {e}")
@@ -1468,7 +1475,7 @@ class AnimalService:
             response.sex_options = self._get_sex_counts(base_conditions, base_params, filters)
 
             # Get breed counts (limit to top breeds to avoid overwhelming response)
-            response.breed_options = self._get_breed_counts(base_conditions, base_params, filters)
+            response.breed_options = self._get_primary_breed_counts(base_conditions, base_params, filters)
 
             # Get organization counts
             response.organization_options = self._get_organization_counts(base_conditions, base_params, filters)

--- a/frontend/src/hooks/dogs/__tests__/useDogsFilters.test.ts
+++ b/frontend/src/hooks/dogs/__tests__/useDogsFilters.test.ts
@@ -419,14 +419,27 @@ describe("breed filter uses the canonical breed", () => {
   // Filtering on standardized_breed - the display label - split each breed
   // into "X" and "X Cross", so /dogs disagreed with the breed pages: picking
   // Border Collie returned 20 dogs where /breeds/border-collie showed 41.
+  const withBreed = (breedFilter: string): Filters => ({
+    searchQuery: "",
+    sizeFilter: "Any size",
+    ageFilter: "Any age",
+    sexFilter: "Any",
+    organizationFilter: "any",
+    breedFilter,
+    breedGroupFilter: "Any group",
+    locationCountryFilter: "Any country",
+    availableCountryFilter: "Any country",
+    availableRegionFilter: "Any region",
+  });
+
   it("sends primary_breed, not the display label", () => {
-    const params = buildAPIParams({ breedFilter: "Border Collie" });
+    const params = buildAPIParams(withBreed("Border Collie"));
 
     expect(params.primary_breed).toBe("Border Collie");
     expect(params.standardized_breed).toBeUndefined();
   });
 
   it("omits the breed filter at its default", () => {
-    expect(buildAPIParams({ breedFilter: "Any breed" }).primary_breed).toBeUndefined();
+    expect(buildAPIParams(withBreed("Any breed")).primary_breed).toBeUndefined();
   });
 });

--- a/frontend/src/hooks/dogs/__tests__/useDogsFilters.test.ts
+++ b/frontend/src/hooks/dogs/__tests__/useDogsFilters.test.ts
@@ -161,7 +161,7 @@ describe("useDogsFilters", () => {
         age_category: "Puppy",
         sex: "Male",
         organization_id: "1",
-        standardized_breed: "Labrador",
+        primary_breed: "Labrador",
         breed_group: "Sporting",
         location_country: "Germany",
         available_to_country: "Finland",
@@ -412,5 +412,21 @@ describe("useDogsFilters", () => {
 
       expect(result.current.availableRegions).toEqual(["Any region"]);
     });
+  });
+});
+
+describe("breed filter uses the canonical breed", () => {
+  // Filtering on standardized_breed - the display label - split each breed
+  // into "X" and "X Cross", so /dogs disagreed with the breed pages: picking
+  // Border Collie returned 20 dogs where /breeds/border-collie showed 41.
+  it("sends primary_breed, not the display label", () => {
+    const params = buildAPIParams({ breedFilter: "Border Collie" });
+
+    expect(params.primary_breed).toBe("Border Collie");
+    expect(params.standardized_breed).toBeUndefined();
+  });
+
+  it("omits the breed filter at its default", () => {
+    expect(buildAPIParams({ breedFilter: "Any breed" }).primary_breed).toBeUndefined();
   });
 });

--- a/frontend/src/hooks/dogs/useDogsFilters.ts
+++ b/frontend/src/hooks/dogs/useDogsFilters.ts
@@ -205,7 +205,10 @@ function buildAPIParams(filterValues: Filters): Record<string, string> {
 
   const breed = (filterValues.breedFilter || "").trim();
   if (breed && breed !== FILTER_DEFAULTS.BREED) {
-    params.standardized_breed = breed;
+    // primary_breed is the canonical identity, so a breed and its crosses stay
+    // together. standardized_breed is the display label and would split them,
+    // disagreeing with the breed pages.
+    params.primary_breed = breed;
   }
 
   const breedGroup = (filterValues.breedGroupFilter || "").trim();

--- a/tests/services/test_animal_service_breed_groups.py
+++ b/tests/services/test_animal_service_breed_groups.py
@@ -37,7 +37,7 @@ class TestBreedGroupQueriesUseColumn:
         assert service.get_distinct_breed_groups() == ["Guardian"]
 
     def test_distinct_breeds_filters_by_group_column(self):
-        service, cursor = _service_with_rows([{"standardized_breed": "Greyhound"}])
+        service, cursor = _service_with_rows([{"primary_breed": "Greyhound"}])
 
         result = service.get_distinct_breeds(breed_group="Hound")
 
@@ -47,8 +47,38 @@ class TestBreedGroupQueriesUseColumn:
         assert result == ["Greyhound"]
 
     def test_distinct_breeds_ignores_any_group_sentinel(self):
-        service, cursor = _service_with_rows([{"standardized_breed": "Greyhound"}])
+        service, cursor = _service_with_rows([{"primary_breed": "Greyhound"}])
 
         service.get_distinct_breeds(breed_group="Any group")
 
         assert "Any group" not in (cursor.execute.call_args[0][1] or [])
+
+
+@pytest.mark.unit
+class TestDogsFilterUsesCanonicalBreed:
+    """The /dogs breed filter must agree with the breed pages.
+
+    Filtering on standardized_breed - the display label - split every breed
+    into "X" and "X Cross", so picking Border Collie on /dogs returned 20 dogs
+    while /breeds/border-collie showed 41. The dropdown carried 167 options,
+    78 of them a cross of a breed already listed.
+    """
+
+    def test_distinct_breeds_lists_canonical_breeds(self):
+        service, cursor = _service_with_rows([{"primary_breed": "Border Collie"}])
+
+        result = service.get_distinct_breeds()
+
+        sql = cursor.execute.call_args[0][0]
+        assert "primary_breed" in sql
+        assert "standardized_breed" not in sql, "the display label splits X from X Cross"
+        assert result == ["Border Collie"]
+
+    def test_distinct_breeds_still_filters_by_group(self):
+        service, cursor = _service_with_rows([{"primary_breed": "Greyhound"}])
+
+        service.get_distinct_breeds(breed_group="Hound")
+
+        sql, params = cursor.execute.call_args[0]
+        assert "breed_group = %s" in sql
+        assert "Hound" in params


### PR DESCRIPTION
## Problem

The `/dogs` breed filter queried `standardized_breed` — the display label. Since #330 labels a cross `"X Cross"`, every breed split into two dropdown entries and picking one returned only part of it:

| | |
|---|---|
| Pick "Border Collie" on `/dogs` | 20 dogs |
| `/breeds/border-collie` | 41 dogs |

Same site, same breed, two answers. The dropdown carried **167 options, 78 of them a cross of a breed already listed**; on `primary_breed` it's **101**.

This is the purebred-vs-cross question we settled for breed pages (merge), left applied inconsistently because #330 changed the pages and not this filter.

## Change

The dropdown query, the filter counts and the request parameter all move to `primary_breed` — the canonical identity that covers a breed together with its crosses, and the same basis the breed pages use.

The counts helper for this **already existed** as `_get_primary_breed_counts` and had never been called; it's now wired up in place of the display-label one, so there's a single way to count breeds rather than two.

## Backward compatible

Links carrying `?standardized_breed=` still work — the API keeps that filter. Only what the UI *sends* and *lists* has changed.

## Tests

Backend: the dropdown queries `primary_breed`, not the display label, and still honours the group filter.

Frontend: `buildAPIParams` sends `primary_breed` and never `standardized_breed`, and omits the filter at its default.

Two earlier tests mocked rows keyed on `standardized_breed` and were updated to the column the code now reads.

**1,707 backend**, **3,598 frontend**, ruff clean, tsc clean.