### PR TITLE
fix(tests): repair seven failures no pipeline has run since January

### DIFF
--- a/tests/api/test_animals_meta.py
+++ b/tests/api/test_animals_meta.py
@@ -23,7 +23,6 @@ class TestAnimalsMeta:
         # every element is a non-empty string
         assert all(isinstance(x, str) and x for x in data)
 
-    @pytest.mark.slow  # Fails in CI due to database setup differences
     def test_breeds_contains_known_value(self, client):
         """Ensure the breeds meta endpoint returns 'Mixed Breed'."""
         resp = client.get("/api/animals/meta/breeds")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -315,26 +315,27 @@ def manage_test_data(request):
 
         # Insert comprehensive test animals for all tests
         animals_sql = """
-        INSERT INTO animals (id, name, slug, animal_type, sex, status, organization_id, adoption_url, properties, primary_image_url, created_at, updated_at, availability_confidence, breed, standardized_breed, breed_group, size, age_text, age_min_months, age_max_months)
+        INSERT INTO animals (id, name, slug, animal_type, sex, status, organization_id, adoption_url, properties, primary_image_url, created_at, updated_at, availability_confidence, breed, standardized_breed, breed_group, size, age_text, age_min_months, age_max_months, primary_breed, breed_type, breed_slug)
         VALUES
-            (9001, 'Test Male Dog', 'test-male-dog', 'dog', 'Male', 'available', 901, 'http://example.com/9001', '{}', 'http://example.com/male.jpg', NOW(), NOW(), 'high', 'Golden Retriever', 'Golden Retriever', 'Sporting', 'large', '2 years', 24, 24),
-            (9002, 'Mixed Breed Dog', 'mixed-breed-dog', 'dog', 'Female', 'available', 901, 'http://example.com/9002', '{}', 'http://example.com/female.jpg', NOW(), NOW(), 'high', 'Mixed Breed', 'Mixed Breed', 'Mixed', 'medium', '1 year', 12, 12),
-            (9003, 'German Shepherd', 'german-shepherd', 'dog', 'Male', 'available', 901, 'http://example.com/9003', '{}', 'http://example.com/shepherd.jpg', NOW(), NOW(), 'high', 'German Shepherd', 'German Shepherd', 'Herding', 'large', '3 years', 36, 36),
-            (9004, 'Labrador Mix', 'labrador-mix', 'dog', 'Female', 'available', 901, 'http://example.com/9004', '{}', 'http://example.com/lab.jpg', NOW(), NOW(), 'high', 'Labrador Retriever', 'Labrador Retriever', 'Sporting', 'large', '18 months', 18, 18),
-            (9005, 'Beagle', 'beagle', 'dog', 'Male', 'available', 901, 'http://example.com/9005', '{}', 'http://example.com/beagle.jpg', NOW(), NOW(), 'high', 'Beagle', 'Beagle', 'Hound', 'medium', '4 years', 48, 48),
-            (9006, 'Poodle', 'poodle', 'dog', 'Female', 'available', 901, 'http://example.com/9006', '{}', 'http://example.com/poodle.jpg', NOW(), NOW(), 'high', 'Poodle', 'Poodle', 'Non-Sporting', 'medium', '6 months', 6, 6),
-            (9007, 'Bulldog', 'bulldog', 'dog', 'Male', 'available', 901, 'http://example.com/9007', '{}', 'http://example.com/bulldog.jpg', NOW(), NOW(), 'high', 'Bulldog', 'Bulldog', 'Non-Sporting', 'medium', '5 years', 60, 60),
-            (9008, 'Chihuahua', 'chihuahua', 'dog', 'Female', 'available', 901, 'http://example.com/9008', '{}', 'http://example.com/chihuahua.jpg', NOW(), NOW(), 'high', 'Chihuahua', 'Chihuahua', 'Toy', 'small', '8 years', 96, 96),
-            (9009, 'Rottweiler', 'rottweiler', 'dog', 'Male', 'available', 901, 'http://example.com/9009', '{}', 'http://example.com/rottweiler.jpg', NOW(), NOW(), 'high', 'Rottweiler', 'Rottweiler', 'Working', 'large', '7 years', 84, 84),
-            (9010, 'Border Collie', 'border-collie', 'dog', 'Female', 'available', 901, 'http://example.com/9010', '{}', 'http://example.com/collie.jpg', NOW(), NOW(), 'high', 'Border Collie', 'Border Collie', 'Herding', 'medium', '2 years', 24, 24),
-            (9011, 'Siberian Husky', 'siberian-husky', 'dog', 'Male', 'available', 901, 'http://example.com/9011', '{}', 'http://example.com/husky.jpg', NOW(), NOW(), 'high', 'Siberian Husky', 'Siberian Husky', 'Working', 'large', '4 years', 48, 48),
-            (9012, 'Yorkshire Terrier', 'yorkshire-terrier', 'dog', 'Female', 'available', 901, 'http://example.com/9012', '{}', 'http://example.com/yorkie.jpg', NOW(), NOW(), 'high', 'Yorkshire Terrier', 'Yorkshire Terrier', 'Toy', 'small', '3 years', 36, 36)
+            (9001, 'Test Male Dog', 'test-male-dog', 'dog', 'Male', 'available', 901, 'http://example.com/9001', '{}', 'http://example.com/male.jpg', NOW(), NOW(), 'high', 'Golden Retriever', 'Golden Retriever', 'Sporting', 'large', '2 years', 24, 24, 'Golden Retriever', 'purebred', 'golden-retriever'),
+            (9002, 'Mixed Breed Dog', 'mixed-breed-dog', 'dog', 'Female', 'available', 901, 'http://example.com/9002', '{}', 'http://example.com/female.jpg', NOW(), NOW(), 'high', 'Mixed Breed', 'Mixed Breed', 'Mixed', 'medium', '1 year', 12, 12, 'Mixed Breed', 'mixed', 'mixed-breed'),
+            (9003, 'German Shepherd', 'german-shepherd', 'dog', 'Male', 'available', 901, 'http://example.com/9003', '{}', 'http://example.com/shepherd.jpg', NOW(), NOW(), 'high', 'German Shepherd', 'German Shepherd', 'Herding', 'large', '3 years', 36, 36, 'German Shepherd Dog', 'purebred', 'german-shepherd-dog'),
+            (9004, 'Labrador Mix', 'labrador-mix', 'dog', 'Female', 'available', 901, 'http://example.com/9004', '{}', 'http://example.com/lab.jpg', NOW(), NOW(), 'high', 'Labrador Retriever', 'Labrador Retriever', 'Sporting', 'large', '18 months', 18, 18, 'Labrador Retriever', 'purebred', 'labrador-retriever'),
+            (9005, 'Beagle', 'beagle', 'dog', 'Male', 'available', 901, 'http://example.com/9005', '{}', 'http://example.com/beagle.jpg', NOW(), NOW(), 'high', 'Beagle', 'Beagle', 'Hound', 'medium', '4 years', 48, 48, 'Beagle', 'purebred', 'beagle'),
+            (9006, 'Poodle', 'poodle', 'dog', 'Female', 'available', 901, 'http://example.com/9006', '{}', 'http://example.com/poodle.jpg', NOW(), NOW(), 'high', 'Poodle', 'Poodle', 'Non-Sporting', 'medium', '6 months', 6, 6, 'Poodle', 'purebred', 'poodle'),
+            (9007, 'Bulldog', 'bulldog', 'dog', 'Male', 'available', 901, 'http://example.com/9007', '{}', 'http://example.com/bulldog.jpg', NOW(), NOW(), 'high', 'Bulldog', 'Bulldog', 'Non-Sporting', 'medium', '5 years', 60, 60, 'Bulldog', 'purebred', 'bulldog'),
+            (9008, 'Chihuahua', 'chihuahua', 'dog', 'Female', 'available', 901, 'http://example.com/9008', '{}', 'http://example.com/chihuahua.jpg', NOW(), NOW(), 'high', 'Chihuahua', 'Chihuahua', 'Toy', 'small', '8 years', 96, 96, 'Chihuahua', 'purebred', 'chihuahua'),
+            (9009, 'Rottweiler', 'rottweiler', 'dog', 'Male', 'available', 901, 'http://example.com/9009', '{}', 'http://example.com/rottweiler.jpg', NOW(), NOW(), 'high', 'Rottweiler', 'Rottweiler', 'Working', 'large', '7 years', 84, 84, 'Rottweiler', 'purebred', 'rottweiler'),
+            (9010, 'Border Collie', 'border-collie', 'dog', 'Female', 'available', 901, 'http://example.com/9010', '{}', 'http://example.com/collie.jpg', NOW(), NOW(), 'high', 'Border Collie', 'Border Collie', 'Herding', 'medium', '2 years', 24, 24, 'Border Collie', 'purebred', 'border-collie'),
+            (9011, 'Siberian Husky', 'siberian-husky', 'dog', 'Male', 'available', 901, 'http://example.com/9011', '{}', 'http://example.com/husky.jpg', NOW(), NOW(), 'high', 'Siberian Husky', 'Siberian Husky', 'Working', 'large', '4 years', 48, 48, 'Siberian Husky', 'purebred', 'siberian-husky'),
+            (9012, 'Yorkshire Terrier', 'yorkshire-terrier', 'dog', 'Female', 'available', 901, 'http://example.com/9012', '{}', 'http://example.com/yorkie.jpg', NOW(), NOW(), 'high', 'Yorkshire Terrier', 'Yorkshire Terrier', 'Toy', 'small', '3 years', 36, 36, 'Yorkshire Terrier', 'purebred', 'yorkshire-terrier')
         ON CONFLICT (id) DO UPDATE SET
             name = EXCLUDED.name, slug = EXCLUDED.slug, animal_type = EXCLUDED.animal_type, sex = EXCLUDED.sex, status = EXCLUDED.status,
             organization_id = EXCLUDED.organization_id, adoption_url = EXCLUDED.adoption_url, properties = EXCLUDED.properties,
             primary_image_url = EXCLUDED.primary_image_url, updated_at = NOW(), availability_confidence = EXCLUDED.availability_confidence,
             breed = EXCLUDED.breed, standardized_breed = EXCLUDED.standardized_breed, breed_group = EXCLUDED.breed_group, size = EXCLUDED.size, age_text = EXCLUDED.age_text,
-            age_min_months = EXCLUDED.age_min_months, age_max_months = EXCLUDED.age_max_months;
+            age_min_months = EXCLUDED.age_min_months, age_max_months = EXCLUDED.age_max_months,
+            primary_breed = EXCLUDED.primary_breed, breed_type = EXCLUDED.breed_type, breed_slug = EXCLUDED.breed_slug;
         """
         cursor.execute(animals_sql)
         print("[conftest.manage_test_data] Comprehensive test animals inserted (12 dogs with various breeds).")

