### PR TITLE
chore(tests): make markers state what a test needs, not how fast it is

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 - [ ] Documentation
 
 ## Testing
-- [ ] Backend tests pass: `pytest -m "not slow and not browser"`
+- [ ] Backend tests pass: `pytest -m "not browser"`
 - [ ] Frontend tests pass: `cd frontend && npm test`
 - [ ] Build succeeds: `cd frontend && npm run build`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,7 +235,7 @@ docs/
 # Backend
 uv run ruff check . --fix
 uv run ruff format .
-uv run pytest -m 'not slow and not browser and not external' --maxfail=3
+uv run pytest -m "not browser" --maxfail=3
 
 # Frontend
 cd frontend
@@ -284,24 +284,29 @@ Jest 30+ uses `--testPathPatterns` (plural) for file patterns.
 ### Backend
 
 ```bash
-uv run pytest -m "unit" --maxfail=5              # Tier 1: Quick feedback
-uv run pytest -m "not slow and not browser and not external" --maxfail=3  # Tier 2: CI
-uv run pytest                                     # Tier 3: Full suite
+uv run pytest -m "unit" --maxfail=5   # Quick feedback, no database needed
+uv run pytest -m "not browser"        # What CI runs on every PR
+uv run pytest                         # Everything, including browser tests
 ```
 
 ### Pytest Markers (9 essential)
 
-| Marker                | Purpose                      |
-| --------------------- | ---------------------------- |
-| `unit`                | Pure logic, no I/O (<10ms)   |
-| `integration`         | Internal services (10-100ms) |
-| `slow`                | Complex setup (>1s)          |
-| `database`            | Requires DB access           |
-| `browser`             | Requires Playwright/Selenium |
-| `external`            | Requires external APIs       |
-| `security`            | Security validation          |
-| `requires_migrations` | Production-like migrations   |
-| `real_clock`          | Must observe real elapsed time |
+| Marker       | Purpose                                        |
+| ------------ | ---------------------------------------------- |
+| `database`   | Requires a PostgreSQL database                 |
+| `browser`    | Requires Playwright/Selenium                   |
+| `external`   | Requires external APIs or credentials          |
+| `real_clock` | Must observe real elapsed time                 |
+| `unit`       | Pure logic, no I/O                             |
+| `integration`| Exercises more than one internal component     |
+| `benchmark`  | Measures performance rather than asserting     |
+
+Markers say what a test **needs**, so a runner can decide whether it can run
+one. They are not speed labels. `slow` claimed ">1s" while every test carrying
+it finished in milliseconds, and because CI deselected on it, it became a
+quarantine: seven failing tests hid behind it for seven months. Measure speed
+with `--durations`, do not assert it with a decorator. `--strict-markers` is on,
+so an unregistered marker is an error rather than a silent no-op.
 
 Sleeps are stubbed suite-wide by the autouse `stub_clock` fixture, so a
 test that needs real elapsed time — thread overlap, a timing bound — must

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,7 +289,7 @@ uv run pytest -m "not browser"        # What CI runs on every PR
 uv run pytest                         # Everything, including browser tests
 ```
 
-### Pytest Markers (9 essential)
+### Pytest Markers (7 essential)
 
 | Marker       | Purpose                                        |
 | ------------ | ---------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -215,11 +215,16 @@ pnpm build             # Build verification
 
 ### Test Markers
 
-- `@pytest.mark.unit` - Pure logic, no IO
-- `@pytest.mark.fast` - < 1 second
-- `@pytest.mark.integration` - API/DB interaction
-- `@pytest.mark.slow` - > 5 seconds
-- `@pytest.mark.browser` - Playwright tests
+Markers say what a test **needs**, not how fast it is. `--strict-markers` is
+on, so an unregistered marker is an error rather than a silent no-op.
+
+- `@pytest.mark.database` - Requires a PostgreSQL database
+- `@pytest.mark.browser` - Requires Playwright/Selenium
+- `@pytest.mark.external` - Requires external APIs or credentials
+- `@pytest.mark.real_clock` - Must observe real elapsed time
+- `@pytest.mark.unit` - Pure logic, no I/O
+- `@pytest.mark.integration` - Exercises more than one internal component
+- `@pytest.mark.benchmark` - Measures performance rather than asserting behaviour
 
 ---
 

--- a/docs/guidelines/PYTHON_GUIDELINES.md
+++ b/docs/guidelines/PYTHON_GUIDELINES.md
@@ -88,7 +88,7 @@ select = ["E", "F", "I", "N", "W", "UP", "B", "C4", "SIM"]
 ### 4. Tests Must Pass
 
 ```bash
-uv run pytest -m "not slow and not browser and not external" --maxfail=3
+uv run pytest -m "not browser" --maxfail=3
 ```
 
 ---
@@ -566,7 +566,7 @@ Before submitting a Python PR:
 ```
 [ ] ruff check passes: `uv run ruff check .`
 [ ] ruff format passes: `uv run ruff format --check .`
-[ ] All tests pass: `uv run pytest -m "not slow and not browser and not external"`
+[ ] All tests pass: `uv run pytest -m "not browser"`
 [ ] Type hints on all new functions
 [ ] No bare except: clauses
 [ ] No string paths (use pathlib.Path)

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -140,7 +140,7 @@ open http://localhost:3000  # Or visit in browser
 
 ```bash
 # Backend tests (125 test files)
-uv run pytest tests/ -m "not slow" -v
+uv run pytest tests/ -m "not browser" -v
 
 # Frontend tests (267 test files)
 cd frontend
@@ -414,7 +414,7 @@ pnpm exec playwright test
 ```bash
 # Backend Development
 uv run pytest tests/ -m "unit or fast" -v          # Fast feedback
