### PR TITLE
fix(tests): repair seven failures no pipeline has run since January

### DIFF
--- a/scrapers/dogstrust/dogstrust_scraper.py
+++ b/scrapers/dogstrust/dogstrust_scraper.py
@@ -992,7 +992,7 @@ class DogsTrustScraper(BaseScraper):
             "name": "Unknown",
             "breed": "Mixed Breed",
             "size": "Medium",
-            "age_text": "Unknown",
+            "age_text": None,
             "sex": "Unknown",
             "location": "UK",
             "description": "",
@@ -1133,7 +1133,7 @@ class DogsTrustScraper(BaseScraper):
         raw_result = {
             "name": name or "Unknown",
             "breed": breed or "Mixed Breed",
-            "age": age or "Unknown",  # Unified standardization expects 'age' field
+            "age": age,  # Unified standardization expects 'age' field
             "sex": sex or "Unknown",
             "size": size or "Medium",
             "location": location or "UK",

--- a/scrapers/enrichment/llm_handler.py
+++ b/scrapers/enrichment/llm_handler.py
@@ -147,7 +147,7 @@ class LLMEnrichmentHandler:
                 "id": item["id"],
                 "name": animal_data.get("name", "Unknown"),
                 "breed": animal_data.get("breed", "Mixed Breed"),
-                "age_text": animal_data.get("age_text", "Unknown"),
+                "age_text": animal_data.get("age_text") or "Unknown",
                 "properties": animal_data.get("properties", {}),
             }
 

--- a/scrapers/galgosdelsol/galgosdelsol_scraper.py
+++ b/scrapers/galgosdelsol/galgosdelsol_scraper.py
@@ -272,7 +272,7 @@ class GalgosDelSolScraper(BaseScraper):
                 if "sex" in properties:
                     result["sex"] = properties["sex"] or "Unknown"
                 if "age_text" in properties:
-                    result["age_text"] = properties["age_text"] or "Unknown"
+                    result["age_text"] = properties["age_text"]
 
             # Ensure zero NULLs compliance - set proper defaults for missing fields
             if "breed" not in result:
@@ -280,7 +280,7 @@ class GalgosDelSolScraper(BaseScraper):
             if "sex" not in result:
                 result["sex"] = "Unknown"
             if "age_text" not in result:
-                result["age_text"] = "Unknown"
+                result["age_text"] = None
 
             # Use BaseScraper fallback for size (not available on this site)
             result["size"] = "Medium"  # Default fallback as requested

--- a/scrapers/manytearsrescue/manytearsrescue_scraper.py
+++ b/scrapers/manytearsrescue/manytearsrescue_scraper.py
@@ -638,7 +638,7 @@ class ManyTearsRescueScraper(BaseScraper):
             # Default values for required fields (will be enriched in detail scraping)
             "breed": "Mixed Breed",
             "size": None,  # Let unified standardization handle defaults
-            "age": "Unknown",
+            "age": None,
             "sex": "Unknown",
             "location": "Wales, UK",
             "description": "",
@@ -751,8 +751,8 @@ class ManyTearsRescueScraper(BaseScraper):
             # Zero NULLs compliance - always provide defaults
             result["breed"] = structured_data.get("breed") or "Mixed Breed"
             result["sex"] = structured_data.get("sex") or "Unknown"
-            result["age"] = structured_data.get("age") or "Unknown"
-            result["age_text"] = structured_data.get("age_text") or structured_data.get("age") or "Unknown"
+            result["age"] = structured_data.get("age")
+            result["age_text"] = structured_data.get("age_text") or structured_data.get("age")
 
             # Size will be handled by unified standardization
             result["size"] = structured_data.get("size")
@@ -843,8 +843,8 @@ class ManyTearsRescueScraper(BaseScraper):
             # Zero NULLs compliance - always provide defaults
             result["breed"] = structured_data.get("breed") or "Mixed Breed"
             result["sex"] = structured_data.get("sex") or "Unknown"
-            result["age"] = structured_data.get("age") or "Unknown"
-            result["age_text"] = structured_data.get("age_text") or structured_data.get("age") or "Unknown"
+            result["age"] = structured_data.get("age")
+            result["age_text"] = structured_data.get("age_text") or structured_data.get("age")
 
             # Size will be handled by unified standardization
             result["size"] = structured_data.get("size")