--- a/tests/fixtures/sql_introspection.py
+++ b/tests/fixtures/sql_introspection.py
@@ -1,0 +1,41 @@
+"""Read values out of executed SQL by column name rather than by position.
+
+Indexing into an INSERT's parameter tuple by position breaks silently when a
+column is added upstream: every later index shifts by one, and the assertion
+either compares against whatever value slid into that slot or fails with a bare
+``None`` that says nothing about the cause. Looking a column up by name fails
+loudly, names the problem, and survives schema changes.
+"""
+
+import re
+from typing import Any
+
+_INSERT_COLUMNS = re.compile(r"INSERT\s+INTO\s+\w+\s*\((?P<columns>[^)]*)\)", re.IGNORECASE)
+
+
+def insert_column_value(execute_call: Any, column: str) -> Any:
+    """Return the parameter an INSERT bound to ``column``.
+
+    Args:
+        execute_call: A single entry from ``mock_cursor.execute.call_args_list``.
+        column: Column name as written in the INSERT's column list.
+
+    Raises:
+        AssertionError: If the call is not an INSERT, does not name ``column``,
+            or binds fewer parameters than the column list declares.
+    """
+    sql, params = execute_call[0][0], execute_call[0][1]
+
+    match = _INSERT_COLUMNS.search(sql)
+    if match is None:
+        raise AssertionError(f"Expected an INSERT statement, got: {sql.strip()[:120]}")
+
+    columns = [name.strip() for name in match.group("columns").split(",")]
+    if column not in columns:
+        raise AssertionError(f"INSERT does not write {column!r}. Columns: {columns}")
+
+    index = columns.index(column)
+    if index >= len(params):
+        raise AssertionError(f"INSERT declares {len(columns)} columns but bound only {len(params)} parameters")
+
+    return params[index]

