### PR TITLE
fix(dogstrust): decode detail pages as the page declares, not Latin-1

### DIFF
--- a/scrapers/dogstrust/dogstrust_scraper.py
+++ b/scrapers/dogstrust/dogstrust_scraper.py
@@ -1076,7 +1076,7 @@ class DogsTrustScraper(BaseScraper):
                     return {}
 
         # Parse HTML with BeautifulSoup
-        soup = BeautifulSoup(response.text, "html.parser")
+        soup = self._soup_from_response(response)
 
         # Extract core fields using analysis-identified selectors
         name = self._extract_name(soup)
@@ -1183,6 +1183,16 @@ class DogsTrustScraper(BaseScraper):
         """Extract location from center filter link."""
         location_link = soup.find("a", href=re.compile(r"centres%5B0%5D="))
         return location_link.get_text(strip=True) if location_link else ""
+
+    def _soup_from_response(self, response) -> BeautifulSoup:
+        """Parse a detail page response, decoding it as the page declares.
+
+        Dogs Trust sends text/html with no charset, so requests falls back to
+        ISO-8859-1 and response.text turns every smart quote into mojibake.
+        Handing BeautifulSoup the raw bytes lets it read the meta charset
+        instead.
+        """
+        return BeautifulSoup(response.content, "html.parser")
 
     def _extract_description(self, soup: BeautifulSoup) -> str:
         """Extract description from the two per-dog sections.

--- a/tests/scrapers/test_dogstrust_scraper.py
+++ b/tests/scrapers/test_dogstrust_scraper.py
@@ -668,3 +668,50 @@ class TestDogsTrustDescriptionExtraction:
 
     def test_returns_empty_string_when_sections_are_absent(self):
         assert self._extract("<html><body><h2>Key information</h2><p>Nope.</p></body></html>") == ""
+
+
+@pytest.mark.unit
+class TestDogsTrustResponseDecoding:
+    """Dogs Trust serves text/html with no charset.
+
+    requests then falls back to ISO-8859-1 per RFC 2616, so response.text
+    decodes the UTF-8 bytes as Latin-1 and every smart quote becomes mojibake:
+    "He'd" arrives as "Heâ€™d". This was invisible while descriptions were the
+    breed-guide promo, which has no apostrophes; the dogs' real narratives do,
+    and 183 of 478 available dogs were affected.
+    """
+
+    SMART_QUOTE_HTML = (
+        '<html><body><div class="DogPage-module--contentBlock--7017c">'
+        '<h2 class="DogPage-module--contentHeading--ee730">Are you right for Kevin?</h2>'
+        '<div class="DogPage-module--contentBody--7b69a">'
+        "<span>Kevin’s ready for a home he’d love.</span>"
+        "</div></div></body></html>"
+    )
+
+    class FakeResponse:
+        """Stands in for a requests.Response with no charset in Content-Type."""
+
+        def __init__(self, html: str):
+            self._body = html.encode("utf-8")
+
+        @property
+        def content(self) -> bytes:
+            return self._body
+
+        @property
+        def text(self) -> str:
+            return self._body.decode("iso-8859-1")
+
+    def test_response_text_alone_would_corrupt_the_apostrophes(self):
+        """Guards the premise: this is what the old code parsed."""
+        assert "â" in self.FakeResponse(self.SMART_QUOTE_HTML).text
+
+    def test_description_decodes_as_utf8(self):
+        scraper = DogsTrustScraper()
+        response = self.FakeResponse(self.SMART_QUOTE_HTML)
+
+        description = scraper._extract_description(scraper._soup_from_response(response))
+
+        assert "Kevin's ready for a home he'd love." == description
+        assert "â" not in description


### PR DESCRIPTION
Follow-up to #344. Separate PR because it's an independent bug.

## The bug

Dogs Trust serves `content-type: text/html` with **no charset**. Per RFC 2616, `requests` then falls back to ISO-8859-1, so `response.text` decodes the page's UTF-8 bytes as Latin-1 and every smart quote becomes mojibake:

```
"he's"  →  "heâ\x80\x99s"
"who's" →  "whoâ\x80\x99s"
```

`requests` reports `r.encoding == 'ISO-8859-1'` for these pages, which is the tell.

## Why it surfaced now

It isn't new — it was hidden. While `_extract_description` was returning the breed-guide promo ("Everything you need to know about Border Collies"), there were no apostrophes to corrupt. Once #344 made the extractor return the dogs' actual narratives, **183 of 478 available dogs** carried mojibake.

## The fix

Hand BeautifulSoup the raw bytes instead of the mis-decoded string, so it reads the page's meta charset.

Verified against two live pages with the defect:

| Dog | Before | After |
|---|---|---|
| Henri | `despite his size heâ\x80\x99s a sensitive` | `despite his size he's a sensitive` |
| Sasha | `5 month old Staffy Cross, whoâ\x80\x99s hoping` | `5 month old Staffy Cross, who's hoping` |

## No backfill needed

The profiler already strips the artefacts — **zero** LLM descriptions contain them, and that is the text readers actually see. The raw scraped value is only the fallback. Existing rows correct themselves on the next scrape, so this needs no re-scrape and no re-spend.

## Tests

Two tests. One asserts the fix; the other guards the premise by confirming `response.text` alone *does* corrupt the apostrophes — so if Dogs Trust ever starts sending a charset, that test fails and tells us the workaround is obsolete rather than silently passing forever.

Backend: 1,740 passed.