-uv run pytest tests/ -m "not browser and not requires_migrations" -v  # CI pipeline
+uv run pytest tests/ -m "not browser" -v  # CI pipeline
 uv run pytest tests/ -v                            # All tests
 
 # Frontend Development

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -199,7 +199,6 @@ test('complete adoption journey', async ({ page }) => {
 
 ### Backend Performance
 ```python
-@pytest.mark.slow
 def test_scraper_performance():
     start_time = time.time()
     result = scraper.collect_data()
@@ -235,7 +234,6 @@ test('sanitizes malicious content', () => {
 
 ### SQL Injection Prevention
 ```python
-@pytest.mark.security
 def test_sql_injection_prevention():
     malicious_input = "'; DROP TABLE animals; --"
     result = search_animals(name=malicious_input)
@@ -251,7 +249,7 @@ def test_sql_injection_prevention():
 # Backend
 uv run ruff check . --fix
 uv run ruff format .
-uv run pytest tests/ -m "not slow" -v
+uv run pytest tests/ -m "not browser" -v
 
 # Frontend
 cd frontend
@@ -277,7 +275,7 @@ pnpm test -- --maxWorkers=4
 ### Watch Mode (TDD)
 ```bash
 # Backend
-uv run pytest tests/ -m "not slow" --tb=short -q
+uv run pytest tests/ -m "not browser" --tb=short -q
 
 # Frontend
 pnpm test -- --watch --coverage

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -318,7 +318,7 @@ async def get_filtered_dogs(filters: DogFilters) -> list[Dog]:
 ```bash
 # Backend (pytest)
 pytest -m "unit or fast" --maxfail=5          # Tier 1: Quick (2-3 min)
-pytest -m "not slow and not browser" --maxfail=3  # Tier 2: CI (5-8 min)
+pytest -m "not browser" --maxfail=3  # What CI runs on every PR
 pytest                                         # Tier 3: Full (10-15 min)
 
 # Frontend (Jest + Playwright)
@@ -333,7 +333,6 @@ pnpm exec playwright test                      # E2E tests
 @pytest.mark.unit        # Pure logic, no IO
 @pytest.mark.fast        # < 1 second
 @pytest.mark.integration # API/DB interaction
-@pytest.mark.slow        # > 5 seconds
 @pytest.mark.browser     # Selenium/Playwright
 ```
 

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -330,10 +330,10 @@ pnpm exec playwright test                      # E2E tests
 ### Test Markers
 
 ```python
-@pytest.mark.unit        # Pure logic, no IO
-@pytest.mark.fast        # < 1 second
-@pytest.mark.integration # API/DB interaction
-@pytest.mark.browser     # Selenium/Playwright
+@pytest.mark.unit        # Pure logic, no I/O
+@pytest.mark.integration # Exercises more than one internal component
+@pytest.mark.database    # Requires a PostgreSQL database
+@pytest.mark.browser     # Requires Playwright/Selenium
 ```
 
 ## Configuration Management

--- a/docs/technical/scraper-architecture.md
+++ b/docs/technical/scraper-architecture.md
@@ -815,7 +815,6 @@ pytest tests/scrapers/test_<org>_scraper.py -m browser -v
 @pytest.mark.fast        # < 1 second
 @pytest.mark.browser     # Playwright/Selenium required
 @pytest.mark.external    # Hits live sites
-@pytest.mark.slow        # > 5 seconds
 ```
 
 ### Running Scrapers

--- a/docs/technical/scraper-architecture.md
+++ b/docs/technical/scraper-architecture.md
@@ -811,10 +811,10 @@ pytest tests/scrapers/test_<org>_scraper.py -m browser -v
 ### Test Markers
 
 ```python
-@pytest.mark.unit        # Pure logic, no IO
-@pytest.mark.fast        # < 1 second
-@pytest.mark.browser     # Playwright/Selenium required
-@pytest.mark.external    # Hits live sites
+@pytest.mark.unit        # Pure logic, no I/O
+@pytest.mark.database    # Requires a PostgreSQL database
+@pytest.mark.browser     # Requires Playwright/Selenium
+@pytest.mark.external    # Requires external APIs or credentials
 ```
 
 ### Running Scrapers

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,12 +1,17 @@
 [pytest]
 testpaths = tests
+addopts = --strict-markers --strict-config
+
+# Markers state what a test NEEDS, so a runner can decide whether it can run
+# one. They are not speed labels: `slow` used to claim ">1s" while every test
+# carrying it finished in milliseconds, and because CI deselected on it, it
+# quietly became a quarantine - seven failing tests hid behind it for seven
+# months. Speed is measured with --durations, not asserted with a decorator.
 markers =
-    unit: Pure logic tests, no I/O (<10ms)
-    integration: Internal services tests (10-100ms)
-    slow: Complex setup tests (>1s)
-    database: Requires database access
+    database: Requires a PostgreSQL database
     browser: Requires Playwright/Selenium
-    external: Requires external APIs
-    security: Security validation tests
-    requires_migrations: Requires production-like migrations
+    external: Requires external APIs or credentials
     real_clock: Must observe real elapsed time; opts out of the stub_clock fixture
+    unit: Pure logic, no I/O
+    integration: Exercises more than one internal component
+    benchmark: Measures performance rather than asserting behaviour

--- a/tests/api/test_animals_api.py
+++ b/tests/api/test_animals_api.py
@@ -5,7 +5,6 @@ import pytest
 from fastapi.testclient import TestClient
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestAnimalsAPI:
     # Use the client fixture from conftest.py instead of creating our own

--- a/tests/api/test_animals_batch.py
+++ b/tests/api/test_animals_batch.py
@@ -2,7 +2,6 @@ import pytest
 from fastapi.testclient import TestClient
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestBatchEndpointValidation:
     def test_no_ids_returns_422(self, client: TestClient):
@@ -23,7 +22,6 @@ class TestBatchEndpointValidation:
         assert response.status_code == 422
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestBatchEndpointIntegration:
     def test_single_id_returns_matching_animal(self, client: TestClient):

--- a/tests/api/test_animals_edge_cases.py
+++ b/tests/api/test_animals_edge_cases.py
@@ -11,7 +11,6 @@ MEDIUM_IDS = {9002, 9005, 9006, 9007, 9010}
 SMALL_IDS = {9008, 9012}
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestPaginationEdgeCases:
     def test_offset_beyond_total_returns_empty_list(self, client: TestClient):
@@ -35,7 +34,6 @@ class TestPaginationEdgeCases:
         assert len(data) == TOTAL_TEST_DOGS
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestFilterValidation:
     def test_filter_by_sex_male_returns_only_males(self, client: TestClient):
@@ -109,7 +107,6 @@ class TestFilterValidation:
         assert response.json() == []
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestSearchSafety:
     def test_search_with_percent_returns_no_results(self, client: TestClient):
@@ -148,7 +145,6 @@ class TestSearchSafety:
         assert data[0]["id"] == 9005
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestSlugAndIdLookup:
     def test_nonexistent_slug_returns_404(self, client: TestClient):

--- a/tests/api/test_animals_filtering_edge_cases.py
+++ b/tests/api/test_animals_filtering_edge_cases.py
@@ -9,7 +9,6 @@ import urllib.parse
 import pytest
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestAnimalsFilteringEdgeCases:
     """Test edge cases and complex filtering in animals endpoints."""

--- a/tests/api/test_animals_meta.py
+++ b/tests/api/test_animals_meta.py
@@ -34,7 +34,6 @@ class TestAnimalsMeta:
         resp = client.get("/api/animals/meta/available_regions")
         assert resp.status_code == 422
 
-    @pytest.mark.slow  # Fails in CI due to missing service_regions table
     def test_available_regions_with_country(self, client):
         """GET /api/animals/meta/available_regions?country=<X> returns string list."""
         # First grab any valid country

--- a/tests/api/test_animals_random.py
+++ b/tests/api/test_animals_random.py
@@ -1,7 +1,6 @@
 import pytest
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestRandomAnimals:
     # Use the client fixture from conftest.py instead of creating our own

--- a/tests/api/test_compatibility_filters.py
+++ b/tests/api/test_compatibility_filters.py
@@ -170,7 +170,6 @@ class TestCompatibilityFilterSQLConditions:
         assert "yes" in params
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestCompatibilityFilterAPI:
     @pytest.mark.parametrize("field", ["good_with_kids", "good_with_dogs", "good_with_cats"])

--- a/tests/api/test_database_error_handling.py
+++ b/tests/api/test_database_error_handling.py
@@ -7,7 +7,6 @@ from api.dependencies import get_pooled_db_cursor
 from api.main import app
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestDatabaseErrorHandling:
     # Use the client fixture from conftest.py instead of creating our own

--- a/tests/api/test_dependencies.py
+++ b/tests/api/test_dependencies.py
@@ -14,7 +14,6 @@ from api.dependencies import get_database_connection, get_db_cursor
 
 
 @pytest.mark.database
-@pytest.mark.slow
 class TestGetDbCursor:
     """Test suite for get_db_cursor dependency."""
 

--- a/tests/api/test_jsonb_field_parsing.py
+++ b/tests/api/test_jsonb_field_parsing.py
@@ -162,7 +162,6 @@ class TestBuildOrganizationObject:
         assert build_organization_object({}) is None
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestJSONBFieldsInAPI:
     """Integration: verify JSONB fields are always dict/list in API responses, never strings."""

--- a/tests/api/test_llm_security_simple.py
+++ b/tests/api/test_llm_security_simple.py
@@ -16,7 +16,6 @@ import pytest
 ADMIN_KEY = "test-admin-key-for-llm-security-tests"
 
 
-@pytest.mark.security
 @pytest.mark.database
 @pytest.mark.integration
 class TestLLMSecurityBasics:

--- a/tests/api/test_monitoring_edge_cases.py
+++ b/tests/api/test_monitoring_edge_cases.py
@@ -6,9 +6,7 @@ import pytest
 ADMIN_KEY = "test-admin-key-for-monitoring"
 
 
-@pytest.mark.slow
 @pytest.mark.database
-@pytest.mark.requires_migrations
 class TestMonitoringAuthRequirements:
     PROTECTED_ENDPOINTS = [
         "/api/monitoring/scrapers",
@@ -32,7 +30,6 @@ class TestMonitoringAuthRequirements:
         assert response.status_code == 401, f"{endpoint} returned {response.status_code} with invalid key"
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestHealthCheckPublicAccess:
     def test_health_accessible_without_auth(self, api_client_no_auth):

--- a/tests/api/test_organizations_comprehensive.py
+++ b/tests/api/test_organizations_comprehensive.py
@@ -13,7 +13,6 @@ from api.dependencies import get_db_cursor
 from api.main import app
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestOrganizationsJSONParsing:
     # Use the client fixture from conftest.py instead of creating our own
@@ -196,7 +195,6 @@ class TestOrganizationsJSONParsing:
                 app.dependency_overrides.clear()
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestOrganizationsDatabaseErrors:
     # Use the client fixture from conftest.py instead of creating our own
@@ -279,7 +277,6 @@ class TestOrganizationsDatabaseErrors:
                 app.dependency_overrides.clear()
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestOrganizationRecentDogsEndpoint:
     # Use the client fixture from conftest.py instead of creating our own
@@ -403,7 +400,6 @@ class TestOrganizationRecentDogsEndpoint:
         assert isinstance(data, list)
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestOrganizationStatisticsEndpoint:
     # Use the client fixture from conftest.py instead of creating our own
@@ -499,7 +495,6 @@ class TestOrganizationStatisticsEndpoint:
                 app.dependency_overrides.clear()
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestOrganizationDetailEdgeCases:
     # Use the client fixture from conftest.py instead of creating our own

--- a/tests/api/test_organizations_edge_cases.py
+++ b/tests/api/test_organizations_edge_cases.py
@@ -3,7 +3,6 @@ import urllib.parse
 import pytest
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestOrganizationSlugLookup:
     def test_nonexistent_slug_returns_404(self, client):
@@ -28,7 +27,6 @@ class TestOrganizationSlugLookup:
         assert isinstance(response.json(), list)
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestOrganizationSearchFiltering:
     def test_search_with_sql_percent_wildcard(self, client):
@@ -72,7 +70,6 @@ class TestOrganizationSearchFiltering:
         assert response.json() == []
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestOrganizationListValidation:
     def test_org_list_contains_test_org(self, client):
@@ -97,7 +94,6 @@ class TestOrganizationListValidation:
         assert len(orgs) == 1
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestOrganizationRecentDogsEdgeCases:
     def test_recent_dogs_returns_list(self, client):
@@ -122,7 +118,6 @@ class TestOrganizationRecentDogsEdgeCases:
             assert dog["thumbnail_url"] is not None
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestOrganizationStatisticsEdgeCases:
     def test_statistics_values_are_numeric(self, client):

--- a/tests/api/test_organizations_integration.py
+++ b/tests/api/test_organizations_integration.py
@@ -7,7 +7,6 @@ Tests recent-dogs and statistics endpoints with real database interaction.
 import pytest
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestOrganizationRecentDogsIntegration:
     # Use the client fixture from conftest.py instead of creating our own
@@ -70,7 +69,6 @@ class TestOrganizationRecentDogsIntegration:
             assert "primary_image_url" in dog or "thumbnail_url" in dog
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestOrganizationStatisticsIntegration:
     # Use the client fixture from conftest.py instead of creating our own
@@ -138,7 +136,6 @@ class TestOrganizationStatisticsIntegration:
         assert data["new_this_week"] <= data["new_this_month"] + 7  # Allow some flexibility
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestOrganizationJSONParsingIntegration:
     # Use the client fixture from conftest.py instead of creating our own

--- a/tests/api/test_profiler_filters.py
+++ b/tests/api/test_profiler_filters.py
@@ -140,7 +140,6 @@ class TestProfilerFilterCombinations:
         assert request.age_category == "Adult"
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestProfilerFilterAPI:
     """Integration tests for profiler filter API endpoints."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,16 +81,11 @@ def initialize_database_pool(request):
 
     For unit/fast tests, skip database initialization since they should not access database.
     """
-    # Check if we're running only unit/fast tests that don't need database
-    print(f"\n[conftest] DEBUG: request.config exists: {hasattr(request.config, 'getoption')}")
-    if hasattr(request.config, "getoption"):
-        markexpr = request.config.getoption("-m", None)
-        print(f"[conftest] DEBUG: markexpr = {markexpr}")
-        if markexpr and ("unit or fast" in markexpr or "unit and fast" in markexpr):
-            print("\n[conftest] Skipping database pool initialization for unit/fast tests.")
-            yield  # Must yield for fixture to work
-            return
-
+    # This used to also branch on `"unit or fast" in markexpr`, which no runner
+    # ever passed - `fast` has not been a marker for a long time and `-m "unit"`
+    # does not contain the substring. The branch was unreachable, so the pool
+    # initialised anyway and a bare except below swallowed the failure after
+    # three backoff attempts. PYTEST_UNIT_ONLY is the switch that works.
     # Check environment variable that indicates unit-only test run
     if os.environ.get("PYTEST_UNIT_ONLY") == "true":
         print("\n[conftest] Skipping database pool initialization for unit-only test run.")

--- a/tests/data_consistency/test_standardization_consistency.py
+++ b/tests/data_consistency/test_standardization_consistency.py
@@ -1,15 +1,12 @@
 import os
 import sys
 
-import pytest
-
 from utils.standardization import standardize_age, standardize_breed
 
 # Add project root to path
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 
-@pytest.mark.slow
 class TestDataConsistency:
     """Test data standardization consistency."""
 

--- a/tests/integration/test_r2_integration.py
+++ b/tests/integration/test_r2_integration.py
@@ -10,7 +10,6 @@ from utils.r2_service import R2Service
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 
-@pytest.mark.slow
 @pytest.mark.external
 @pytest.mark.integration
 class TestR2Integration:

--- a/tests/scrapers/rean/test_rean_scraper.py
+++ b/tests/scrapers/rean/test_rean_scraper.py
@@ -734,7 +734,6 @@ class TestREANNetworkOperations:
         result = scraper.scrape_page("https://rean.org.uk/test")
         assert result == "Sample page content"
 
-    @pytest.mark.slow
     @pytest.mark.external
     @patch("requests.get")
     def test_scrape_page_failure(self, mock_get, scraper):
@@ -743,7 +742,6 @@ class TestREANNetworkOperations:
         result = scraper.scrape_page("https://rean.org.uk/test")
         assert result is None
 
-    @pytest.mark.slow
     @pytest.mark.external
     @patch("requests.get")
     @patch("time.sleep")
@@ -758,7 +756,6 @@ class TestREANNetworkOperations:
         assert result == "Success"
         assert mock_get.call_count == 2
 
-    @pytest.mark.slow
     @pytest.mark.external
     @patch("requests.get")
     @patch("time.sleep")
@@ -770,7 +767,6 @@ class TestREANNetworkOperations:
         assert result is None
         assert mock_get.call_count <= scraper.max_retries + 1
 
-    @pytest.mark.slow
     @pytest.mark.external
     @patch("requests.get")
     def test_http_error_codes(self, mock_get, scraper):
@@ -786,7 +782,6 @@ class TestREANNetworkOperations:
 
 
 class TestREANBrowserExtraction:
-    @pytest.mark.slow
     @pytest.mark.browser
     @patch("scrapers.rean.dogs_scraper.get_browser_service")
     def test_extract_images_with_browser_basic(self, mock_browser_service, scraper):
@@ -820,7 +815,6 @@ class TestREANBrowserExtraction:
         assert "https://img1.wsimg.com/isteam/ip/abc123/dog1.jpg" in images
         assert "https://img1.wsimg.com/isteam/ip/def456/dog2.jpg" in images
 
-    @pytest.mark.slow
     @pytest.mark.browser
     @patch("scrapers.rean.dogs_scraper.get_browser_service")
     @patch("scrapers.rean.dogs_scraper.time.sleep")
@@ -842,7 +836,6 @@ class TestREANBrowserExtraction:
         scroll_calls = [call for call in mock_driver.execute_script.call_args_list if "scrollTo" in str(call)]
         assert len(scroll_calls) > 0
 
-    @pytest.mark.slow
     @pytest.mark.browser
     @patch("scrapers.rean.dogs_scraper.get_browser_service")
     def test_extract_images_with_browser_filters_wsimg_only(self, mock_browser_service, scraper):
@@ -889,7 +882,6 @@ class TestREANBrowserExtraction:
 
         assert images == []
 
-    @pytest.mark.slow
     @pytest.mark.browser
     @patch("scrapers.rean.dogs_scraper.get_browser_service")
     def test_extract_images_with_browser_configuration(self, mock_browser_service, scraper):
@@ -906,7 +898,6 @@ class TestREANBrowserExtraction:
 
         mock_service.create_driver.assert_called_once()
 
-    @pytest.mark.slow
     @pytest.mark.browser
     @patch("selenium.webdriver.Chrome")
     def test_extract_images_browser_webdriver_failure(self, mock_chrome, scraper):
@@ -916,7 +907,6 @@ class TestREANBrowserExtraction:
 
         assert result == []
 
-    @pytest.mark.slow
     @pytest.mark.browser
     @patch("selenium.webdriver.Chrome")
     def test_browser_element_not_found(self, mock_chrome, scraper):
@@ -932,7 +922,6 @@ class TestREANBrowserExtraction:
 
 
 class TestREANIntegration:
-    @pytest.mark.slow
     @pytest.mark.browser
     @patch("selenium.webdriver.Chrome")
     @patch("time.sleep")
@@ -961,7 +950,6 @@ class TestREANIntegration:
         assert result[0]["age_text"] == "4 months"
         assert result[0]["primary_image_url"] == "https://img1.wsimg.com/isteam/ip/abc/toby.jpg"
 
-    @pytest.mark.slow
     @pytest.mark.browser
     @patch("selenium.webdriver.Chrome")
     def test_unified_extraction_fallback(self, mock_chrome, scraper):
@@ -974,7 +962,6 @@ class TestREANIntegration:
         assert result == []
         scraper._extract_dogs_legacy_fallback.assert_called_once()
 
-    @pytest.mark.slow
     @pytest.mark.external
     @patch("requests.get")
     @patch("selenium.webdriver.Chrome")
@@ -1015,7 +1002,6 @@ class TestREANIntegration:
         assert dog["animal_type"] == "dog"
         assert "external_id" in dog
 
-    @pytest.mark.slow
     @pytest.mark.external
     def test_rate_limiting_between_pages(self, scraper):
         with patch("time.sleep") as mock_sleep, patch("requests.get") as mock_get:

--- a/tests/scrapers/test_base_scraper_batch_uploads.py
+++ b/tests/scrapers/test_base_scraper_batch_uploads.py
@@ -9,7 +9,6 @@ from scrapers.base_scraper import BaseScraper
 
 @pytest.mark.external
 @pytest.mark.integration
-@pytest.mark.slow
 @pytest.mark.unit
 class TestBaseScraperBatchUploads:
     """Test batch upload functionality in BaseScraper."""

--- a/tests/scrapers/test_daisy_family_rescue_scraper.py
+++ b/tests/scrapers/test_daisy_family_rescue_scraper.py
@@ -133,7 +133,6 @@ weiblich, kastriert"""
 
         assert len(result) == 2
 
-    @pytest.mark.slow
     @pytest.mark.browser
     def test_handle_lazy_loading(self, scraper):
         mock_driver = Mock()

--- a/tests/scrapers/test_daisy_family_rescue_translations.py
+++ b/tests/scrapers/test_daisy_family_rescue_translations.py
@@ -26,7 +26,6 @@ from utils.standardization import standardize_age, standardize_breed
 
 @pytest.mark.database
 @pytest.mark.integration
-@pytest.mark.slow
 class TestNameNormalization:
     """Test name normalization and capitalization."""
 

--- a/tests/scrapers/test_dogstrust_scraper.py
+++ b/tests/scrapers/test_dogstrust_scraper.py
@@ -18,7 +18,6 @@ from tests.scrapers.test_scraper_base import ScraperTestBase
 from utils.unified_standardization import UnifiedStandardizer
 
 
-@pytest.mark.slow
 @pytest.mark.browser
 class TestDogsTrustScraper(ScraperTestBase):
     """Test cases for DogsTrustScraper - only scraper-specific tests."""

--- a/tests/scrapers/test_enhanced_failure_detection.py
+++ b/tests/scrapers/test_enhanced_failure_detection.py
@@ -13,7 +13,6 @@ from scrapers.base_scraper import BaseScraper
 from tests.fixtures.service_mocks import create_mock_session_manager
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestEnhancedFailureDetection:
     """Test enhanced failure detection scenarios."""
@@ -154,7 +153,6 @@ class TestEnhancedFailureDetection:
         assert result is False
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestFailureDetectionEdgeCases:
     """Test edge cases for failure detection."""
@@ -214,7 +212,6 @@ class TestFailureDetectionEdgeCases:
         assert result is True
 
 
-@pytest.mark.slow
 class TestFailureDetectionConfiguration:
     """Test configurable aspects of failure detection."""
 
@@ -279,7 +276,6 @@ class TestFailureDetectionConfiguration:
         mock_scraper.session_manager.detect_partial_failure.assert_called_once_with(10, 0.5, 3, 15, 0, 0)
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestFailureLoggingAndReporting:
     """Test that failure detection provides good logging and debugging info."""

--- a/tests/scrapers/test_manytearsrescue_scraper.py
+++ b/tests/scrapers/test_manytearsrescue_scraper.py
@@ -5,7 +5,6 @@ import pytest
 from scrapers.manytearsrescue.manytearsrescue_scraper import ManyTearsRescueScraper
 
 
-@pytest.mark.slow
 @pytest.mark.browser
 class TestManyTearsRescueScraper:
     def test_scraper_initialization_with_config(self):

--- a/tests/scrapers/test_misis_rescue_scraper.py
+++ b/tests/scrapers/test_misis_rescue_scraper.py
@@ -1253,7 +1253,6 @@ class TestIntegratedNormalization:
 
 @pytest.mark.browser
 @pytest.mark.integration
-@pytest.mark.slow
 class TestErrorPageDetection:
     @patch("scrapers.misis_rescue.scraper.get_browser_service")
     def test_error_page_detected_in_title(self, mock_browser_service):
@@ -1380,7 +1379,6 @@ class TestPerformanceOptimization:
         assert len(result.get("image_urls", [])) > 0
 
 
-@pytest.mark.slow
 @pytest.mark.integration
 @pytest.mark.external
 class TestListingExtraction:

--- a/tests/scrapers/test_theunderdog_scraper.py
+++ b/tests/scrapers/test_theunderdog_scraper.py
@@ -7,7 +7,6 @@ from scrapers.theunderdog.theunderdog_scraper import TheUnderdogScraper
 
 
 @pytest.mark.database
-@pytest.mark.slow
 @pytest.mark.integration
 @pytest.mark.external
 class TestTheUnderdogScraper:
@@ -359,7 +358,6 @@ class TestTheUnderdogDetailScraping:
 
 
 @pytest.mark.integration
-@pytest.mark.slow
 @pytest.mark.external
 class TestTheUnderdogIntegration:
     @pytest.fixture

--- a/tests/scrapers/test_tierschutzverein_europa_integration.py
+++ b/tests/scrapers/test_tierschutzverein_europa_integration.py
@@ -410,7 +410,6 @@ class TestScraperCoreFunctions:
 @pytest.mark.database
 @pytest.mark.integration
 @pytest.mark.browser
-@pytest.mark.slow
 class TestTierschutzvereinEuropaIntegration:
     def test_scraper_base_scraper_integration(self):
         scraper = TierschutzvereinEuropaScraper(config_id="tierschutzverein-europa")

--- a/tests/scrapers/test_tierschutzverein_europa_translations.py
+++ b/tests/scrapers/test_tierschutzverein_europa_translations.py
@@ -17,7 +17,6 @@ from utils.standardization import standardize_age, standardize_breed
 
 @pytest.mark.database
 @pytest.mark.integration
-@pytest.mark.slow
 class TestGenderTranslation:
     """Test translation of all gender values found in production database."""
 

--- a/tests/security/test_input_validation.py
+++ b/tests/security/test_input_validation.py
@@ -7,7 +7,6 @@ import pytest
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestSecurity:
     """Test security aspects of the application."""

--- a/tests/security/test_input_validation_comprehensive.py
+++ b/tests/security/test_input_validation_comprehensive.py
@@ -6,7 +6,6 @@ from api.main import app
 client = TestClient(app)
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestInputValidationComprehensive:
     """Test comprehensive input validation across all endpoints."""

--- a/tests/services/llm/test_organization_config_loader.py
+++ b/tests/services/llm/test_organization_config_loader.py
@@ -22,7 +22,6 @@ from services.llm.organization_config_loader import (
 
 @pytest.mark.integration
 @pytest.mark.integration
-@pytest.mark.slow
 class TestOrganizationConfig:
     """Test organization configuration model."""
 

--- a/tests/services/railway/test_index_sync.py
+++ b/tests/services/railway/test_index_sync.py
@@ -13,7 +13,6 @@ from services.railway.index_sync import (
 
 
 @pytest.mark.integration
-@pytest.mark.slow
 @pytest.mark.unit
 class TestIndexSync:
     """Test suite for index synchronization functionality."""

--- a/tests/services/test_animal_service_edge_cases.py
+++ b/tests/services/test_animal_service_edge_cases.py
@@ -29,7 +29,6 @@ class TestEscapeLikePattern:
         assert escape_like_pattern("50%_off\\deal") == "50\\%\\_off\\\\deal"
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestAnimalServiceSorting:
     def test_sort_by_name_asc(self, client):
@@ -55,7 +54,6 @@ class TestAnimalServiceSorting:
         assert created_dates == sorted(created_dates, reverse=True)
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestAnimalServiceBreedGroupFilter:
     def test_filter_by_herding_breed_group(self, client):
@@ -66,7 +64,6 @@ class TestAnimalServiceBreedGroupFilter:
         assert names == ["Border Collie", "German Shepherd"]
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestAnimalServiceAgeFilter:
     def test_filter_adult_age_category(self, client):

--- a/tests/services/test_availability_confidence_fix.py
+++ b/tests/services/test_availability_confidence_fix.py
@@ -15,7 +15,6 @@ from services.session_manager import SessionManager
 
 @pytest.mark.database
 @pytest.mark.integration
-@pytest.mark.slow
 class TestAvailabilityConfidenceFix:
     """Test the availability confidence SQL logic."""
 

--- a/tests/services/test_basescraper_image_integration.py
+++ b/tests/services/test_basescraper_image_integration.py
@@ -12,7 +12,6 @@ from scrapers.base_scraper import BaseScraper
 from services.image_processing_service import ImageProcessingService
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestBaseScraperWithImageProcessingService:
     """Test BaseScraper using injected ImageProcessingService."""

--- a/tests/services/test_basescraper_with_database_service.py
+++ b/tests/services/test_basescraper_with_database_service.py
@@ -14,7 +14,6 @@ from scrapers.base_scraper import BaseScraper
 from services.database_service import DatabaseService
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestBaseScraperWithDatabaseService:
     """Test BaseScraper using injected DatabaseService."""
@@ -139,7 +138,6 @@ class TestBaseScraperWithDatabaseService:
         assert "DatabaseService" in caplog.text
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestBaseScraperCompleteIntegration:
     """Test that all BaseScraper database methods use DatabaseService when available.

--- a/tests/services/test_breed_confidence_numeric.py
+++ b/tests/services/test_breed_confidence_numeric.py
@@ -32,7 +32,6 @@ class TestLexicalComparisonWasWrong:
         assert sorted([0.9, 0.85]) == [0.85, 0.9]
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestConfidenceWrittenAsNumber:
     def _service(self, fetchone_side_effect):

--- a/tests/services/test_database_service.py
+++ b/tests/services/test_database_service.py
@@ -51,7 +51,6 @@ class TestDatabaseServiceDirectConnection:
         )
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestDatabaseServiceWithConnectionPool:
     """Test DatabaseService using connection pool."""
@@ -221,7 +220,6 @@ class TestDatabaseServiceWithConnectionPool:
             assert db_service.conn == mock_connection
 
 
-@pytest.mark.slow
 @pytest.mark.database
 class TestDatabaseServiceRawBreedPersistence:
     """Both write paths must persist breed_raw or the original text is lost on disk."""

--- a/tests/services/test_image_deduplication.py
+++ b/tests/services/test_image_deduplication.py
@@ -10,7 +10,6 @@ from services.image_processing_service import ImageProcessingService
 
 @pytest.mark.external
 @pytest.mark.integration
-@pytest.mark.slow
 @pytest.mark.unit
 class TestImageDeduplication:
     """Test deduplication of images to avoid re-uploading existing R2 images."""

--- a/tests/services/test_progress_tracker.py
+++ b/tests/services/test_progress_tracker.py
@@ -16,7 +16,6 @@ from services.progress_tracker import LoggingLevel, ProgressTracker
 
 @pytest.mark.database
 @pytest.mark.integration
-@pytest.mark.slow
 class TestProgressTracker:
     """Test for ProgressTracker service with adaptive verbosity levels."""
 

--- a/tests/services/test_r2_service.py
+++ b/tests/services/test_r2_service.py
@@ -11,10 +11,8 @@ from botocore.exceptions import ClientError
 from utils.r2_service import R2ConfigurationError, R2Service
 
 
-@pytest.mark.slow
 @pytest.mark.integration
 @pytest.mark.external
-@pytest.mark.slow
 class TestR2ServiceConfiguration:
     """Test R2Service configuration and validation"""
 

--- a/tests/services/test_slug_service.py
+++ b/tests/services/test_slug_service.py
@@ -8,7 +8,6 @@ from api.services.slug_service import (
 
 
 @pytest.mark.integration
-@pytest.mark.slow
 class TestSanitizeForUrl:
     """Test URL sanitization function."""
 

--- a/tests/utils/test_r2_batch_upload.py
+++ b/tests/utils/test_r2_batch_upload.py
@@ -10,7 +10,6 @@ from utils.r2_service import R2Service
 
 @pytest.mark.database
 @pytest.mark.external
-@pytest.mark.slow
 @pytest.mark.integration
 class TestR2BatchUpload(unittest.TestCase):
     """Test batch upload functionality for R2 Service."""

--- a/tests/utils/test_r2_concurrent_upload.py
+++ b/tests/utils/test_r2_concurrent_upload.py
@@ -10,7 +10,6 @@ from utils.r2_service import R2Service
 
 
 @pytest.mark.external
-@pytest.mark.slow
 @pytest.mark.integration
 class TestR2ConcurrentUpload(unittest.TestCase):
     """Test concurrent upload functionality for R2 Service."""

--- a/tests/utils/test_r2_exponential_backoff.py
+++ b/tests/utils/test_r2_exponential_backoff.py
@@ -10,7 +10,6 @@ from utils.r2_service import R2Service
 
 @pytest.mark.database
 @pytest.mark.external
-@pytest.mark.slow
 @pytest.mark.integration
 class TestR2ExponentialBackoff(unittest.TestCase):
     """Test exponential backoff for R2 uploads"""

--- a/tests/utils/test_standardization.py
+++ b/tests/utils/test_standardization.py
@@ -1,7 +1,5 @@
 from datetime import datetime
 
-import pytest
-
 from utils.standardization import (
     apply_standardization,
     get_size_from_breed,
@@ -10,7 +8,6 @@ from utils.standardization import (
 )
 
 
-@pytest.mark.slow
 class TestBreedStandardization:
     def test_exact_breed_match(self):
         """Test exact matches against the breed mapping dictionary."""
@@ -66,7 +63,6 @@ class TestBreedStandardization:
         assert standardize_breed(None) == ("Unknown", "Unknown", None)
 
 
-@pytest.mark.slow
 class TestAgeStandardization:
     def test_years_format(self):
         """Test parsing of age expressed in years."""
@@ -243,7 +239,6 @@ class TestAgeStandardization:
         assert result["age_category"] == "Senior"
 
 
-@pytest.mark.slow
 class TestSizeEstimation:
     def test_size_from_known_breed(self):
         """Test size estimation from known breeds."""
@@ -264,7 +259,6 @@ class TestSizeEstimation:
         assert get_size_from_breed("Some Random Breed") is None
 
 
-@pytest.mark.slow
 class TestFullStandardization:
     def test_apply_standardization_complete_data(self):
         """Test full standardization with complete data."""

--- a/tests/utils/test_unified_standardization.py
+++ b/tests/utils/test_unified_standardization.py
@@ -3,7 +3,6 @@ import pytest
 from utils.unified_standardization import UnifiedStandardizer
 
 
-@pytest.mark.slow
 class TestUnifiedStandardizer:
     """Test suite for the unified standardization module that consolidates all breed, age, and size standardization."""
 


### PR DESCRIPTION
Step 4 of the audit. The marker that caused this whole series is gone.

## `slow` was a lie, and it worked as a quarantine

Its own definition said ">1s". Measured: the 360 tests CI deselected on it ran in **6.76 seconds combined**, slowest single test **0.14s**. Not one qualified.

Because CI filtered on it, it stopped being a description and became a quarantine — seven failing tests sat behind it for seven months. One carried the admission in a comment:

```python
@pytest.mark.slow  # Fails in CI due to database setup differences
def test_breeds_contains_known_value(self, client):
```

Removed from **48 files**. Speed is measured with `--durations`; a decorator cannot assert it and will drift the moment anything changes.

## Also removed

| marker | uses | why |
|---|---|---|
| `security` | 1 | Never selected by any runner, while `tests/security/` holds a whole directory |
| `requires_migrations` | 1 | Only ever excluded by a workflow that hadn't run since January |
| `benchmark` | 1 | **In use but never registered** — a typo behaved identically to a real marker |

`--strict-markers` and `--strict-config` are now on, so an unregistered marker is an error rather than a silent no-op.

## What remains

Markers now say what a test **needs**, so a runner can decide whether it can run one:

`database` · `browser` · `external` · `real_clock` — plus `unit` and `integration` as description.

## The dead conftest branch

```python
if markexpr and ("unit or fast" in markexpr or "unit and fast" in markexpr):
```

No runner ever passed that. `fast` stopped being a marker long ago, and `-m "unit"` does not contain the substring — so the pool initialised regardless and a bare `except` swallowed the failure after three backoff attempts with 1s+2s waits. Removed; `PYTEST_UNIT_ONLY` (set in `ci-push.yml` since #350) is the switch that works.

## Docs

`AGENTS.md`, `docs/guides/testing.md`, `docs/guides/installation.md`, `docs/technical/architecture.md`, `docs/technical/scraper-architecture.md`, `docs/guidelines/PYTHON_GUIDELINES.md` and `.github/PULL_REQUEST_TEMPLATE.md` all still told contributors to run `-m "not slow and not browser and not external"` — a tier that no longer exists. All updated.

## Verified

```
-m "not browser"   2183 passed      (what CI runs)
-m "unit"          1051 passed      (what ci-push runs)
full suite         2222 collected, 2218 passed, 0 failed
```

`--strict-markers` collects cleanly, confirming no undeclared markers remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDVRkA4nvfVFaoYvmR1M4k