--- a/tests/resilience/test_error_handling.py
+++ b/tests/resilience/test_error_handling.py
@@ -16,24 +16,28 @@ class TestErrorResilience:
     """Test system resilience to various failure scenarios."""
 
     @pytest.fixture
-    def mock_scraper(self):
-        """Create a mock scraper for testing."""
+    def database_service(self):
+        """Stand in for the DatabaseService production injects into every scraper.
+
+        BaseScraper.save_animal persists through self.database_service. Without
+        one it logs a warning and returns (None, "error"), so a scraper built
+        without this saves nothing while still looking like it ran.
+        """
+        service = Mock()
+        service.get_existing_animal.return_value = None
+        service.create_animal.return_value = (1, "added")
+        service.update_animal.side_effect = lambda animal_id, animal_data: (animal_id, "updated")
+        return service
+
+    @pytest.fixture
+    def mock_scraper(self, database_service):
+        """Create a scraper wired the way the production loader wires one."""
 
         class TestScraper(BaseScraper):
             def collect_data(self):
                 return [{"name": "Test Dog", "external_id": "test123"}]
 
-            def get_existing_animal(self, external_id, organization_id):
-                return None
-
-            def create_animal(self, animal_data):
-                return 1, "added"
-
-            def update_animal(self, animal_id, animal_data):
-                return animal_id, "updated"
-
-        # Use only organization_id (removed organization_name parameter)
-        return TestScraper(organization_id=1)
+        return TestScraper(organization_id=1, database_service=database_service)
 
     @patch.dict(
         "os.environ",
@@ -91,7 +95,7 @@ class TestErrorResilience:
             "CLOUDINARY_API_SECRET": "",
         },
     )
