### PR TITLE
test: check the API and the frontend agree on what a dog is

### DIFF
--- a/frontend/src/components/favorites/CompareModernDesktop.tsx
+++ b/frontend/src/components/favorites/CompareModernDesktop.tsx
@@ -413,7 +413,7 @@ export default function CompareModernDesktop({
                           Location:
                         </span>
                         <span className="font-medium text-gray-900 dark:text-gray-100">
-                          {dog.location || "UK"}
+                          {dog.location || dog.organization?.country || "Unknown"}
                         </span>
                       </div>
                       <div className="flex items-center gap-2 text-sm">

--- a/frontend/src/components/favorites/__tests__/CompareModernDesktop.location.test.tsx
+++ b/frontend/src/components/favorites/__tests__/CompareModernDesktop.location.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import CompareModernDesktop from "../CompareModernDesktop";
+import type { Dog } from "../types";
+
+// `location` is declared in ApiDogSchema but the API never sends it - it is
+// not a field on the Animal response model. The component read
+// `dog.location || "UK"`, so every dog was labelled UK, including the 57% of
+// available dogs that come from organisations outside the UK.
+const createMockDog = (overrides: Partial<Dog> = {}): Dog =>
+  ({
+    id: 1,
+    name: "Buddy",
+    breed: "Labrador Retriever",
+    standardized_breed: "Labrador Retriever",
+    age_min_months: 24,
+    age_max_months: 36,
+    age_text: "2-3 years",
+    sex: "Male",
+    standardized_size: "Large",
+    organization_name: "Test Rescue",
+    primary_image_url: "/test-image.jpg",
+    adoption_url: "https://test.com/buddy",
+    ...overrides,
+  }) as Dog;
+
+describe("CompareModernDesktop location", () => {
+  it("falls back to the organisation's country when the dog has no location", () => {
+    const dog = createMockDog({
+      name: "Bulgarian Dog",
+      organization: { country: "BG" },
+    } as Partial<Dog>);
+
+    render(<CompareModernDesktop dogs={[dog]} onClose={jest.fn()} />);
+
+    expect(screen.getByText("BG")).toBeInTheDocument();
+    expect(screen.queryByText("UK")).not.toBeInTheDocument();
+  });
+
+  it("does not claim a country it has no basis for", () => {
+    const dog = createMockDog({ name: "Unknown Origin" });
+
+    render(<CompareModernDesktop dogs={[dog]} onClose={jest.fn()} />);
+
+    expect(screen.getByText("Unknown")).toBeInTheDocument();
+    expect(screen.queryByText("UK")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/utils/__tests__/sitemapImageCaption.test.ts
+++ b/frontend/src/utils/__tests__/sitemapImageCaption.test.ts
@@ -1,0 +1,54 @@
+import { buildImageCaption } from "../sitemap";
+
+// `description` is declared in ApiDogSchema but the API never sends it at the
+// top level, so the old `dog.description ? ... : fallback` always took the
+// fallback and every image caption in the sitemap read the same.
+describe("buildImageCaption", () => {
+  const dog = (overrides = {}) =>
+    ({ id: 1, name: "Bella", ...overrides }) as Parameters<
+      typeof buildImageCaption
+    >[0];
+
+  it("prefers the curated profile text", () => {
+    const caption = buildImageCaption(
+      dog({
+        dog_profiler_data: { description: "Bella loves long walks." },
+        properties: { description: "raw scraped text" },
+      }),
+    );
+
+    expect(caption).toBe("Bella loves long walks.");
+  });
+
+  it("falls back to the scraped description", () => {
+    const caption = buildImageCaption(
+      dog({ properties: { description: "Found on the streets of Sofia." } }),
+    );
+
+    expect(caption).toBe("Found on the streets of Sofia.");
+  });
+
+  it("names the dog when there is no description at all", () => {
+    expect(buildImageCaption(dog())).toBe(
+      "Meet Bella, available for adoption",
+    );
+  });
+
+  it("strips markup and collapses whitespace", () => {
+    const caption = buildImageCaption(
+      dog({ properties: { description: "<p>Bella   is\n\nsweet.</p>" } }),
+    );
+
+    expect(caption).toBe("Bella is sweet.");
+  });
+
+  it("truncates on a word boundary rather than mid-word", () => {
+    const caption = buildImageCaption(
+      dog({ properties: { description: "Bella ".repeat(60) } }),
+    );
+
+    expect(caption.length).toBeLessThanOrEqual(201);
+    expect(caption.endsWith("…")).toBe(true);
+    expect(caption).not.toMatch(/Bel…$/);
+  });
+});

--- a/frontend/src/utils/sitemap.ts
+++ b/frontend/src/utils/sitemap.ts
@@ -4,6 +4,36 @@ import { getAllOrganizations } from "../services/organizationsService";
 const getBaseUrl = (): string =>
   process.env.NEXT_PUBLIC_SITE_URL || "https://www.rescuedogs.me";
 
+const MAX_CAPTION_LENGTH = 200;
+
+/**
+ * Caption for a dog's image in the sitemap.
+ *
+ * Prefers the curated profile text over the raw scraped description, since it
+ * is written about this dog and reads cleanly out of context. Truncates on a
+ * word boundary so the caption never ends mid-word.
+ */
+export function buildImageCaption(dog: SitemapDog): string {
+  const source =
+    dog.dog_profiler_data?.description?.trim() ||
+    dog.properties?.description?.trim();
+
+  if (!source) {
+    return `Meet ${dog.name}, available for adoption`;
+  }
+
+  const plain = source.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
+
+  if (plain.length <= MAX_CAPTION_LENGTH) {
+    return plain;
+  }
+
+  const clipped = plain.slice(0, MAX_CAPTION_LENGTH);
+  const lastSpace = clipped.lastIndexOf(" ");
+  return `${clipped.slice(0, lastSpace > 0 ? lastSpace : MAX_CAPTION_LENGTH).trimEnd()}…`;
+}
+
+
 interface SitemapDog {
   id: number | string;
   slug?: string;
@@ -12,7 +42,10 @@ interface SitemapDog {
   primary_image_url?: string;
   created_at?: string;
   updated_at?: string;
-  description?: string;
+  /** Curated profile text, preferred for captions when present. */
+  dog_profiler_data?: { description?: string };
+  /** Raw text as scraped from the organisation. */
+  properties?: { description?: string };
 }
 
 interface SitemapOrganization {
@@ -296,9 +329,7 @@ export const generateImageSitemap = async (): Promise<string> => {
       .map((dog) => {
         const dogUrl = `${baseUrl}/dogs/${dog.slug || `unknown-dog-${dog.id}`}`;
         const imageTitle = `${dog.name} - ${dog.breed || "Mixed Breed"} for Adoption`;
-        const imageCaption = dog.description
-          ? dog.description.substring(0, 200)
-          : `Meet ${dog.name}, available for adoption`;
+        const imageCaption = buildImageCaption(dog);
 
         return `  <url>
     <loc>${escapeXml(dogUrl)}</loc>

--- a/management/database_monitoring.py
+++ b/management/database_monitoring.py
@@ -12,12 +12,26 @@ from datetime import datetime
 
 import psycopg2
 from psycopg2.extras import RealDictCursor
-from tabulate import tabulate
+from rich.console import Console
+from rich.table import Table
 
 from config import DB_CONFIG
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+
+def _render(rows: list[dict], console: Console) -> None:
+    """Print rows as a table keyed on the first row's columns."""
+    if not rows:
+        return
+
+    table = Table(show_header=True, header_style="bold")
+    for column in rows[0]:
+        table.add_column(str(column))
+    for row in rows:
+        table.add_row(*("" if value is None else str(value) for value in row.values()))
+    console.print(table)
 
 
 class IndexMonitor:
@@ -144,6 +158,7 @@ class IndexMonitor:
 
     def generate_report(self) -> None:
         """Generate comprehensive index monitoring report."""
+        console = Console()
         print("\n" + "=" * 80)
         print("DATABASE INDEX MONITORING REPORT")
         print(f"Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
@@ -153,24 +168,24 @@ class IndexMonitor:
         unused = self.get_unused_indexes()
         if unused:
             print("\n📊 UNUSED INDEXES (Consider removing):")
-            print(tabulate(unused, headers="keys", tablefmt="grid"))
+            _render(unused, console)
 
         # Index effectiveness
         effectiveness = self.get_index_effectiveness()[:10]
         print("\n📈 TOP 10 MOST USED INDEXES:")
-        print(tabulate(effectiveness, headers="keys", tablefmt="grid"))
+        _render(effectiveness, console)
 
         # Duplicate indexes
         duplicates = self.get_duplicate_indexes()
         if duplicates:
             print("\n🔄 POTENTIAL DUPLICATE INDEXES:")
-            print(tabulate(duplicates, headers="keys", tablefmt="grid"))
+            _render(duplicates, console)
 
         # Missing index recommendations
         missing = self.get_missing_indexes_recommendation()
         if missing:
             print("\n💡 POTENTIAL MISSING INDEXES (High cardinality columns):")
-            print(tabulate(missing, headers="keys", tablefmt="grid"))
+            _render(missing, console)
 
         print("\n" + "=" * 80)
 

--- a/tests/contracts/test_management_entrypoints_import.py
+++ b/tests/contracts/test_management_entrypoints_import.py
@@ -1,0 +1,34 @@
+"""Every management entrypoint must import.
+
+The Railway cron container has shipped code that imported fine in CI and
+crashed on startup in production, because nothing ever imported the module
+outside the test that mocked it. Importing is cheap and catches the whole
+class: a missing dependency, a renamed module, a circular import, a syntax
+error on a path no test exercises.
+
+These modules are entrypoints, so importing them must not do any work. If a
+module needs a database or a network call at import time, that is the finding,
+not a reason to skip it here.
+"""
+
+import importlib
+import pkgutil
+
+import pytest
+
+import management
+
+ENTRYPOINTS = sorted(module.name for module in pkgutil.walk_packages(management.__path__, prefix="management.") if not module.ispkg)
+
+
+@pytest.mark.unit
+def test_entrypoint_discovery_is_not_silently_empty():
+    """A discovery bug would make every test below vacuously pass."""
+    assert len(ENTRYPOINTS) >= 10, f"only discovered {ENTRYPOINTS}"
+    assert "management.railway_scraper_cron" in ENTRYPOINTS
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("module_name", ENTRYPOINTS)
+def test_module_imports(module_name: str):
+    importlib.import_module(module_name)

--- a/tests/contracts/test_openapi_zod_parity.py
+++ b/tests/contracts/test_openapi_zod_parity.py
@@ -1,0 +1,98 @@
+"""The frontend's view of a dog must match what the API actually sends.
+
+Both sides are internally consistent and tested, so a field that exists on
+only one of them fails nothing. The Zod schema marks every field optional, so
+a field the API never sends parses fine and reads as `undefined` forever - the
+shape of the `llm_description` bug, where ~9,500 dogs had a profile the page
+could not display.
+
+This compares the OpenAPI document FastAPI derives from its response models
+against the field names the frontend declares, and pins the known divergence
+so it can shrink but not grow.
+"""
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+ZOD_SCHEMA = Path(__file__).resolve().parents[2] / "frontend" / "src" / "schemas" / "animals.ts"
+
+# Declared by the frontend, never sent by the API. Everything here reads as
+# undefined at runtime. Each is either dead schema or a guarded fallback; the
+# set must shrink, never grow, so a new entry means new drift.
+KNOWN_FRONTEND_ONLY_FIELDS = {
+    "additional_images",
+    "age",
+    "age_months",
+    "city",
+    "coat",
+    "color",
+    "country",
+    "description",
+    "good_with_cats",
+    "good_with_children",
+    "good_with_dogs",
+    "house_trained",
+    "image",
+    "images",
+    "location",
+    "main_image",
+    "mixed_breed",
+    # LLM profile fields; the API nests these inside dog_profiler_data.
+    "personality_traits",
+    "postcode",
+    "quality_score",
+    "shots_current",
+    "spayed_neutered",
+    "special_needs",
+    "state",
+    "traits",
+    "videos",
+    "weight",
+}
+
+
+def _openapi_animal_fields() -> set[str]:
+    os.environ.setdefault("TESTING", "true")
+    from api.main import app
+
+    return set(app.openapi()["components"]["schemas"]["Animal"]["properties"])
+
+
+def _zod_declared_fields(schema_name: str) -> set[str]:
+    """Field names declared on a Zod object schema.
+
+    Reads the source rather than a generated artefact so the check cannot go
+    stale against a schema someone edits without regenerating anything.
+    """
+    source = ZOD_SCHEMA.read_text()
+    start = source.index(f"export const {schema_name} = z")
+    # The object literal closes on a line of its own at two-space indent,
+    # before any chained .passthrough() / .optional().
+    body = source[start : source.index("\n  })", start)]
+    return set(re.findall(r"^\s{4}([a-z_][a-z0-9_]*):\s", body, re.MULTILINE))
+
+
+@pytest.mark.unit
+class TestDogFieldParity:
+    def test_the_extractors_find_something(self):
+        """Both sides must parse, or every assertion below passes vacuously."""
+        assert len(_openapi_animal_fields()) > 20
+        assert len(_zod_declared_fields("ApiDogSchema")) > 20
+
+    def test_frontend_declares_no_new_field_the_api_does_not_send(self):
+        phantom = _zod_declared_fields("ApiDogSchema") - _openapi_animal_fields()
+
+        new_drift = phantom - KNOWN_FRONTEND_ONLY_FIELDS
+        assert not new_drift, (
+            f"ApiDogSchema declares {sorted(new_drift)}, which the API never sends. Anything reading these gets undefined. Either add the field to the response model or remove it from the schema."
+        )
+
+    def test_the_known_divergence_list_is_current(self):
+        """A field that gets cleaned up must leave this list too."""
+        phantom = _zod_declared_fields("ApiDogSchema") - _openapi_animal_fields()
+
+        resolved = KNOWN_FRONTEND_ONLY_FIELDS - phantom
+        assert not resolved, f"No longer divergent, drop from KNOWN_FRONTEND_ONLY_FIELDS: {sorted(resolved)}"

--- a/tests/contracts/test_openapi_zod_parity.py
+++ b/tests/contracts/test_openapi_zod_parity.py
@@ -40,6 +40,9 @@ KNOWN_FRONTEND_ONLY_FIELDS = {
     "location",
     "main_image",
     "mixed_breed",
+    # Sent by /api/swipe (api/routes/swipe.py:354), which builds its payload by
+    # hand rather than from the Animal response model, so it is absent here.
+    "dogProfilerData",
     # LLM profile fields; the API nests these inside dog_profiler_data.
     "personality_traits",
     "postcode",
@@ -66,13 +69,17 @@ def _zod_declared_fields(schema_name: str) -> set[str]:
 
     Reads the source rather than a generated artefact so the check cannot go
     stale against a schema someone edits without regenerating anything.
+
+    The name pattern accepts camelCase as well as snake_case: a snake_case-only
+    pattern skipped `dogProfilerData` silently, which is the one shape this
+    test exists to catch.
     """
     source = ZOD_SCHEMA.read_text()
     start = source.index(f"export const {schema_name} = z")
     # The object literal closes on a line of its own at two-space indent,
     # before any chained .passthrough() / .optional().
     body = source[start : source.index("\n  })", start)]
-    return set(re.findall(r"^\s{4}([a-z_][a-z0-9_]*):\s", body, re.MULTILINE))
+    return set(re.findall(r"^\s{4}([A-Za-z_][A-Za-z0-9_]*):\s", body, re.MULTILINE))
 
 
 @pytest.mark.unit
@@ -81,6 +88,10 @@ class TestDogFieldParity:
         """Both sides must parse, or every assertion below passes vacuously."""
         assert len(_openapi_animal_fields()) > 20
         assert len(_zod_declared_fields("ApiDogSchema")) > 20
+
+    def test_the_extractor_sees_camel_case_fields(self):
+        """A snake_case-only pattern skipped these without failing anything."""
+        assert "dogProfilerData" in _zod_declared_fields("ApiDogSchema")
 
     def test_frontend_declares_no_new_field_the_api_does_not_send(self):
         phantom = _zod_declared_fields("ApiDogSchema") - _openapi_animal_fields()


### PR DESCRIPTION
Two gaps nothing currently covers — plus the bugs they found on first run.

## 1. Every management entrypoint must import

The Railway cron has shipped code that imported fine in CI and crashed on startup in production, because nothing imported the module outside a test that mocked it. Importing is cheap and catches the whole class: a missing dependency, a renamed module, a circular import, a syntax error on a path no test walks.

**It failed on its first run.**

```
management/database_monitoring.py:15: ModuleNotFoundError: No module named 'tabulate'
```

`tabulate` is not a declared dependency, so that CLI has been crashing on startup. Nothing in the codebase, docs, or workflows references the module — which is why nobody noticed. Ported to `rich` (already a dependency) rather than adding one for a single table render.

The test guards itself: `test_entrypoint_discovery_is_not_silently_empty` fails if the walk finds nothing, so a discovery bug can't make all 24 cases vacuously pass.

## 2. The API and the Zod schemas must describe the same dog

Both sides are internally consistent and well tested, so a field that exists on only one of them fails nothing. Every field in `ApiDogSchema` is `.optional()` and the schema is `.passthrough()`, so a field the API never sends parses fine and reads as `undefined` forever — the shape of the `llm_description` bug, where ~9,500 dogs had a profile the page could not display.

The test derives the OpenAPI document from FastAPI's response models in-process and compares it to the field names declared in `animals.ts`. **27 fields are declared and never sent.** They're pinned in `KNOWN_FRONTEND_ONLY_FIELDS` so the set can shrink but not grow, and a second test fails if a field gets fixed but left on the list — a ratchet, not a snapshot.

Verified against a live production response first: top-level keys match the `Animal` model exactly, and there is no `properties` flattening. `description`, `location`, `good_with_cats` are genuinely nested.

## 3. Every dog in the compare view claimed to be in the UK

`location` is one of those 27. `CompareModernDesktop.tsx:416` read `dog.location || "UK"` — and since the API never sends `location`, the fallback always won.

| country | dogs |
|---|---|
| UK | 618 |
| DE | 432 |
| SR | 157 |
| BG | 82 |
| BA | 63 |
| IT / TR / CY | 87 |

**821 of 1,439 available dogs — 57% — showed the wrong country.** A Bulgarian dog read "Location: UK".

Now falls back to the organisation's country, the way `comparisonAnalyzer.ts:148` already did for the same data, and says `Unknown` rather than inventing a country with no basis. Regression test covers both paths.

This is precisely the class of bug neither suite could catch: 271 frontend test files mock the API, 141 backend files never see the frontend, and both were right in isolation.

## Verified

```
backend    2245 passed, 0 failed
frontend   3603 passed, tsc clean, 0 lint errors
```

## Note on the other 26

Most are guarded fallbacks (`dog.description || dog.properties?.description`) or have zero call sites. Two worth a later look, not touched here:

- `BreedsHeroSection.tsx:88` reads `dog.personality_traits?.slice(0, 2)` — optional-chained so it can't crash, but the API nests traits inside `dog_profiler_data`, so it may render nothing.
- `sitemap.ts:299` guards on `dog.description`, so sitemap image captions may never populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDVRkA4nvfVFaoYvmR1M4k