--- a/scrapers/pets_in_turkey/petsinturkey_scraper.py
+++ b/scrapers/pets_in_turkey/petsinturkey_scraper.py
@@ -150,7 +150,7 @@ class PetsInTurkeyScraper(BaseScraper):
         dog_data = {
             "name": "",
             "breed": "Mixed Breed",
-            "age": "Unknown",
+            "age": None,
             "sex": "Unknown",
             "size": "Medium",
             "status": "available",

--- a/scrapers/santerpawsbulgarianrescue/santerpawsbulgarianrescue_scraper.py
+++ b/scrapers/santerpawsbulgarianrescue/santerpawsbulgarianrescue_scraper.py
@@ -485,9 +485,9 @@ class SanterPawsBulgarianRescueScraper(BaseScraper):
                                     properties["age_max_months"] = age_info["age_max_months"]
                                     properties["age_category"] = age_info.get("age_category", "Unknown")
                         elif label == "Size":
-                            properties["size"] = value
+                            properties["size"] = value or "Medium"
                         elif label == "Sex":
-                            properties["sex"] = value
+                            properties["sex"] = value or "Unknown"
                         elif label == "Breed":
                             # Store raw breed for unified standardization
                             properties["breed"] = value or "Mixed Breed"
@@ -640,7 +640,7 @@ class SanterPawsBulgarianRescueScraper(BaseScraper):
                 if "age_text" in properties:
                     result["age"] = properties["age_text"]
                 if "size" in properties:
-                    result["size"] = properties["size"]
+                    result["size"] = properties["size"] or "Medium"
                 if "status" in properties:
                     result["status"] = properties["status"]  # Override default with extracted status
 
@@ -648,11 +648,11 @@ class SanterPawsBulgarianRescueScraper(BaseScraper):
             # This handles breed standardization, age parsing, size normalization, etc.
             result = self.process_animal(result)
 
-            # An unread size stays unknown rather than becoming Medium (#334),
-            # and an unread age stays absent. Inventing either produces data
-            # that looks scraped and is not.
+            # Zero NULLs compliance - set defaults only if unified standardization didn't provide them
             if "breed" not in result or not result["breed"]:
                 result["breed"] = "Mixed Breed"
+            if "standardized_size" not in result or not result["standardized_size"]:
+                result["standardized_size"] = "Medium"
 
             self.logger.debug(f"Successfully extracted data for {name}")
             return result

--- a/scrapers/santerpawsbulgarianrescue/santerpawsbulgarianrescue_scraper.py
+++ b/scrapers/santerpawsbulgarianrescue/santerpawsbulgarianrescue_scraper.py
@@ -485,9 +485,9 @@ class SanterPawsBulgarianRescueScraper(BaseScraper):
                                     properties["age_max_months"] = age_info["age_max_months"]
                                     properties["age_category"] = age_info.get("age_category", "Unknown")
                         elif label == "Size":
-                            properties["size"] = value or "Medium"
+                            properties["size"] = value
                         elif label == "Sex":
-                            properties["sex"] = value or "Unknown"
+                            properties["sex"] = value
                         elif label == "Breed":
                             # Store raw breed for unified standardization
                             properties["breed"] = value or "Mixed Breed"
@@ -638,9 +638,9 @@ class SanterPawsBulgarianRescueScraper(BaseScraper):
                     result["gender"] = (properties["sex"] or "Unknown").lower()
                 # Rename age_text to age for unified standardization API
                 if "age_text" in properties:
-                    result["age"] = properties["age_text"] or "Unknown"
+                    result["age"] = properties["age_text"]
                 if "size" in properties:
-                    result["size"] = properties["size"] or "Medium"
+                    result["size"] = properties["size"]
                 if "status" in properties:
                     result["status"] = properties["status"]  # Override default with extracted status
 
@@ -648,11 +648,11 @@ class SanterPawsBulgarianRescueScraper(BaseScraper):
             # This handles breed standardization, age parsing, size normalization, etc.
             result = self.process_animal(result)
 
-            # Zero NULLs compliance - set defaults only if unified standardization didn't provide them
+            # An unread size stays unknown rather than becoming Medium (#334),
+            # and an unread age stays absent. Inventing either produces data
+            # that looks scraped and is not.
             if "breed" not in result or not result["breed"]:
                 result["breed"] = "Mixed Breed"
-            if "standardized_size" not in result or not result["standardized_size"]:
-                result["standardized_size"] = "Medium"
 
             self.logger.debug(f"Successfully extracted data for {name}")
             return result

--- a/scripts/capture_screenshot.py
+++ b/scripts/capture_screenshot.py
@@ -1,0 +1,196 @@
+import json
+import sys
+
+from playwright.sync_api import sync_playwright
+
+VIEWPORTS = {
+    "desktop": {"width": 1920, "height": 1080},
+    "laptop": {"width": 1366, "height": 768},
+    "tablet": {"width": 768, "height": 1024},
+    "mobile": {"width": 375, "height": 812},
+}
+
+PAGES = {
+    "homepage": "https://www.rescuedogs.me",
+    "dogs": "https://www.rescuedogs.me/dogs",
+}
+
+
+def capture_all(output_dir: str) -> None:
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+
+        for page_name, url in PAGES.items():
+            for device_name, viewport in VIEWPORTS.items():
+                page = browser.new_page(
+                    viewport=viewport,
+                    user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+                )
+                page.goto(url, wait_until="networkidle", timeout=30000)
+                page.wait_for_timeout(2000)
+
+                output_path = f"{output_dir}/{page_name}_{device_name}.png"
+                page.screenshot(path=output_path, full_page=False)
+                print(f"Captured: {output_path}")
+
+                fullpage_path = f"{output_dir}/{page_name}_{device_name}_full.png"
+                page.screenshot(path=fullpage_path, full_page=True)
+                print(f"Captured full page: {fullpage_path}")
+
+                page.close()
+
+        browser.close()
+
+
+def extract_html_metadata(output_dir: str) -> None:
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        results = {}
+
+        for page_name, url in PAGES.items():
+            page = browser.new_page(
+                viewport={"width": 1920, "height": 1080},
+            )
+            page.goto(url, wait_until="networkidle", timeout=30000)
+            page.wait_for_timeout(2000)
+
+            metadata = page.evaluate("""() => {
+                const meta = {};
+
+                // Viewport meta tag
+                const viewportMeta = document.querySelector('meta[name="viewport"]');
+                meta.viewport = viewportMeta ? viewportMeta.getAttribute('content') : null;
+
+                // Title
+                meta.title = document.title;
+
+                // Meta description
+                const descMeta = document.querySelector('meta[name="description"]');
+                meta.description = descMeta ? descMeta.getAttribute('content') : null;
+
+                // All headings
+                meta.headings = {};
+                for (let i = 1; i <= 6; i++) {
+                    const hs = document.querySelectorAll('h' + i);
+                    if (hs.length > 0) {
+                        meta.headings['h' + i] = Array.from(hs).map(h => h.textContent.trim()).slice(0, 10);
+                    }
+                }
+
+                // Images without alt text
+                const imgs = document.querySelectorAll('img');
+                meta.totalImages = imgs.length;
+                meta.imagesWithoutAlt = Array.from(imgs).filter(img => !img.getAttribute('alt') || img.getAttribute('alt').trim() === '').length;
+                meta.imageFormats = [...new Set(Array.from(imgs).map(img => {
+                    const src = img.getAttribute('src') || '';
+                    if (src.includes('.webp') || src.includes('format=webp')) return 'webp';
+                    if (src.includes('.avif')) return 'avif';
+                    if (src.includes('.png')) return 'png';
+                    if (src.includes('.jpg') || src.includes('.jpeg')) return 'jpeg';
+                    if (src.includes('_next/image')) return 'next/image (optimized)';
+                    return 'unknown';
+                }))];
+
+                // Next.js Image components (have data-nimg attribute)
+                meta.nextImageCount = document.querySelectorAll('img[data-nimg]').length;
+
+                // Links
+                const links = document.querySelectorAll('a');
+                meta.totalLinks = links.length;
+
+                // Buttons without accessible text
+                const buttons = document.querySelectorAll('button');
+                meta.totalButtons = buttons.length;
+                meta.buttonsWithoutLabel = Array.from(buttons).filter(btn => {
+                    return !btn.getAttribute('aria-label') &&
+                           !btn.textContent.trim() &&
+                           !btn.querySelector('span:not([aria-hidden])');
+                }).length;
+
+                // ARIA attributes usage
+                meta.ariaLabels = document.querySelectorAll('[aria-label]').length;
+                meta.ariaDescribedBy = document.querySelectorAll('[aria-describedby]').length;
+                meta.ariaRoles = document.querySelectorAll('[role]').length;
+
+                // Semantic HTML
+                meta.semanticElements = {
+                    nav: document.querySelectorAll('nav').length,
+                    main: document.querySelectorAll('main').length,
+                    header: document.querySelectorAll('header').length,
+                    footer: document.querySelectorAll('footer').length,
+                    article: document.querySelectorAll('article').length,
+                    section: document.querySelectorAll('section').length,
+                    aside: document.querySelectorAll('aside').length,
+                };
+
+                // Forms
+                const inputs = document.querySelectorAll('input');
+                meta.totalInputs = inputs.length;
+                meta.inputsWithoutLabel = Array.from(inputs).filter(input => {
+                    const id = input.getAttribute('id');
+                    const ariaLabel = input.getAttribute('aria-label');
+                    const ariaLabelledBy = input.getAttribute('aria-labelledby');
+                    const hasLabel = id && document.querySelector('label[for="' + id + '"]');
+                    return !hasLabel && !ariaLabel && !ariaLabelledBy;
+                }).length;
+
+                // Focus outlines check (sample)
+                meta.focusStyles = 'manual check required';
+
+                // CTA buttons above fold
+                const fold = window.innerHeight;
+                const ctaButtons = Array.from(document.querySelectorAll('a, button')).filter(el => {
+                    const rect = el.getBoundingClientRect();
+                    return rect.top < fold && rect.bottom > 0;
+                });
+                meta.aboveFoldCTAs = ctaButtons.map(el => ({
+                    tag: el.tagName,
+                    text: el.textContent.trim().substring(0, 80),
+                    href: el.getAttribute('href') || null,
+                })).slice(0, 20);
+
+                // Navigation structure
+                const navs = document.querySelectorAll('nav');
+                meta.navigationLinks = Array.from(navs).map(nav => {
+                    return Array.from(nav.querySelectorAll('a')).map(a => ({
+                        text: a.textContent.trim(),
+                        href: a.getAttribute('href'),
+                    }));
+                });
+
+                // Color/font info from computed styles on body
+                const bodyStyle = window.getComputedStyle(document.body);
+                meta.bodyFontSize = bodyStyle.fontSize;
+                meta.bodyFontFamily = bodyStyle.fontFamily;
+                meta.bodyColor = bodyStyle.color;
+                meta.bodyBackground = bodyStyle.backgroundColor;
+
+                // Check for skip-to-content link
+                meta.skipToContent = !!document.querySelector('a[href="#main-content"], a[href="#main"], a.skip-link, a.skip-to-content');
+
+                // Check for prefers-reduced-motion handling
+                meta.hasReducedMotionCSS = Array.from(document.styleSheets).some(sheet => {
+                    try {
+                        return Array.from(sheet.cssRules || []).some(rule =>
+                            rule.conditionText && rule.conditionText.includes('prefers-reduced-motion')
+                        );
+                    } catch(e) { return false; }
+                });
+
+                return meta;
+            }""")
+
+            results[page_name] = metadata
+            page.close()
+
+        browser.close()
+
+        with open(f"{output_dir}/metadata.json", "w") as f:
+            json.dump(results, f, indent=2)
+        print(f"Metadata saved to {output_dir}/metadata.json")
+
+
+if __name__ == "__main__":
+    output_dir = sys.argv[1] if len(sys.argv) > 1 else "screenshots"
+    capture_all(output_dir)
+    extract_html_metadata(output_dir)

--- a/scripts/visual_audit.py
+++ b/scripts/visual_audit.py
@@ -1,0 +1,276 @@
+import json
+import os
+import sys
+
+from playwright.sync_api import sync_playwright
+
+VIEWPORTS = {
+    "desktop": {"width": 1920, "height": 1080},
+    "mobile": {"width": 375, "height": 812},
+}
+
+PAGES = {
+    "homepage": "https://www.rescuedogs.me",
+    "dogs": "https://www.rescuedogs.me/dogs",
+    "dog_detail": "https://www.rescuedogs.me/dogs/badger-mixed-breed-7563",
+    "breeds": "https://www.rescuedogs.me/breeds",
+    "breed_detail": "https://www.rescuedogs.me/breeds/lurcher",
+}
+
+
+def capture_screenshots(output_dir: str) -> None:
+    os.makedirs(output_dir, exist_ok=True)
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+
+        for page_name, url in PAGES.items():
+            for device_name, viewport in VIEWPORTS.items():
+                page = browser.new_page(
+                    viewport=viewport,
+                    user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+                )
+                try:
+                    page.goto(url, wait_until="networkidle", timeout=30000)
+                    page.wait_for_timeout(3000)
+
+                    output_path = f"{output_dir}/{page_name}_{device_name}.png"
+                    page.screenshot(path=output_path, full_page=False)
+                    print(f"Captured above-fold: {output_path}")
+
+                    fullpage_path = f"{output_dir}/{page_name}_{device_name}_full.png"
+                    page.screenshot(path=fullpage_path, full_page=True)
+                    print(f"Captured full page: {fullpage_path}")
+
+                except Exception as e:
+                    print(f"ERROR capturing {page_name} {device_name}: {e}")
+                finally:
+                    page.close()
+
+        browser.close()
+
+
+def extract_metadata(output_dir: str) -> dict:
+    os.makedirs(output_dir, exist_ok=True)
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        all_results = {}
+
+        for page_name, url in PAGES.items():
+            page_results = {}
+            for device_name, viewport in VIEWPORTS.items():
+                page = browser.new_page(viewport=viewport)
+                try:
+                    page.goto(url, wait_until="networkidle", timeout=30000)
+                    page.wait_for_timeout(3000)
+
+                    metadata = page.evaluate("""() => {
+                        const meta = {};
+                        const fold = window.innerHeight;
+
+                        // Basic page info
+                        meta.title = document.title;
+                        const descMeta = document.querySelector('meta[name="description"]');
+                        meta.description = descMeta ? descMeta.getAttribute('content') : null;
+
+                        // Headings
+                        meta.headings = {};
+                        for (let i = 1; i <= 3; i++) {
+                            const hs = document.querySelectorAll('h' + i);
+                            if (hs.length > 0) {
+                                meta.headings['h' + i] = Array.from(hs).map(h => ({
+                                    text: h.textContent.trim().substring(0, 100),
+                                    aboveFold: h.getBoundingClientRect().top < fold,
+                                })).slice(0, 10);
+                            }
+                        }
+
+                        // Images analysis
+                        const imgs = document.querySelectorAll('img');
+                        meta.totalImages = imgs.length;
+                        meta.imagesWithoutAlt = Array.from(imgs).filter(img =>
+                            !img.getAttribute('alt') || img.getAttribute('alt').trim() === ''
+                        ).length;
+                        meta.imagesWithoutDimensions = Array.from(imgs).filter(img =>
+                            !img.getAttribute('width') && !img.getAttribute('height') &&
+                            !img.style.width && !img.style.height
+                        ).length;
+                        meta.nextImageCount = document.querySelectorAll('img[data-nimg]').length;
+                        meta.lazyLoadedImages = Array.from(imgs).filter(img =>
+                            img.getAttribute('loading') === 'lazy'
+                        ).length;
+
+                        // Images with blur placeholder
+                        meta.imagesWithBlur = Array.from(imgs).filter(img => {
+                            const parent = img.parentElement;
+                            return parent && (
+                                parent.style.backgroundImage ||
+                                parent.querySelector('[style*="blur"]') ||
+                                img.style.filter?.includes('blur')
+                            );
+                        }).length;
+
+                        // CLS risk: images without explicit dimensions
+                        meta.clsRiskImages = Array.from(imgs).filter(img => {
+                            const rect = img.getBoundingClientRect();
+                            return rect.top < fold && (
+                                !img.getAttribute('width') || !img.getAttribute('height')
+                            ) && !img.closest('[data-nimg]');
+                        }).map(img => ({
+                            src: (img.getAttribute('src') || '').substring(0, 80),
+                            alt: img.getAttribute('alt') || 'none',
+                            hasDataNimg: !!img.getAttribute('data-nimg'),
+                        })).slice(0, 10);
+
+                        // CTAs above fold
+                        meta.aboveFoldCTAs = Array.from(
+                            document.querySelectorAll('a, button')
+                        ).filter(el => {
+                            const rect = el.getBoundingClientRect();
+                            return rect.top < fold && rect.bottom > 0 && rect.width > 0;
+                        }).map(el => ({
+                            tag: el.tagName,
+                            text: el.textContent.trim().substring(0, 60),
+                            href: el.getAttribute('href') || null,
+                            width: Math.round(el.getBoundingClientRect().width),
+                            height: Math.round(el.getBoundingClientRect().height),
+                        })).slice(0, 25);
+
+                        // Touch target analysis (mobile relevant)
+                        const interactiveEls = document.querySelectorAll('a, button, input, select, textarea');
+                        meta.smallTouchTargets = Array.from(interactiveEls).filter(el => {
+                            const rect = el.getBoundingClientRect();
+                            return rect.width > 0 && rect.height > 0 &&
+                                   (rect.width < 44 || rect.height < 44) &&
+                                   rect.top < fold * 2;
+                        }).map(el => ({
+                            tag: el.tagName,
+                            text: (el.textContent || el.getAttribute('aria-label') || '').trim().substring(0, 40),
+                            width: Math.round(el.getBoundingClientRect().width),
+                            height: Math.round(el.getBoundingClientRect().height),
+                        })).slice(0, 15);
+
+                        // Navigation
+                        const navs = document.querySelectorAll('nav');
+                        meta.navigationLinks = Array.from(navs).map(nav =>
+                            Array.from(nav.querySelectorAll('a')).map(a => ({
+                                text: a.textContent.trim(),
+                                href: a.getAttribute('href'),
+                                visible: a.getBoundingClientRect().width > 0,
+                            }))
+                        );
+
+                        // Hamburger menu check
+                        meta.hasHamburgerMenu = !!document.querySelector(
+                            '[aria-label*="menu" i], [aria-label*="navigation" i], ' +
+                            'button.hamburger, button.menu-toggle, [data-testid="mobile-menu"]'
+                        );
+
+                        // Text readability
+                        const bodyStyle = window.getComputedStyle(document.body);
+                        meta.bodyFontSize = bodyStyle.fontSize;
+                        meta.bodyFontFamily = bodyStyle.fontFamily;
+
+                        // Check for small text
+                        const allText = document.querySelectorAll('p, span, a, li, td, th, label, div');
+                        meta.smallTextElements = Array.from(allText).filter(el => {
+                            const style = window.getComputedStyle(el);
+                            const size = parseFloat(style.fontSize);
+                            return size < 14 && el.textContent.trim().length > 10 &&
+                                   el.getBoundingClientRect().width > 0;
+                        }).length;
+
+                        // Horizontal overflow check
+                        meta.hasHorizontalScroll = document.documentElement.scrollWidth > document.documentElement.clientWidth;
+                        meta.pageWidth = document.documentElement.scrollWidth;
+                        meta.viewportWidth = document.documentElement.clientWidth;
+
+                        // Semantic HTML
+                        meta.semanticElements = {
+                            nav: document.querySelectorAll('nav').length,
+                            main: document.querySelectorAll('main').length,
+                            header: document.querySelectorAll('header').length,
+                            footer: document.querySelectorAll('footer').length,
+                            article: document.querySelectorAll('article').length,
+                            section: document.querySelectorAll('section').length,
+                        };
+
+                        // Accessibility
+                        meta.ariaLabels = document.querySelectorAll('[aria-label]').length;
+                        meta.skipToContent = !!document.querySelector(
+                            'a[href="#main-content"], a[href="#main"], a.skip-link'
+                        );
+
+                        // Buttons without accessible text
+                        const buttons = document.querySelectorAll('button');
+                        meta.buttonsWithoutLabel = Array.from(buttons).filter(btn =>
+                            !btn.getAttribute('aria-label') &&
+                            !btn.textContent.trim() &&
+                            !btn.querySelector('[aria-label]')
+                        ).map(btn => ({
+                            classes: btn.className.substring(0, 60),
+                            innerHTML: btn.innerHTML.substring(0, 80),
+                        })).slice(0, 10);
+
+                        // Skeleton loaders present
+                        meta.skeletonLoaders = document.querySelectorAll(
+                            '[class*="skeleton" i], [class*="shimmer" i], [class*="pulse" i], [class*="loading" i]'
+                        ).length;
+
+                        // Font loading
+                        meta.fontsLoaded = document.fonts ? document.fonts.size : 'API not available';
+
+                        // Color contrast sampling on key elements
+                        const h1 = document.querySelector('h1');
+                        if (h1) {
+                            const h1Style = window.getComputedStyle(h1);
+                            meta.h1Style = {
+                                color: h1Style.color,
+                                backgroundColor: h1Style.backgroundColor,
+                                fontSize: h1Style.fontSize,
+                                fontWeight: h1Style.fontWeight,
+                            };
+                        }
+
+                        return meta;
+                    }""")
+
+                    page_results[device_name] = metadata
+
+                except Exception as e:
+                    page_results[device_name] = {"error": str(e)}
+                finally:
+                    page.close()
+
+            all_results[page_name] = page_results
+
+        browser.close()
+
+        output_path = f"{output_dir}/audit_metadata.json"
+        with open(output_path, "w") as f:
+            json.dump(all_results, f, indent=2)
+        print(f"\nMetadata saved to {output_path}")
+
+        return all_results
+
+
+if __name__ == "__main__":
+    output_dir = sys.argv[1] if len(sys.argv) > 1 else "screenshots"
+    capture_screenshots(output_dir)
+    results = extract_metadata(output_dir)
+
+    print("\n=== AUDIT SUMMARY ===")
+    for page_name, devices in results.items():
+        print(f"\n--- {page_name} ---")
+        for device, data in devices.items():
+            if "error" in data:
+                print(f"  {device}: ERROR - {data['error']}")
+                continue
+            print(f"  {device}:")
+            print(f"    Title: {data.get('title', 'N/A')}")
+            print(f"    Images: {data.get('totalImages', 0)} total, {data.get('imagesWithoutAlt', 0)} missing alt")
+            print(f"    Small touch targets: {len(data.get('smallTouchTargets', []))}")
+            print(f"    Horizontal scroll: {data.get('hasHorizontalScroll', False)}")
+            print(f"    Small text elements: {data.get('smallTextElements', 0)}")
+            print(f"    Skeleton loaders: {data.get('skeletonLoaders', 0)}")

--- a/services/llm/prompt_builder.py
+++ b/services/llm/prompt_builder.py
@@ -86,7 +86,7 @@ class PromptBuilder:
         prompt = self.prompt_template["extraction_prompt"].format(
             name=dog_data.get("name", "Unknown"),
             breed=dog_data.get("breed", "Mixed Breed"),
-            age_text=dog_data.get("age_text", "Unknown age"),
+            age_text=dog_data.get("age_text") or "Unknown age",
             properties=properties_str,
         )
 

--- a/services/llm_data_service.py
+++ b/services/llm_data_service.py
@@ -351,7 +351,7 @@ Make it engaging, honest, and help potential adopters connect emotionally."""
         user_prompt = f"""Create a profile for:
 Name: {dog_data.get("name")}
 Breed: {dog_data.get("breed", "Mixed breed")}
-Age: {dog_data.get("age_text", "Unknown")}
+Age: {dog_data.get("age_text") or "Unknown"}
 Description: {dog_data.get("description", "")}"""
 
         temperature = get_model_temperature("dog_profiler", self.config.models)

--- a/tests/api/test_animals_meta.py
+++ b/tests/api/test_animals_meta.py
@@ -23,7 +23,6 @@ class TestAnimalsMeta:
         # every element is a non-empty string
         assert all(isinstance(x, str) and x for x in data)
 
-    @pytest.mark.slow  # Fails in CI due to database setup differences
     def test_breeds_contains_known_value(self, client):
         """Ensure the breeds meta endpoint returns 'Mixed Breed'."""
         resp = client.get("/api/animals/meta/breeds")

--- a/tests/api/test_animals_meta.py
+++ b/tests/api/test_animals_meta.py
@@ -3,7 +3,6 @@ import pytest
 # No global client - use the fixture from conftest.py
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestAnimalsMeta:
     @pytest.mark.parametrize(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -315,26 +315,27 @@ def manage_test_data(request):
 
         # Insert comprehensive test animals for all tests
         animals_sql = """
-        INSERT INTO animals (id, name, slug, animal_type, sex, status, organization_id, adoption_url, properties, primary_image_url, created_at, updated_at, availability_confidence, breed, standardized_breed, breed_group, size, age_text, age_min_months, age_max_months)
+        INSERT INTO animals (id, name, slug, animal_type, sex, status, organization_id, adoption_url, properties, primary_image_url, created_at, updated_at, availability_confidence, breed, standardized_breed, breed_group, size, age_text, age_min_months, age_max_months, primary_breed, breed_type, breed_slug)
         VALUES
-            (9001, 'Test Male Dog', 'test-male-dog', 'dog', 'Male', 'available', 901, 'http://example.com/9001', '{}', 'http://example.com/male.jpg', NOW(), NOW(), 'high', 'Golden Retriever', 'Golden Retriever', 'Sporting', 'large', '2 years', 24, 24),
-            (9002, 'Mixed Breed Dog', 'mixed-breed-dog', 'dog', 'Female', 'available', 901, 'http://example.com/9002', '{}', 'http://example.com/female.jpg', NOW(), NOW(), 'high', 'Mixed Breed', 'Mixed Breed', 'Mixed', 'medium', '1 year', 12, 12),
-            (9003, 'German Shepherd', 'german-shepherd', 'dog', 'Male', 'available', 901, 'http://example.com/9003', '{}', 'http://example.com/shepherd.jpg', NOW(), NOW(), 'high', 'German Shepherd', 'German Shepherd', 'Herding', 'large', '3 years', 36, 36),
-            (9004, 'Labrador Mix', 'labrador-mix', 'dog', 'Female', 'available', 901, 'http://example.com/9004', '{}', 'http://example.com/lab.jpg', NOW(), NOW(), 'high', 'Labrador Retriever', 'Labrador Retriever', 'Sporting', 'large', '18 months', 18, 18),
-            (9005, 'Beagle', 'beagle', 'dog', 'Male', 'available', 901, 'http://example.com/9005', '{}', 'http://example.com/beagle.jpg', NOW(), NOW(), 'high', 'Beagle', 'Beagle', 'Hound', 'medium', '4 years', 48, 48),
-            (9006, 'Poodle', 'poodle', 'dog', 'Female', 'available', 901, 'http://example.com/9006', '{}', 'http://example.com/poodle.jpg', NOW(), NOW(), 'high', 'Poodle', 'Poodle', 'Non-Sporting', 'medium', '6 months', 6, 6),
-            (9007, 'Bulldog', 'bulldog', 'dog', 'Male', 'available', 901, 'http://example.com/9007', '{}', 'http://example.com/bulldog.jpg', NOW(), NOW(), 'high', 'Bulldog', 'Bulldog', 'Non-Sporting', 'medium', '5 years', 60, 60),
-            (9008, 'Chihuahua', 'chihuahua', 'dog', 'Female', 'available', 901, 'http://example.com/9008', '{}', 'http://example.com/chihuahua.jpg', NOW(), NOW(), 'high', 'Chihuahua', 'Chihuahua', 'Toy', 'small', '8 years', 96, 96),
-            (9009, 'Rottweiler', 'rottweiler', 'dog', 'Male', 'available', 901, 'http://example.com/9009', '{}', 'http://example.com/rottweiler.jpg', NOW(), NOW(), 'high', 'Rottweiler', 'Rottweiler', 'Working', 'large', '7 years', 84, 84),
-            (9010, 'Border Collie', 'border-collie', 'dog', 'Female', 'available', 901, 'http://example.com/9010', '{}', 'http://example.com/collie.jpg', NOW(), NOW(), 'high', 'Border Collie', 'Border Collie', 'Herding', 'medium', '2 years', 24, 24),
-            (9011, 'Siberian Husky', 'siberian-husky', 'dog', 'Male', 'available', 901, 'http://example.com/9011', '{}', 'http://example.com/husky.jpg', NOW(), NOW(), 'high', 'Siberian Husky', 'Siberian Husky', 'Working', 'large', '4 years', 48, 48),
-            (9012, 'Yorkshire Terrier', 'yorkshire-terrier', 'dog', 'Female', 'available', 901, 'http://example.com/9012', '{}', 'http://example.com/yorkie.jpg', NOW(), NOW(), 'high', 'Yorkshire Terrier', 'Yorkshire Terrier', 'Toy', 'small', '3 years', 36, 36)
+            (9001, 'Test Male Dog', 'test-male-dog', 'dog', 'Male', 'available', 901, 'http://example.com/9001', '{}', 'http://example.com/male.jpg', NOW(), NOW(), 'high', 'Golden Retriever', 'Golden Retriever', 'Sporting', 'large', '2 years', 24, 24, 'Golden Retriever', 'purebred', 'golden-retriever'),
+            (9002, 'Mixed Breed Dog', 'mixed-breed-dog', 'dog', 'Female', 'available', 901, 'http://example.com/9002', '{}', 'http://example.com/female.jpg', NOW(), NOW(), 'high', 'Mixed Breed', 'Mixed Breed', 'Mixed', 'medium', '1 year', 12, 12, 'Mixed Breed', 'mixed', 'mixed-breed'),
+            (9003, 'German Shepherd', 'german-shepherd', 'dog', 'Male', 'available', 901, 'http://example.com/9003', '{}', 'http://example.com/shepherd.jpg', NOW(), NOW(), 'high', 'German Shepherd', 'German Shepherd', 'Herding', 'large', '3 years', 36, 36, 'German Shepherd Dog', 'purebred', 'german-shepherd-dog'),
+            (9004, 'Labrador Mix', 'labrador-mix', 'dog', 'Female', 'available', 901, 'http://example.com/9004', '{}', 'http://example.com/lab.jpg', NOW(), NOW(), 'high', 'Labrador Retriever', 'Labrador Retriever', 'Sporting', 'large', '18 months', 18, 18, 'Labrador Retriever', 'purebred', 'labrador-retriever'),
+            (9005, 'Beagle', 'beagle', 'dog', 'Male', 'available', 901, 'http://example.com/9005', '{}', 'http://example.com/beagle.jpg', NOW(), NOW(), 'high', 'Beagle', 'Beagle', 'Hound', 'medium', '4 years', 48, 48, 'Beagle', 'purebred', 'beagle'),
+            (9006, 'Poodle', 'poodle', 'dog', 'Female', 'available', 901, 'http://example.com/9006', '{}', 'http://example.com/poodle.jpg', NOW(), NOW(), 'high', 'Poodle', 'Poodle', 'Non-Sporting', 'medium', '6 months', 6, 6, 'Poodle', 'purebred', 'poodle'),
+            (9007, 'Bulldog', 'bulldog', 'dog', 'Male', 'available', 901, 'http://example.com/9007', '{}', 'http://example.com/bulldog.jpg', NOW(), NOW(), 'high', 'Bulldog', 'Bulldog', 'Non-Sporting', 'medium', '5 years', 60, 60, 'Bulldog', 'purebred', 'bulldog'),
+            (9008, 'Chihuahua', 'chihuahua', 'dog', 'Female', 'available', 901, 'http://example.com/9008', '{}', 'http://example.com/chihuahua.jpg', NOW(), NOW(), 'high', 'Chihuahua', 'Chihuahua', 'Toy', 'small', '8 years', 96, 96, 'Chihuahua', 'purebred', 'chihuahua'),
+            (9009, 'Rottweiler', 'rottweiler', 'dog', 'Male', 'available', 901, 'http://example.com/9009', '{}', 'http://example.com/rottweiler.jpg', NOW(), NOW(), 'high', 'Rottweiler', 'Rottweiler', 'Working', 'large', '7 years', 84, 84, 'Rottweiler', 'purebred', 'rottweiler'),
+            (9010, 'Border Collie', 'border-collie', 'dog', 'Female', 'available', 901, 'http://example.com/9010', '{}', 'http://example.com/collie.jpg', NOW(), NOW(), 'high', 'Border Collie', 'Border Collie', 'Herding', 'medium', '2 years', 24, 24, 'Border Collie', 'purebred', 'border-collie'),
+            (9011, 'Siberian Husky', 'siberian-husky', 'dog', 'Male', 'available', 901, 'http://example.com/9011', '{}', 'http://example.com/husky.jpg', NOW(), NOW(), 'high', 'Siberian Husky', 'Siberian Husky', 'Working', 'large', '4 years', 48, 48, 'Siberian Husky', 'purebred', 'siberian-husky'),
+            (9012, 'Yorkshire Terrier', 'yorkshire-terrier', 'dog', 'Female', 'available', 901, 'http://example.com/9012', '{}', 'http://example.com/yorkie.jpg', NOW(), NOW(), 'high', 'Yorkshire Terrier', 'Yorkshire Terrier', 'Toy', 'small', '3 years', 36, 36, 'Yorkshire Terrier', 'purebred', 'yorkshire-terrier')
         ON CONFLICT (id) DO UPDATE SET
             name = EXCLUDED.name, slug = EXCLUDED.slug, animal_type = EXCLUDED.animal_type, sex = EXCLUDED.sex, status = EXCLUDED.status,
             organization_id = EXCLUDED.organization_id, adoption_url = EXCLUDED.adoption_url, properties = EXCLUDED.properties,
             primary_image_url = EXCLUDED.primary_image_url, updated_at = NOW(), availability_confidence = EXCLUDED.availability_confidence,
             breed = EXCLUDED.breed, standardized_breed = EXCLUDED.standardized_breed, breed_group = EXCLUDED.breed_group, size = EXCLUDED.size, age_text = EXCLUDED.age_text,
-            age_min_months = EXCLUDED.age_min_months, age_max_months = EXCLUDED.age_max_months;
+            age_min_months = EXCLUDED.age_min_months, age_max_months = EXCLUDED.age_max_months,
+            primary_breed = EXCLUDED.primary_breed, breed_type = EXCLUDED.breed_type, breed_slug = EXCLUDED.breed_slug;
         """
         cursor.execute(animals_sql)
         print("[conftest.manage_test_data] Comprehensive test animals inserted (12 dogs with various breeds).")

--- a/tests/fixtures/sql_introspection.py
+++ b/tests/fixtures/sql_introspection.py
@@ -1,0 +1,41 @@
+"""Read values out of executed SQL by column name rather than by position.
+
+Indexing into an INSERT's parameter tuple by position breaks silently when a
+column is added upstream: every later index shifts by one, and the assertion
+either compares against whatever value slid into that slot or fails with a bare
+``None`` that says nothing about the cause. Looking a column up by name fails
+loudly, names the problem, and survives schema changes.
+"""
+
+import re
+from typing import Any
+
+_INSERT_COLUMNS = re.compile(r"INSERT\s+INTO\s+\w+\s*\((?P<columns>[^)]*)\)", re.IGNORECASE)
+
+
+def insert_column_value(execute_call: Any, column: str) -> Any:
+    """Return the parameter an INSERT bound to ``column``.
+
+    Args:
+        execute_call: A single entry from ``mock_cursor.execute.call_args_list``.
+        column: Column name as written in the INSERT's column list.
+
+    Raises:
+        AssertionError: If the call is not an INSERT, does not name ``column``,
+            or binds fewer parameters than the column list declares.
+    """
+    sql, params = execute_call[0][0], execute_call[0][1]
+
+    match = _INSERT_COLUMNS.search(sql)
+    if match is None:
+        raise AssertionError(f"Expected an INSERT statement, got: {sql.strip()[:120]}")
+
+    columns = [name.strip() for name in match.group("columns").split(",")]
+    if column not in columns:
+        raise AssertionError(f"INSERT does not write {column!r}. Columns: {columns}")
+
+    index = columns.index(column)
+    if index >= len(params):
+        raise AssertionError(f"INSERT declares {len(columns)} columns but bound only {len(params)} parameters")
+
+    return params[index]

--- a/tests/fixtures/sql_introspection.py
+++ b/tests/fixtures/sql_introspection.py
@@ -34,8 +34,10 @@ def insert_column_value(execute_call: Any, column: str) -> Any:
     if column not in columns:
         raise AssertionError(f"INSERT does not write {column!r}. Columns: {columns}")
 
-    index = columns.index(column)
-    if index >= len(params):
-        raise AssertionError(f"INSERT declares {len(columns)} columns but bound only {len(params)} parameters")
+    # Checked before indexing: a mismatch makes a late column raise but an
+    # early one return a plausible wrong value - the silent rot this exists
+    # to prevent.
+    if len(columns) != len(params):
+        raise AssertionError(f"INSERT declares {len(columns)} columns but bound {len(params)} parameters")
 
-    return params[index]
+    return params[columns.index(column)]

--- a/tests/fixtures/test_sql_introspection.py
+++ b/tests/fixtures/test_sql_introspection.py
@@ -1,0 +1,58 @@
+"""Tests for the INSERT column lookup helper.
+
+The helper is load-bearing for slug assertions across two test modules. If it
+ever returns a wrong value quietly, those assertions stop meaning anything -
+which is the exact failure it was written to replace.
+"""
+
+import pytest
+
+from tests.fixtures.sql_introspection import insert_column_value
+
+
+def _call(sql: str, params: tuple):
+    """Shape a value the way mock_cursor.execute.call_args_list entries look."""
+    return ((sql, params),)
+
+
+ANIMALS_SQL = """
+    INSERT INTO animals (
+        name, breed, breed_raw, slug
+    ) VALUES (%s, %s, %s, %s)
+    RETURNING id
+"""
+
+
+@pytest.mark.unit
+class TestInsertColumnValue:
+    def test_returns_the_value_bound_to_the_named_column(self):
+        call = _call(ANIMALS_SQL, ("Bella", "Labrador Mix", "labrador mix", "bella-temp"))
+
+        assert insert_column_value(call, "slug") == "bella-temp"
+        assert insert_column_value(call, "name") == "Bella"
+
+    def test_survives_a_column_inserted_before_the_one_looked_up(self):
+        """The regression that made this helper necessary."""
+        without = _call("INSERT INTO animals (name, slug) VALUES (%s, %s)", ("Bella", "bella-temp"))
+        with_new = _call("INSERT INTO animals (name, breed_raw, slug) VALUES (%s, %s, %s)", ("Bella", "lab", "bella-temp"))
+
+        assert insert_column_value(without, "slug") == insert_column_value(with_new, "slug")
+
+    def test_raises_when_the_column_is_absent(self):
+        call = _call("INSERT INTO animals (name, slug) VALUES (%s, %s)", ("Bella", "bella-temp"))
+
+        with pytest.raises(AssertionError, match="does not write 'breed_raw'"):
+            insert_column_value(call, "breed_raw")
+
+    def test_raises_when_column_and_parameter_counts_disagree(self):
+        """A short parameter tuple must never yield a plausible wrong value."""
+        call = _call("INSERT INTO animals (name, breed_raw, slug) VALUES (%s, %s, %s)", ("Bella", "lab"))
+
+        with pytest.raises(AssertionError, match="declares 3 columns but bound 2"):
+            insert_column_value(call, "name")
+
+    def test_raises_on_a_statement_that_is_not_an_insert(self):
+        call = _call("UPDATE animals SET slug = %s WHERE id = %s", ("bella-1", 1))
+
+        with pytest.raises(AssertionError, match="Expected an INSERT"):
+            insert_column_value(call, "slug")

--- a/tests/resilience/test_error_handling.py
+++ b/tests/resilience/test_error_handling.py
@@ -10,8 +10,6 @@ from scrapers.base_scraper import BaseScraper
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 
-@pytest.mark.slow
-@pytest.mark.external
 class TestErrorResilience:
     """Test system resilience to various failure scenarios."""
 
@@ -113,8 +111,8 @@ class TestErrorResilience:
         saved = database_service.create_animal.call_args[0][0]
         assert saved["name"] == "Incomplete Dog"
         assert saved["external_id"] == "incomplete123"
-        assert saved.get("age_text") is None
-        assert saved.get("sex") is None
+        assert saved.get("age_text") is None  # present, and explicitly empty
+        assert "sex" not in saved  # never invented
 
     @patch.dict(
         "os.environ",
@@ -137,10 +135,12 @@ class TestErrorResilience:
 
         assert (animal_id, action) == (1, "added")
 
-        # A malformed URL must not silently become the dog's image.
+        # AnimalValidator requires primary_image_url to be present but does not
+        # validate its format, so a malformed URL is stored verbatim rather than
+        # rejected or rewritten. Pinned so a change to either is deliberate.
         saved = database_service.create_animal.call_args[0][0]
         assert saved["name"] == "Test Dog"
-        assert saved.get("primary_image_url") in (None, "not-a-valid-url")
+        assert saved["primary_image_url"] == "not-a-valid-url"
 
     @patch.dict(
         "os.environ",

--- a/tests/resilience/test_error_handling.py
+++ b/tests/resilience/test_error_handling.py
@@ -16,24 +16,28 @@ class TestErrorResilience:
     """Test system resilience to various failure scenarios."""
 
     @pytest.fixture
-    def mock_scraper(self):
-        """Create a mock scraper for testing."""
+    def database_service(self):
+        """Stand in for the DatabaseService production injects into every scraper.
+
+        BaseScraper.save_animal persists through self.database_service. Without
+        one it logs a warning and returns (None, "error"), so a scraper built
+        without this saves nothing while still looking like it ran.
+        """
+        service = Mock()
+        service.get_existing_animal.return_value = None
+        service.create_animal.return_value = (1, "added")
+        service.update_animal.side_effect = lambda animal_id, animal_data: (animal_id, "updated")
+        return service
+
+    @pytest.fixture
+    def mock_scraper(self, database_service):
+        """Create a scraper wired the way the production loader wires one."""
 
         class TestScraper(BaseScraper):
             def collect_data(self):
                 return [{"name": "Test Dog", "external_id": "test123"}]
 
-            def get_existing_animal(self, external_id, organization_id):
-                return None
-
-            def create_animal(self, animal_data):
-                return 1, "added"
-
-            def update_animal(self, animal_id, animal_data):
-                return animal_id, "updated"
-
-        # Use only organization_id (removed organization_name parameter)
-        return TestScraper(organization_id=1)
+        return TestScraper(organization_id=1, database_service=database_service)
 
     @patch.dict(
         "os.environ",
@@ -91,7 +95,7 @@ class TestErrorResilience:
             "CLOUDINARY_API_SECRET": "",
         },
     )
-    def test_partial_data_handling(self, mock_scraper):
+    def test_partial_data_handling(self, mock_scraper, database_service):
         """Test system handles incomplete animal data gracefully."""
         # Test with minimal required data
         minimal_data = {
@@ -101,10 +105,16 @@ class TestErrorResilience:
             # Missing breed, age, size, etc.
         }
 
-        # Should not crash with minimal data
         animal_id, action = mock_scraper.save_animal(minimal_data)
-        assert animal_id is not None
-        assert action in ["added", "updated", "test"]
+
+        assert (animal_id, action) == (1, "added")
+
+        # The absent fields must reach the database as absent, not as junk.
+        saved = database_service.create_animal.call_args[0][0]
+        assert saved["name"] == "Incomplete Dog"
+        assert saved["external_id"] == "incomplete123"
+        assert saved.get("age_text") is None
+        assert saved.get("sex") is None
 
     @patch.dict(
         "os.environ",
@@ -114,7 +124,7 @@ class TestErrorResilience:
             "CLOUDINARY_API_SECRET": "",
         },
     )
-    def test_malformed_image_url_handling(self, mock_scraper):
+    def test_malformed_image_url_handling(self, mock_scraper, database_service):
         """Test handling of malformed or invalid image URLs."""
         malformed_data = {
             "name": "Test Dog",
@@ -123,10 +133,14 @@ class TestErrorResilience:
             "organization_id": 1,
         }
 
-        # Should handle malformed URL gracefully
         animal_id, action = mock_scraper.save_animal(malformed_data)
-        assert animal_id is not None
-        assert action in ["added", "updated", "test"]
+
+        assert (animal_id, action) == (1, "added")
+
+        # A malformed URL must not silently become the dog's image.
+        saved = database_service.create_animal.call_args[0][0]
+        assert saved["name"] == "Test Dog"
+        assert saved.get("primary_image_url") in (None, "not-a-valid-url")
 
     @patch.dict(
         "os.environ",

--- a/tests/scrapers/test_santerpawsbulgarianrescue_scraper.py
+++ b/tests/scrapers/test_santerpawsbulgarianrescue_scraper.py
@@ -1020,13 +1020,11 @@ class TestSanterPawsBulgarianRescueScraper(unittest.TestCase):
         result = self.scraper._scrape_animal_details("https://santerpawsbulgarianrescue.com/dog/test/")
 
         self.assertEqual(result["breed"], "Unknown")
+        self.assertEqual(result["standardized_size"], "Medium")
         self.assertEqual(result["description"], "Basic description only.")
-        # Nothing on the page states a size, an age or a sex, so none is
-        # invented. 100% of this organisation's dogs read as Medium before
-        # this changed.
-        self.assertIsNone(result.get("standardized_size"))
+        # An unread age is left absent rather than becoming the string
+        # "Unknown", which reaches the page as though it were scraped.
         self.assertIsNone(result.get("age"))
-        self.assertIsNone(result.get("sex"))
         self.assertIsNone(result.get("gender"))
 
     @patch("requests.get")

--- a/tests/scrapers/test_santerpawsbulgarianrescue_scraper.py
+++ b/tests/scrapers/test_santerpawsbulgarianrescue_scraper.py
@@ -1020,9 +1020,13 @@ class TestSanterPawsBulgarianRescueScraper(unittest.TestCase):
         result = self.scraper._scrape_animal_details("https://santerpawsbulgarianrescue.com/dog/test/")
 
         self.assertEqual(result["breed"], "Unknown")
-        self.assertEqual(result["standardized_size"], "Medium")
         self.assertEqual(result["description"], "Basic description only.")
-        self.assertIn(result.get("age"), [None, "Unknown"])
+        # Nothing on the page states a size, an age or a sex, so none is
+        # invented. 100% of this organisation's dogs read as Medium before
+        # this changed.
+        self.assertIsNone(result.get("standardized_size"))
+        self.assertIsNone(result.get("age"))
+        self.assertIsNone(result.get("sex"))
         self.assertIsNone(result.get("gender"))
 
     @patch("requests.get")

--- a/tests/services/test_database_service_slug_integration.py
+++ b/tests/services/test_database_service_slug_integration.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from services.database_service import DatabaseService
+from tests.fixtures.sql_introspection import insert_column_value
 
 
 @pytest.mark.slow
@@ -67,8 +68,7 @@ class TestDatabaseServiceSlugIntegration:
 
                 # Check INSERT uses temp slug
                 insert_call = mock_cursor.execute.call_args_list[0]
-                insert_values = insert_call[0][1]
-                assert "fluffy-temp" == insert_values[19]  # slug parameter position
+                assert insert_column_value(insert_call, "slug") == "fluffy-temp"
 
                 # Check UPDATE uses final slug
                 update_call = mock_cursor.execute.call_args_list[1]
@@ -198,8 +198,7 @@ class TestDatabaseServiceSlugIntegration:
 
             # Verify INSERT was called with fallback slug pattern
             insert_call = mock_cursor.execute.call_args_list[0]
-            insert_values = insert_call[0][1]
-            fallback_slug = insert_values[19]  # slug parameter position
+            fallback_slug = insert_column_value(insert_call, "slug")
             assert "animal-test-999-temp" == fallback_slug
 
     def test_create_animal_with_connection_pool(self):
@@ -259,10 +258,11 @@ class TestDatabaseServiceSlugIntegration:
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
 
-        # Mock existing animal data (slug should be preserved)
-        # Updated to include all 16 columns that the SELECT query expects
+        # Mock existing animal data (slug should be preserved).
+        # Must match the SELECT column list in DatabaseService.update_animal
+        # exactly; a short row raises inside the broad except and returns
+        # (None, "error") rather than failing visibly.
         mock_cursor.fetchone.side_effect = [
-            # First call - get current animal data (16 columns)
             (
                 "Old Name",  # name
                 "Old Breed",  # breed
@@ -280,6 +280,7 @@ class TestDatabaseServiceSlugIntegration:
                 None,  # secondary_breed
                 "old-breed-slug",  # breed_slug
                 0.95,  # breed_confidence
+                "Old Breed",  # breed_raw
             ),
             # No second call needed for updates
         ]
@@ -304,11 +305,8 @@ class TestDatabaseServiceSlugIntegration:
             )
 
             with patch("services.database_service.parse_age_text") as mock_parse_age:
-                # Create a mock object with min_months and max_months attributes
-                mock_age_info = MagicMock()
-                mock_age_info.min_months = 12
-                mock_age_info.max_months = 24
-                mock_parse_age.return_value = mock_age_info
+                # parse_age_text returns (age_category, min_months, max_months)
+                mock_parse_age.return_value = ("Young", 12, 24)
 
                 animal_id, action = db_service.update_animal(123, animal_data)
 

--- a/tests/services/test_database_service_slug_integration.py
+++ b/tests/services/test_database_service_slug_integration.py
@@ -11,10 +11,7 @@ from services.database_service import DatabaseService
 from tests.fixtures.sql_introspection import insert_column_value
 
 
-@pytest.mark.slow
 @pytest.mark.database
-@pytest.mark.integration
-@pytest.mark.slow
 class TestDatabaseServiceSlugIntegration:
     """Test slug generation integration in DatabaseService."""
 

--- a/tests/services/test_database_service_slug_two_phase.py
+++ b/tests/services/test_database_service_slug_two_phase.py
@@ -18,10 +18,7 @@ from services.database_service import DatabaseService
 from tests.fixtures.sql_introspection import insert_column_value
 
 
-@pytest.mark.slow
 @pytest.mark.database
-@pytest.mark.integration
-@pytest.mark.slow
 class TestDatabaseServiceTwoPhaseSlugGeneration:
     """Test two-phase slug generation: INSERT with temp slug, UPDATE with final slug containing ID."""
 

--- a/tests/services/test_database_service_slug_two_phase.py
+++ b/tests/services/test_database_service_slug_two_phase.py
@@ -15,6 +15,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from services.database_service import DatabaseService
+from tests.fixtures.sql_introspection import insert_column_value
 
 
 @pytest.mark.slow
@@ -78,14 +79,12 @@ class TestDatabaseServiceTwoPhaseSlugGeneration:
 
         # Verify INSERT was called with temp slug
         insert_call = mock_cursor.execute.call_args_list[1]
-        insert_sql = insert_call[0][0]
-        insert_params = insert_call[0][1]
 
-        assert "INSERT INTO animals" in insert_sql
-        # The temp slug should be in the INSERT (position 19 based on current schema)
-        temp_slug = insert_params[19]  # slug parameter position
-        # "Labrador Mix" standardizes to "Labrador Mix" (capitalized input)
-        assert temp_slug == "bella-labrador-mix-temp"
+        assert "INSERT INTO animals" in insert_call[0][0]
+        temp_slug = insert_column_value(insert_call, "slug")
+        # standardized_breed keeps the cross ("Labrador Mix" -> "Labrador
+        # Retriever Cross"); primary_breed is the bare grouping key.
+        assert temp_slug == "bella-labrador-retriever-cross-temp"
 
         # Verify UPDATE was called with final slug containing ID
         update_call = mock_cursor.execute.call_args_list[3]
@@ -93,7 +92,7 @@ class TestDatabaseServiceTwoPhaseSlugGeneration:
         update_params = update_call[0][1]
 
         assert "UPDATE animals SET slug" in update_sql
-        assert update_params[0] == "bella-labrador-mix-1234"  # final slug with ID
+        assert update_params[0] == "bella-labrador-retriever-cross-1234"  # final slug with ID
         assert update_params[1] == 1234  # WHERE id = animal_id
 
         # Verify transaction was committed

--- a/utils/unified_standardization.py
+++ b/utils/unified_standardization.py
@@ -572,7 +572,7 @@ class UnifiedStandardizer:
             "standardization_confidence": breed_result.get("confidence", 0.0),
             # Age fields - preserve original and add ranges
             "age": age,  # Preserve original age field
-            "age_text": age or "Unknown",  # Database expects age_text field
+            "age_text": age,  # Nullable end to end; an absent age stays absent
             "age_category": age_result.get("age_category"),
             "age_min_months": age_result.get("age_min_months"),
             "age_max_months": age_result.get("age_max_months"),


### PR DESCRIPTION
Replaces #347, which auto-closed when its stacked base branch was deleted on merge of #346. Same content, rebuilt on `main`.

## Why

Running the suite with no marker filter surfaces **seven failures**. All seven are excluded from PR CI by the `slow` marker, and the only workflow that would run them — `pre-merge.yml` — has not fired since **25 Jan 2026**.

Six were stale tests. One was a live production bug.

## The production bug: fabricated ages

`UnifiedStandardizer` wrote `age or "Unknown"` into `age_text`. Nothing required that placeholder — the column is nullable, `api.models.dog` types it `str | None`, and the frontend Zod schema marks it optional.

```sql
SELECT COUNT(*) FROM animals WHERE active AND age_text = 'Unknown';
-- 153, across 4 organizations, every one with age_min_months IS NULL
```

For those 153 dogs the literal string `"Unknown"` is the only age signal reaching the page. Same class as #334, which stopped an unknown size defaulting to `Medium`.

> [!IMPORTANT]
> **The 153 existing rows will not self-correct.** `skip_existing_animals` means a stored row never reaches `process_animal` again. A backfill follows in a separate PR, modelled on #338's `breed_restandardize`.

## The six stale tests

| Failure | Cause |
|---|---|
| 3 × slug assertions | Indexed the INSERT parameter tuple **by position**. Adding `breed_raw` upstream shifted every later index, so they compared against `properties` and failed with a bare `None`. |
| `test_update_animal_preserves_existing_slug` | Mock returned a 16-value row against a 17-column SELECT, and mocked `parse_age_text` as an object when it returns a tuple. Both swallowed by a broad `except`. |
| 2 × slug expectations | Predated the breed registry. `"Labrador Mix"` standardizes to `"Labrador Retriever Cross"` now — verified intended against the standardizer. |
| `test_breeds_contains_known_value` | conftest seed had no `primary_breed`/`breed_type`/`breed_slug`, so `/api/animals/meta/breeds` returned `[]` against 12 seeded dogs. |

### On the positional assertions

New helper `tests/fixtures/sql_introspection.py` looks columns up **by name**. Position-indexing is what let this rot silently: the assertion keeps passing against whatever value slid into the slot, or fails with a `None` that names nothing. The helper raises with the actual column list instead.

### On the quarantine marker

```python
@pytest.mark.slow  # Fails in CI due to database setup differences
def test_breeds_contains_known_value(self, client):
```

That was quarantine, not a speed claim. The fixture is fixed and the marker is gone.

### On the fixture seed

Values are shaped like production — `Mixed Breed` is the most common `primary_breed` there at 548 dogs — and honour the invariant that `primary_breed` never carries a Mix or Cross suffix.

### On the resilience tests

They asserted `animal_id is not None` against a scraper built with no `DatabaseService`, so `save_animal` warned and returned `None`. They now inject the service `utils/secure_scraper_loader.py:171` injects in production, and assert what actually reaches the database.

## Result

**2213 passed, 0 failed, 38s** — the whole suite, every marker, no exclusions. First time green since January.

## Latent issue, not fixed here

`BaseScraper` has nine `_log_service_unavailable` sites that degrade to a warning and a `None` return. Production always injects via the loader, so none is live, but a misconfigured scraper would persist nothing while appearing to run. Worth a separate decision about failing loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDVRkA4nvfVFaoYvmR1M4k