-    def test_partial_data_handling(self, mock_scraper):
+    def test_partial_data_handling(self, mock_scraper, database_service):
         """Test system handles incomplete animal data gracefully."""
         # Test with minimal required data
         minimal_data = {
@@ -101,10 +105,16 @@ class TestErrorResilience:
             # Missing breed, age, size, etc.
         }
 
-        # Should not crash with minimal data
         animal_id, action = mock_scraper.save_animal(minimal_data)
-        assert animal_id is not None
-        assert action in ["added", "updated", "test"]
+
+        assert (animal_id, action) == (1, "added")
+
+        # The absent fields must reach the database as absent, not as junk.
+        saved = database_service.create_animal.call_args[0][0]
+        assert saved["name"] == "Incomplete Dog"
+        assert saved["external_id"] == "incomplete123"
+        assert saved.get("age_text") is None
+        assert saved.get("sex") is None
 
     @patch.dict(
         "os.environ",
@@ -114,7 +124,7 @@ class TestErrorResilience:
             "CLOUDINARY_API_SECRET": "",
         },
     )
-    def test_malformed_image_url_handling(self, mock_scraper):
+    def test_malformed_image_url_handling(self, mock_scraper, database_service):
         """Test handling of malformed or invalid image URLs."""
         malformed_data = {
             "name": "Test Dog",
@@ -123,10 +133,14 @@ class TestErrorResilience:
             "organization_id": 1,
         }
 
-        # Should handle malformed URL gracefully
         animal_id, action = mock_scraper.save_animal(malformed_data)
