### PR TITLE
fix: ground LLM profiles in real source text, and stop serving empty dog pages

### DIFF
--- a/frontend/src/app/dogs/[slug]/__tests__/page.errorCaching.test.jsx
+++ b/frontend/src/app/dogs/[slug]/__tests__/page.errorCaching.test.jsx
@@ -1,0 +1,47 @@
+/**
+ * The dog detail route is ISR-cached for `revalidate` (48h). A render that
+ * silently produced a page with no dog in it would be cached for that whole
+ * window, so a momentary API failure became a permanently broken page.
+ * Production symptom: 6 of 10 sampled available dogs served an ~84KB shell
+ * with no name, no About content and no Pet JSON-LD.
+ */
+import { notFound } from "next/navigation";
+import { DogDetailPageAsync } from "../page";
+import { getAnimalBySlug } from "../../../../services/animalsService";
+
+jest.mock("../../../../services/animalsService", () => ({
+  getAnimalBySlug: jest.fn(),
+  getAllAnimals: jest.fn(),
+  getAllAnimalsForSitemap: jest.fn(),
+}));
+
+jest.mock("next/navigation", () => ({
+  notFound: jest.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+}));
+
+jest.mock("../../../../utils/logger", () => ({
+  reportError: jest.fn(),
+  logger: { log: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const props = { params: Promise.resolve({ slug: "sid-border-collie-cross-11006" }) };
+
+describe("dog detail page — failed fetches must not be cached", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("propagates the error instead of rendering a dog page with no dog", async () => {
+    getAnimalBySlug.mockRejectedValue(new Error("HTTP 503"));
+
+    await expect(DogDetailPageAsync(props)).rejects.toThrow("HTTP 503");
+    expect(notFound).not.toHaveBeenCalled();
+  });
+
+  it("still 404s when the dog genuinely does not exist", async () => {
+    getAnimalBySlug.mockResolvedValue(null);
+
+    await expect(DogDetailPageAsync(props)).rejects.toThrow("NEXT_NOT_FOUND");
+    expect(notFound).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/dogs/[slug]/__tests__/page.errorCaching.test.jsx
+++ b/frontend/src/app/dogs/[slug]/__tests__/page.errorCaching.test.jsx
@@ -45,3 +45,14 @@ describe("dog detail page — failed fetches must not be cached", () => {
     expect(notFound).toHaveBeenCalled();
   });
 });
+
+describe("dog detail page — an unresolvable slug is a failure, not an empty page", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("propagates a params resolution failure instead of rendering a shell", async () => {
+    const badProps = { params: Promise.reject(new Error("params unavailable")) };
+
+    await expect(DogDetailPageAsync(badProps)).rejects.toThrow("params unavailable");
+    expect(getAnimalBySlug).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/dogs/[slug]/page.tsx
+++ b/frontend/src/app/dogs/[slug]/page.tsx
@@ -4,7 +4,6 @@ import { Suspense } from "react";
 import type { Dog } from "../../../types/dog";
 import type { DogWithLlm } from "../../../services/serverAnimalsService";
 import { reportError } from "../../../utils/logger";
-import DogSchema from "../../../components/seo/DogSchema";
 import {
   generateSEODescription,
   generateFallbackDescription,
@@ -155,7 +154,7 @@ function DogDetailPage(_props: DogDetailPageProps): React.JSX.Element {
   return <Layout><DogDetailClient /></Layout>;
 }
 
-async function DogDetailPageAsync(props: DogDetailPageProps): Promise<React.JSX.Element> {
+export async function DogDetailPageAsync(props: DogDetailPageProps): Promise<React.JSX.Element> {
   const { params } = props || {};
   let resolvedParams: { slug?: string } = {};
 
@@ -168,19 +167,20 @@ async function DogDetailPageAsync(props: DogDetailPageProps): Promise<React.JSX.
   }
 
   let initialDog: DogWithLlm | null = null;
-  let fetchError = false;
   if (resolvedParams.slug) {
     try {
       initialDog = await fetchAnimalBySlug(resolvedParams.slug);
     } catch (error) {
-      fetchError = true;
       reportError(error, { context: "DogDetailPageAsync", slug: resolvedParams.slug });
+      // This route is ISR-cached for `revalidate`, so rendering a page without
+      // its dog would cache the failure for 48 hours. Fail the render instead:
+      // the next request retries rather than serving a permanent empty shell.
+      throw error;
     }
-  }
 
-  const fetchAttempted = !!resolvedParams.slug;
-  if (!initialDog && fetchAttempted && !fetchError) {
-    notFound();
+    if (!initialDog) {
+      notFound();
+    }
   }
 
   let heroImageUrl: string | null = null;
@@ -194,7 +194,6 @@ async function DogDetailPageAsync(props: DogDetailPageProps): Promise<React.JSX.
 
   return (
     <Layout>
-      {initialDog && <DogSchema dog={initialDog} />}
       {heroImageUrl && <ImagePreload src={heroImageUrl} />}
       <Suspense fallback={<DogDetailSkeleton />}>
         <DogDetailClient initialDog={initialDog} />

--- a/frontend/src/app/dogs/[slug]/page.tsx
+++ b/frontend/src/app/dogs/[slug]/page.tsx
@@ -163,6 +163,9 @@ export async function DogDetailPageAsync(props: DogDetailPageProps): Promise<Rea
       resolvedParams = await params;
     } catch (error) {
       reportError(error, { context: "DogDetailPageAsync", operation: "resolveParams" });
+      // Swallowing this left the route rendering a dog page with no slug to
+      // fetch, which ISR then cached as an empty page for 48 hours.
+      throw error;
     }
   }
 

--- a/management/llm_commands.py
+++ b/management/llm_commands.py
@@ -227,6 +227,49 @@ async def _enrich_descriptions_async(animals, effective_batch_size, batch_proces
             console.print(f"[bold red]✗[/bold red] Failed to process {error_count} animals")
 
 
+VALID_CONFIDENCE_FILTERS = ("high", "medium", "low", "all")
+
+
+def build_profile_selection_query(org_id: int, force: bool, confidence: str, limit: int | None) -> tuple[str, tuple]:
+    """Build the query selecting which dogs to profile.
+
+    Args:
+        org_id: Organization to select from
+        force: Include dogs that already have a profile, so a batch can be
+            regenerated after a scraper fix changed the source text
+        confidence: One of VALID_CONFIDENCE_FILTERS; "all" drops the filter
+        limit: Optional row cap
+
+    Returns:
+        The SQL and its parameters
+
+    Raises:
+        ValueError: If confidence is not a recognised value
+    """
+    if confidence not in VALID_CONFIDENCE_FILTERS:
+        raise ValueError(f"Unknown confidence filter {confidence!r}; expected one of {VALID_CONFIDENCE_FILTERS}")
+
+    conditions = ["organization_id = %s", "status = 'available'"]
+
+    if not force:
+        conditions.append("(dog_profiler_data IS NULL OR dog_profiler_data = '{}')")
+
+    if confidence != "all":
+        conditions.append(f"availability_confidence = '{confidence}'")
+
+    sql = f"""
+            SELECT id, name, breed, age_text, properties
+            FROM animals
+            WHERE {" AND ".join(conditions)}
+            ORDER BY id DESC
+        """
+
+    if limit:
+        sql += f" LIMIT {int(limit)}"
+
+    return sql, (org_id,)
+
+
 @llm.command()
 @click.option("--organization", "-o", type=int, help="Process only specific organization ID")
 @click.option(
@@ -236,6 +279,13 @@ async def _enrich_descriptions_async(animals, effective_batch_size, batch_proces
     type=int,
     help="Limit number of animals to process per organization",
 )
+@click.option("--force", is_flag=True, help="Re-profile dogs that already have a profile")
+@click.option(
+    "--confidence",
+    type=click.Choice(VALID_CONFIDENCE_FILTERS),
+    default="high",
+    help="Availability confidence to include (default: high)",
+)
 @click.option(
     "--batch-size",
     "-b",
@@ -243,7 +293,7 @@ async def _enrich_descriptions_async(animals, effective_batch_size, batch_proces
     type=int,
     help="Number of items to process per batch (default: 10)",
 )
-def generate_profiles(organization: int | None, limit: int | None, batch_size: int):
+def generate_profiles(organization: int | None, limit: int | None, force: bool, confidence: str, batch_size: int):
     """Generate dog profiler data using org-specific prompts."""
     from services.llm.dog_profiler import DogProfilerPipeline
     from services.llm.organization_config_loader import get_config_loader
@@ -276,19 +326,9 @@ def generate_profiles(organization: int | None, limit: int | None, batch_size: i
         console.print(f"\n[bold blue]Processing {org_config.organization_name} (ID: {org_id})[/bold blue]")
         console.print(f"  Model: {get_llm_config().models.default_model}")
 
-        query = """
-            SELECT id, name, breed, age_text, properties
-            FROM animals
-            WHERE organization_id = %s
-            AND (dog_profiler_data IS NULL OR dog_profiler_data = '{}')
-            AND availability_confidence = 'high'
-            AND status = 'available'
-            ORDER BY id DESC
-        """
-        if limit:
-            query += f" LIMIT {limit}"
+        query, query_params = build_profile_selection_query(org_id=org_id, force=force, confidence=confidence, limit=limit)
 
-        cursor.execute(query, (org_id,))
+        cursor.execute(query, query_params)
         dogs = [
             {
                 "id": r[0],

--- a/management/railway_scraper_cron.py
+++ b/management/railway_scraper_cron.py
@@ -172,7 +172,16 @@ def main():
     parser.add_argument("--dry-run", action="store_true", help="Show what would run without executing")
     parser.add_argument("--list", action="store_true", help="List available scrapers")
     parser.add_argument("--json", action="store_true", help="Output results as JSON only")
+    parser.add_argument(
+        "--force-rescrape",
+        action="store_true",
+        help="Re-scrape animals that would normally be skipped, for refreshing existing rows after a scraper fix",
+    )
     args = parser.parse_args()
+
+    if args.force_rescrape:
+        os.environ["FORCE_RESCRAPE"] = "true"
+        logger.warning("FORCE_RESCRAPE enabled: skip_existing_animals is overridden for this run")
 
     signal.signal(signal.SIGTERM, handle_shutdown)
     signal.signal(signal.SIGINT, handle_shutdown)

--- a/scrapers/base_scraper.py
+++ b/scrapers/base_scraper.py
@@ -49,6 +49,19 @@ from utils.unified_standardization import UnifiedStandardizer
 logger = logging.getLogger(__name__)
 
 
+FORCE_RESCRAPE_VALUES = ("true", "1", "yes")
+
+
+def force_rescrape_enabled() -> bool:
+    """Whether this run should re-scrape animals it would normally skip.
+
+    Set FORCE_RESCRAPE when a scraper fix has changed what the source pages
+    yield and the existing rows need refreshing; orgs configured with
+    skip_existing_animals would otherwise keep their stale text indefinitely.
+    """
+    return os.environ.get("FORCE_RESCRAPE", "").strip().lower() in FORCE_RESCRAPE_VALUES
+
+
 class BaseScraper(ABC):
     """Base scraper class that all organization-specific scrapers will inherit from."""
 
@@ -106,7 +119,7 @@ class BaseScraper(ABC):
             # New retry and batch processing settings
             self.retry_backoff_factor = scraper_config.get("retry_backoff_factor", 2.0)
             self.batch_size = scraper_config.get("batch_size", 6)
-            self.skip_existing_animals = scraper_config.get("skip_existing_animals", False)
+            self.skip_existing_animals = False if force_rescrape_enabled() else scraper_config.get("skip_existing_animals", False)
 
             # Set organization name from config
             self.organization_name = self.org_config.name

--- a/scrapers/dogstrust/dogstrust_scraper.py
+++ b/scrapers/dogstrust/dogstrust_scraper.py
@@ -10,7 +10,7 @@ from threading import Lock
 from typing import Any
 
 import requests
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Tag
 
 from scrapers.base_scraper import BaseScraper
 
@@ -1185,37 +1185,48 @@ class DogsTrustScraper(BaseScraper):
         return location_link.get_text(strip=True) if location_link else ""
 
     def _extract_description(self, soup: BeautifulSoup) -> str:
-        """Extract description from two-part pattern identified in analysis.
+        """Extract description from the two per-dog sections.
 
-        Combines "Are you right for [Name]?" and "Is [Name] right for you?" sections.
+        Combines "Are you right for [Name]?" and "Is [Name] right for you?".
+        The body of each section is a sibling element of the heading, not a
+        <p>, so the section must be walked by sibling rather than searched for
+        a paragraph: a document-wide paragraph search escapes the section and
+        finds the breed-guide promo further down the page instead.
         """
-        description_parts = []
+        description_parts: list[str] = []
 
-        # Find the two description sections
-        h2_elements = soup.find_all("h2")
-        for h2 in h2_elements:
+        for h2 in soup.find_all("h2"):
             h2_text = h2.get_text(strip=True)
 
-            if "Are you right for" in h2_text:
-                # Get the following paragraph
-                next_p = h2.find_next("p")
-                if next_p:
-                    text = next_p.get_text(strip=True)
-                    # Normalize smart quotes and special characters
-                    text = self._normalize_text(text)
-                    description_parts.append(text)
+            if "Are you right for" not in h2_text and "right for you" not in h2_text:
+                continue
 
-            elif "right for you" in h2_text:
-                # Get the following paragraph
-                next_p = h2.find_next("p")
-                if next_p:
-                    text = next_p.get_text(strip=True)
-                    # Normalize smart quotes and special characters
-                    text = self._normalize_text(text)
-                    description_parts.append(text)
+            body = self._extract_section_body(h2)
+            if not body:
+                continue
 
-        # Combine parts with newline separator
-        return "\n\n".join(description_parts) if description_parts else ""
+            text = self._normalize_text(body)
+            if text not in description_parts:
+                description_parts.append(text)
+
+        return "\n\n".join(description_parts)
+
+    def _extract_section_body(self, heading: Tag) -> str:
+        """Collect the text that belongs to a heading's own section.
+
+        Stops at the next heading so the walk cannot spill into whatever
+        content block follows.
+        """
+        parts = []
+
+        for sibling in heading.find_next_siblings():
+            if sibling.name in ("h1", "h2", "h3", "h4", "h5", "h6"):
+                break
+            text = sibling.get_text(" ", strip=True)
+            if text:
+                parts.append(text)
+
+        return " ".join(parts)
 
     def _extract_primary_image(self, soup: BeautifulSoup, dog_id: str | None = None) -> str:
         """Extract this dog's primary photo from the detail page.

--- a/services/llm/dog_profiler.py
+++ b/services/llm/dog_profiler.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
 from services.llm.config import get_llm_config
 from services.llm.database_updater import DatabaseUpdater
 from services.llm.extracted_profile_normalizer import ExtractedProfileNormalizer
+from services.llm.grounding import is_sufficiently_grounded, source_text_length
 from services.llm.llm_client import LLMClient
 from services.llm.prompt_builder import PromptBuilder
 from services.llm.quality_rubric import DogProfileQualityRubric
@@ -159,6 +160,10 @@ class DogProfilerPipeline:
         """
         dog_id = dog_data.get("id", "unknown")
         dog_name = dog_data.get("name", "Unknown")
+
+        if not is_sufficiently_grounded(dog_data):
+            logger.warning(f"Skipping dog {dog_id} ({dog_name}): only {source_text_length(dog_data)} chars of source text, below the grounding floor")
+            return None
 
         try:
             start_time = time.time()

--- a/services/llm/grounding.py
+++ b/services/llm/grounding.py
@@ -1,0 +1,45 @@
+"""Grounding checks for LLM dog profiling.
+
+The prompt builder serialises the entire properties dict into the request, so
+the model's only defence against inventing a personality is having real source
+text to work from. These pure helpers decide whether a dog has enough of it.
+"""
+
+import os
+from typing import Any
+
+MIN_SOURCE_TEXT_CHARS = 150
+
+
+def source_text_length(dog_data: dict[str, Any]) -> int:
+    """Length of the longest narrative field in a dog's scraped properties.
+
+    Scrapers disagree on where narrative text goes - `description`,
+    `raw_description`, `Beschreibung`, `page_text_excerpt` - so the longest
+    string value stands in for "the narrative", rather than a per-org key list
+    that silently returns zero when an org is missing from it.
+    """
+    properties = dog_data.get("properties")
+    if not isinstance(properties, dict):
+        return 0
+
+    lengths = [len(value) for value in properties.values() if isinstance(value, str)]
+
+    return max(lengths, default=0)
+
+
+def minimum_source_chars() -> int:
+    """Grounding threshold, overridable for tuning without a code change."""
+    raw = os.environ.get("LLM_MIN_SOURCE_CHARS")
+    if raw is None:
+        return MIN_SOURCE_TEXT_CHARS
+
+    try:
+        return int(raw)
+    except ValueError:
+        return MIN_SOURCE_TEXT_CHARS
+
+
+def is_sufficiently_grounded(dog_data: dict[str, Any]) -> bool:
+    """Whether there is enough source text to profile this dog honestly."""
+    return source_text_length(dog_data) >= minimum_source_chars()

--- a/tests/management/test_llm_generate_profiles_force.py
+++ b/tests/management/test_llm_generate_profiles_force.py
@@ -1,0 +1,51 @@
+"""Re-profiling an already-profiled dog.
+
+generate_profiles only ever selected dogs with no profile, so the 445 Dogs Trust
+dogs whose profiles were invented from breed-guide junk could not be regenerated
+after the scraper was fixed. It also filtered to availability_confidence 'high',
+which would have left the 90 junk-sourced medium and low confidence dogs behind.
+"""
+
+import pytest
+
+from management.llm_commands import build_profile_selection_query
+
+
+@pytest.mark.unit
+class TestProfileSelectionQuery:
+    def test_default_skips_dogs_that_already_have_a_profile(self):
+        sql, params = build_profile_selection_query(org_id=28, force=False, confidence="high", limit=None)
+
+        assert "dog_profiler_data IS NULL" in sql
+        assert params == (28,)
+
+    def test_force_includes_dogs_that_already_have_a_profile(self):
+        sql, _ = build_profile_selection_query(org_id=28, force=True, confidence="high", limit=None)
+
+        assert "dog_profiler_data IS NULL" not in sql
+
+    def test_default_confidence_stays_high_only(self):
+        sql, _ = build_profile_selection_query(org_id=28, force=False, confidence="high", limit=None)
+
+        assert "availability_confidence = 'high'" in sql
+
+    def test_confidence_all_drops_the_filter(self):
+        sql, _ = build_profile_selection_query(org_id=28, force=True, confidence="all", limit=None)
+
+        assert "availability_confidence" not in sql
+
+    def test_always_restricted_to_available_dogs_of_one_org(self):
+        sql, params = build_profile_selection_query(org_id=28, force=True, confidence="all", limit=None)
+
+        assert "status = 'available'" in sql
+        assert "organization_id = %s" in sql
+        assert params == (28,)
+
+    def test_limit_is_applied_as_an_integer_not_interpolated_text(self):
+        sql, _ = build_profile_selection_query(org_id=28, force=True, confidence="all", limit=50)
+
+        assert "LIMIT 50" in sql
+
+    def test_rejects_an_unknown_confidence_value(self):
+        with pytest.raises(ValueError):
+            build_profile_selection_query(org_id=28, force=True, confidence="'; DROP TABLE animals;--", limit=None)

--- a/tests/scrapers/test_dogstrust_scraper.py
+++ b/tests/scrapers/test_dogstrust_scraper.py
@@ -605,3 +605,66 @@ class TestDogsTrustPrimaryImage:
         result = scraper._extract_primary_image(soup, dog_id="3632928")
 
         assert result == ""
+
+
+DETAIL_PAGE_HTML = """
+<html><body>
+  <div class="DogPage-module--contentBlock--7017c">
+    <h2 class="DogPage-module--contentHeading--ee730">Are you right for <span>Noodle</span>?</h2>
+    <div class="DogPage-module--contentBody--7b69a">
+      <span>Noodle can live with teenagers but will need to be the only dog at home for now.</span>
+    </div>
+  </div>
+  <div class="DogPage-module--contentBlock--7017c">
+    <h2 class="DogPage-module--contentHeading--ee730">Is <span>Noodle</span> right for you?</h2>
+    <div class="DogPage-module--contentBody--7b69a">
+      <span>Noodle is only two years old and loves to be stroked on her nose.</span>
+    </div>
+  </div>
+  <div class="breed-promo">
+    <h2>More about collie (border) crosss</h2>
+    <p>Everything you need to know about Border Collies</p>
+  </div>
+  <div class="rehoming">
+    <h2>How our rehoming process works</h2>
+    <p>In our form you can tell us all about your home, your lifestyle and the kind of dog you want.</p>
+  </div>
+</body></html>
+"""
+
+
+@pytest.mark.unit
+class TestDogsTrustDescriptionExtraction:
+    """The two description sections live in a sibling div, not a <p>.
+
+    Regression cover for the production bug where h2.find_next("p") walked past
+    the section into the breed-guide promo, giving 385 of 512 available dogs a
+    description of "Everything you need to know about <breed>".
+    """
+
+    @staticmethod
+    def _extract(html: str) -> str:
+        from bs4 import BeautifulSoup
+
+        return DogsTrustScraper()._extract_description(BeautifulSoup(html, "html.parser"))
+
+    def test_returns_the_dogs_own_narrative_from_both_sections(self):
+        description = self._extract(DETAIL_PAGE_HTML)
+
+        assert "Noodle can live with teenagers" in description
+        assert "loves to be stroked on her nose" in description
+
+    def test_never_returns_breed_guide_or_rehoming_boilerplate(self):
+        description = self._extract(DETAIL_PAGE_HTML)
+
+        assert "Everything you need to know" not in description
+        assert "In our form you can tell us" not in description
+
+    def test_does_not_duplicate_the_same_paragraph(self):
+        description = self._extract(DETAIL_PAGE_HTML)
+        parts = [part for part in description.split("\n\n") if part]
+
+        assert len(parts) == len(set(parts))
+
+    def test_returns_empty_string_when_sections_are_absent(self):
+        assert self._extract("<html><body><h2>Key information</h2><p>Nope.</p></body></html>") == ""

--- a/tests/scrapers/test_force_rescrape_override.py
+++ b/tests/scrapers/test_force_rescrape_override.py
@@ -1,0 +1,32 @@
+"""One-off override for skip_existing_animals.
+
+Dogs Trust runs with skip_existing_animals: true, so after the description
+extractor was fixed the 512 dogs already in the database would never have been
+re-fetched and would have kept their breed-guide descriptions forever. Forcing a
+full re-scrape needed a runtime switch rather than a config edit that someone has
+to remember to revert.
+"""
+
+import pytest
+
+from scrapers.base_scraper import force_rescrape_enabled
+
+
+@pytest.mark.unit
+class TestForceRescrapeEnabled:
+    def test_off_by_default(self, monkeypatch):
+        monkeypatch.delenv("FORCE_RESCRAPE", raising=False)
+
+        assert force_rescrape_enabled() is False
+
+    @pytest.mark.parametrize("value", ["true", "TRUE", "True", "1", "yes"])
+    def test_recognises_affirmative_values(self, monkeypatch, value):
+        monkeypatch.setenv("FORCE_RESCRAPE", value)
+
+        assert force_rescrape_enabled() is True
+
+    @pytest.mark.parametrize("value", ["false", "0", "no", "", "maybe"])
+    def test_anything_else_is_off(self, monkeypatch, value):
+        monkeypatch.setenv("FORCE_RESCRAPE", value)
+
+        assert force_rescrape_enabled() is False

--- a/tests/services/llm/test_dog_profiler_grounding.py
+++ b/tests/services/llm/test_dog_profiler_grounding.py
@@ -54,8 +54,14 @@ class TestPipelineSkipsUngroundedDogs:
     """An ungrounded dog must cost nothing and produce nothing."""
 
     @pytest.fixture
-    def pipeline(self):
+    def pipeline(self, monkeypatch):
         from services.llm.dog_profiler import DogProfilerPipeline
+
+        # The pipeline requires a key at construction. These tests never reach
+        # the network - the guard returns first, and the model call is mocked -
+        # so a placeholder keeps them running in CI rather than being skipped,
+        # which is the point for a guard whose job is to prevent spend.
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key-never-used")
 
         return DogProfilerPipeline(organization_id=11, dry_run=True)
 

--- a/tests/services/llm/test_dog_profiler_grounding.py
+++ b/tests/services/llm/test_dog_profiler_grounding.py
@@ -1,0 +1,83 @@
+"""Grounding floor for LLM profiling.
+
+The prompt serialises the whole properties dict into the request, so a dog with
+no real narrative text still gets a fluent, confident, invented profile. In
+production this produced profiles asserting temperament for Dogs Trust dogs
+whose only source text was a breed guide, and gave Santer Paws 347 characters of
+profile from 108 characters of source.
+"""
+
+import pytest
+
+from services.llm.grounding import MIN_SOURCE_TEXT_CHARS, is_sufficiently_grounded, source_text_length
+
+
+@pytest.mark.unit
+class TestSourceTextLength:
+    def test_uses_the_longest_narrative_field_whatever_it_is_called(self):
+        dog = {"properties": {"Beschreibung": "x" * 400, "Rasse": "Mischling"}}
+
+        assert source_text_length(dog) == 400
+
+    def test_ignores_non_string_values(self):
+        dog = {"properties": {"age_min_months": 24, "tags": ["a", "b"], "description": "y" * 200}}
+
+        assert source_text_length(dog) == 200
+
+    def test_returns_zero_when_there_are_no_properties(self):
+        assert source_text_length({}) == 0
+        assert source_text_length({"properties": None}) == 0
+
+
+@pytest.mark.unit
+class TestGroundingFloor:
+    def test_rejects_a_dog_with_no_narrative_source(self):
+        assert is_sufficiently_grounded({"properties": {"weight": "12kg"}}) is False
+
+    def test_rejects_the_duplicated_dogs_trust_breed_promo(self):
+        promo = "Everything you need to know about Border Collies"
+        dog = {"properties": {"description": f"{promo}\n\n{promo}"}}
+
+        assert is_sufficiently_grounded(dog) is False
+
+    def test_accepts_a_real_narrative(self):
+        dog = {"properties": {"description": "Noodle can live with teenagers but will need to be the only dog at home. " * 4}}
+
+        assert is_sufficiently_grounded(dog) is True
+
+    def test_threshold_is_the_documented_one(self):
+        assert MIN_SOURCE_TEXT_CHARS == 150
+
+
+@pytest.mark.unit
+class TestPipelineSkipsUngroundedDogs:
+    """An ungrounded dog must cost nothing and produce nothing."""
+
+    @pytest.fixture
+    def pipeline(self):
+        from services.llm.dog_profiler import DogProfilerPipeline
+
+        return DogProfilerPipeline(organization_id=11, dry_run=True)
+
+    @pytest.mark.asyncio
+    async def test_returns_none_without_calling_the_model(self, pipeline):
+        from unittest.mock import AsyncMock
+
+        pipeline.retry_handler.execute_with_retry = AsyncMock()
+        ungrounded = {"id": 1, "name": "Boston", "properties": {"description": "Everything you need to know about Lurchers"}}
+
+        result = await pipeline.process_dog(ungrounded)
+
+        assert result is None
+        pipeline.retry_handler.execute_with_retry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_still_profiles_a_grounded_dog(self, pipeline):
+        from unittest.mock import AsyncMock
+
+        pipeline.retry_handler.execute_with_retry = AsyncMock(side_effect=RuntimeError("reached the model"))
+        grounded = {"id": 2, "name": "Noodle", "properties": {"description": "Noodle can live with teenagers and is house trained. " * 5}}
+
+        await pipeline.process_dog(grounded)
+
+        pipeline.retry_handler.execute_with_retry.assert_called_once()


### PR DESCRIPTION
End-to-end audit of LLM enrichment across all 13 orgs, plus the fixes it surfaced. All findings verified against production, not tests.

## What the audit found

A prior investigation reported that `llm_description` was a phantom field and that ~9,472 dogs of profiling had never been displayed. **That was wrong.** The backend never uses that *name* — the API returns the column as `description` (`enhanced_animal_service.py:176`) and the frontend renames it (`serverAnimalsService.ts:955`). Verified live: `/dogs/dennis-lhasa-apso-8516` renders the LLM text in About.

The two real defects were elsewhere.

## 1. Dogs Trust scraper returns the breed guide

`_extract_description` called `h2.find_next("p")`, which searches the whole rest of the document. The section body is a sibling `div`, not a `<p>`, so both branches fell through to the breed promo.

- 385 of 512 available dogs had `"Everything you need to know about <breed>"` as their description
- 437 carried the identical paragraph twice
- No other org affected

That text goes verbatim into the profiling prompt, so the model invented temperament from it — Clive's profile asserts "He gets on well with other dogs" from a source that is the Border Collie breed guide, twice.

Fixed by walking the heading's own siblings and stopping at the next heading. Verified on three live pages: **1265, 1648 and 609 characters** of real narrative that was previously discarded.

## 2. Dog pages cached as empty shells

The route is ISR-cached for 48h. When the fetch threw, the page rendered anyway with `initialDog` null — no name, no About, no Pet JSON-LD — and that failure was cached for the full window.

6 of 10 sampled *available* dogs were serving an 84KB shell (working pages are ~125KB). A fresh on-demand render reproduced it.

**Corrected prevalence:** that sample was drawn from the newest ids, which are exactly the affected cohort — it measures the cohort, not the site. A *random* sample of 20 available dogs found **1 shell**. The affected set is dogs added since the last production build: **65 of 1,473 available dogs (4.4%)** were created since 19 Aug. Small at any moment, but replenished by every scrape run until a deploy happens. This is also the one place the phantom-field symptom is genuinely real: the fallback path refetches via the client service, which never sets `llm_description`.

Now throws instead, so the next request retries. Also removes a duplicate `DogSchema` render — every working page carried two copies of the same Product JSON-LD.

## 3. Grounding floor

Profiling below 150 chars of source text is now skipped. Measured as the longest string in `properties`, so it works across every scraper's naming (`description`, `raw_description`, `Beschreibung`, `page_text_excerpt`) rather than a per-org key list that silently returns zero.

Grounding varies sharply by org — output ÷ source length:

| Org | Dogs | Source chars | Invention | |
|---|---|---|---|---|
| Dogs Trust | 5,359 | 930 | 0.2× | poisoned source |
| Santer Paws | 196 | 108 | **3.2×** | 163/196 below floor |
| Daisy Family | 187 | 283 | 0.8× | 129/181 below floor |
| Woof Project | 68 | 1,293 | 0.3× | healthy |
| The Underdog | 180 | 2,543 | 0.1× | healthy |

Above 1× the model is producing more prose than it was given, which it can only do by inventing.

## Not included — needs your go-ahead

Re-profiling costs real money and touches production, so nothing was run:

- **445 available Dogs Trust dogs — $2.23** (do after this merges, so the source is clean)
- 330 unprofiled dogs — $1.65, but **Pets in Turkey (128, 0% profiled, 21 chars mean source) is a scraper failure**, not a profiling one
- Full Dogs Trust re-profile is $26.80 — most of the monthly cap for 3,898 records that aren't poisoned. Not recommended.

## Verification

- Backend: 1,720 passed
- Frontend: 3,600 passed, `tsc` clean, 0 lint errors, build passes
- New: 11 tests across the scraper, the render path, and the grounding floor

---

## Added: the two things the Dogs Trust backfill needed

Verifying the fix against a real dog surfaced two blockers that made the planned backfill impossible.

**`--force` / `--confidence` on `generate-profiles`.** The command only ever selected dogs with no `dog_profiler_data`, so the 445 dogs with invented profiles could not be regenerated. It also hardcoded `availability_confidence = 'high'`, which would have left 90 junk-sourced medium/low dogs behind — they're equally visible on the site. Selection is extracted into `build_profile_selection_query` so it's testable without a database. Defaults unchanged.

**`FORCE_RESCRAPE` override.** Dogs Trust runs `skip_existing_animals: true`, so a normal cron run would not re-fetch the 512 existing dogs — their junk descriptions would survive the scraper fix, and re-profiling would re-buy the same invented text. `FORCE_RESCRAPE=true` (or `--force-rescrape` on the cron entrypoint) overrides it for one run, rather than editing org config that stays wrong until someone reverts it.

## Runbook after merge

1. Deploy — this also invalidates the ISR cache holding the empty pages
2. Trigger the Railway scrape with `FORCE_RESCRAPE=true` (Dogs Trust only: `--org=dogstrust --force-rescrape`); ~512 detail pages at 2.5s ≈ 25 min
3. Spot-check descriptions are real, then `generate-profiles -o 28 --force --confidence all` — 512 dogs, ~$2.56

**Pets in Turkey is excluded deliberately** — the site has no per-dog descriptions, so there is nothing to ground a profile in. It has no entry in `llm_organizations.yaml` at all, and the new grounding floor now enforces that automatically at 21 chars of source.

**Org enablement:** 11 of 12 configured orgs are LLM-enabled; Furry Rescue Italy is `enabled: false` (no prompt developed). Galgos del Sol and Furry Rescue Italy are both `active=false` in the database, though Furry Rescue Italy still has 35 available dogs.

**Test totals:** backend 1,738 passed, frontend 3,601 passed.