-        assert animal_id is not None
-        assert action in ["added", "updated", "test"]
+
+        assert (animal_id, action) == (1, "added")
+
+        # A malformed URL must not silently become the dog's image.
+        saved = database_service.create_animal.call_args[0][0]
+        assert saved["name"] == "Test Dog"
+        assert saved.get("primary_image_url") in (None, "not-a-valid-url")
 
     @patch.dict(
         "os.environ",

--- a/tests/services/test_database_service_slug_integration.py
+++ b/tests/services/test_database_service_slug_integration.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from services.database_service import DatabaseService
+from tests.fixtures.sql_introspection import insert_column_value
 
 
 @pytest.mark.slow
@@ -67,8 +68,7 @@ class TestDatabaseServiceSlugIntegration:
 
                 # Check INSERT uses temp slug
                 insert_call = mock_cursor.execute.call_args_list[0]
-                insert_values = insert_call[0][1]
-                assert "fluffy-temp" == insert_values[19]  # slug parameter position
+                assert insert_column_value(insert_call, "slug") == "fluffy-temp"
 
                 # Check UPDATE uses final slug
                 update_call = mock_cursor.execute.call_args_list[1]
@@ -198,8 +198,7 @@ class TestDatabaseServiceSlugIntegration:
 
             # Verify INSERT was called with fallback slug pattern
             insert_call = mock_cursor.execute.call_args_list[0]
-            insert_values = insert_call[0][1]
-            fallback_slug = insert_values[19]  # slug parameter position
+            fallback_slug = insert_column_value(insert_call, "slug")
             assert "animal-test-999-temp" == fallback_slug
 
     def test_create_animal_with_connection_pool(self):
@@ -259,10 +258,11 @@ class TestDatabaseServiceSlugIntegration:
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
 
-        # Mock existing animal data (slug should be preserved)
-        # Updated to include all 16 columns that the SELECT query expects
+        # Mock existing animal data (slug should be preserved).
+        # Must match the SELECT column list in DatabaseService.update_animal
+        # exactly; a short row raises inside the broad except and returns
+        # (None, "error") rather than failing visibly.
         mock_cursor.fetchone.side_effect = [
-            # First call - get current animal data (16 columns)
             (
                 "Old Name",  # name
                 "Old Breed",  # breed
@@ -280,6 +280,7 @@ class TestDatabaseServiceSlugIntegration:
                 None,  # secondary_breed
                 "old-breed-slug",  # breed_slug
                 0.95,  # breed_confidence
+                "Old Breed",  # breed_raw
             ),
             # No second call needed for updates
         ]
@@ -304,11 +305,8 @@ class TestDatabaseServiceSlugIntegration:
             )
 
             with patch("services.database_service.parse_age_text") as mock_parse_age:
-                # Create a mock object with min_months and max_months attributes
-                mock_age_info = MagicMock()
-                mock_age_info.min_months = 12
-                mock_age_info.max_months = 24
-                mock_parse_age.return_value = mock_age_info
+                # parse_age_text returns (age_category, min_months, max_months)
+                mock_parse_age.return_value = ("Young", 12, 24)
 
                 animal_id, action = db_service.update_animal(123, animal_data)
 

--- a/tests/services/test_database_service_slug_two_phase.py
+++ b/tests/services/test_database_service_slug_two_phase.py
@@ -15,6 +15,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from services.database_service import DatabaseService
+from tests.fixtures.sql_introspection import insert_column_value
 
 
 @pytest.mark.slow
@@ -78,14 +79,12 @@ class TestDatabaseServiceTwoPhaseSlugGeneration:
 
         # Verify INSERT was called with temp slug
         insert_call = mock_cursor.execute.call_args_list[1]
-        insert_sql = insert_call[0][0]
-        insert_params = insert_call[0][1]
 
-        assert "INSERT INTO animals" in insert_sql
-        # The temp slug should be in the INSERT (position 19 based on current schema)
-        temp_slug = insert_params[19]  # slug parameter position
-        # "Labrador Mix" standardizes to "Labrador Mix" (capitalized input)
-        assert temp_slug == "bella-labrador-mix-temp"
+        assert "INSERT INTO animals" in insert_call[0][0]
+        temp_slug = insert_column_value(insert_call, "slug")
+        # standardized_breed keeps the cross ("Labrador Mix" -> "Labrador
+        # Retriever Cross"); primary_breed is the bare grouping key.
+        assert temp_slug == "bella-labrador-retriever-cross-temp"
 
         # Verify UPDATE was called with final slug containing ID
         update_call = mock_cursor.execute.call_args_list[3]
@@ -93,7 +92,7 @@ class TestDatabaseServiceTwoPhaseSlugGeneration:
         update_params = update_call[0][1]
 
         assert "UPDATE animals SET slug" in update_sql
-        assert update_params[0] == "bella-labrador-mix-1234"  # final slug with ID
+        assert update_params[0] == "bella-labrador-retriever-cross-1234"  # final slug with ID
         assert update_params[1] == 1234  # WHERE id = animal_id
 
         # Verify transaction was committed

--- a/utils/unified_standardization.py
+++ b/utils/unified_standardization.py
@@ -572,7 +572,7 @@ class UnifiedStandardizer:
             "standardization_confidence": breed_result.get("confidence", 0.0),
             # Age fields - preserve original and add ranges
             "age": age,  # Preserve original age field
-            "age_text": age or "Unknown",  # Database expects age_text field
+            "age_text": age,  # Nullable end to end; an absent age stays absent
             "age_category": age_result.get("age_category"),
             "age_min_months": age_result.get("age_min_months"),
             "age_max_months": age_result.get("age_max_months"),


### PR DESCRIPTION
Stacked on #346. Base retargets to `main` when that merges.

## Why

Running the suite with no marker filter surfaces **seven failures**. All seven are excluded from PR CI by the `slow` marker, and the only workflow that would run them — `pre-merge.yml` — has not fired since **25 Jan 2026**.

Six were stale tests. One was a live production bug.

## The production bug: fabricated ages

`UnifiedStandardizer` wrote `age or "Unknown"` into `age_text`. Nothing required that placeholder — the column is nullable, `api.models.dog` types it `str | None`, and the frontend Zod schema marks it optional.

```sql
SELECT COUNT(*) FROM animals WHERE active AND age_text = 'Unknown';
-- 153, across 4 organizations, every one with age_min_months IS NULL
```

So for 153 dogs the literal string `"Unknown"` is the only age signal reaching the page. Same class as #334, which stopped an unknown size defaulting to `Medium`.

> [!IMPORTANT]
> **The 153 existing rows will not self-correct.** `skip_existing_animals` means a stored row never reaches `process_animal` again. A backfill is required and is deliberately **not** in this PR.

## The six stale tests

| Failure | Cause |
|---|---|
| 3 × slug assertions | Indexed the INSERT parameter tuple by **position**. Adding `breed_raw` upstream shifted every later index, so they compared against `properties` and failed with a bare `None`. |
| `test_update_animal_preserves_existing_slug` | Mock returned a 16-value row against a 17-column SELECT, and mocked `parse_age_text` as an object when it returns a tuple. Both swallowed by a broad `except`. |
| 2 × slug expectations | Predated the breed registry. `"Labrador Mix"` standardizes to `"Labrador Retriever Cross"` now — verified intended against the standardizer. |
| `test_breeds_contains_known_value` | conftest seed had no `primary_breed`/`breed_type`/`breed_slug`, so `/api/animals/meta/breeds` returned `[]` against 12 seeded dogs. |

### On the positional assertions

New helper `tests/fixtures/sql_introspection.py` looks columns up **by name**. Position-indexing is what let this rot silently for months: the assertion keeps passing against whatever value slid into the slot, or fails with a `None` that names nothing. The helper raises with the actual column list instead.

### On the quarantine marker

```python
@pytest.mark.slow  # Fails in CI due to database setup differences
def test_breeds_contains_known_value(self, client):
```

That marker was quarantine, not a speed claim. The fixture is fixed and the marker is gone.

### On the resilience tests

They asserted `animal_id is not None` against a scraper built with no `DatabaseService`, so `save_animal` warned and returned `None`. They now inject the service `utils/secure_scraper_loader.py:171` injects in production, and assert what actually reaches the database.

## Result

**2213 passed, 0 failed, 35.8s** — the whole suite, every marker, no exclusions. First time green since January.

## Latent issue, not fixed here

`BaseScraper` has nine `_log_service_unavailable` call sites that degrade to a warning and a `None` return. Production always injects via the loader, so none is live, but a misconfigured scraper would persist nothing while appearing to run. Worth a separate decision about failing loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDVRkA4nvfVFaoYvmR1M4k