### PR TITLE
fix(llm): stop handing the model the word None as source text

### DIFF
--- a/api/services/animal_service.py
+++ b/api/services/animal_service.py
@@ -526,7 +526,7 @@ class AnimalService:
             "organization_id": row.get("organization_id"),
             "external_id": row.get("external_id"),
             "language": row.get("language"),
-            "properties": row_dict.get("properties", {}),
+            "properties": row_dict.get("properties") or {},
             "created_at": row.get("created_at"),
             "updated_at": row.get("updated_at"),
             "last_scraped_at": row.get("last_scraped_at"),

--- a/services/animal_data_preparation.py
+++ b/services/animal_data_preparation.py
@@ -44,10 +44,12 @@ def prepare_animal_data(animal_data: dict[str, Any]) -> PreparedAnimalData:
     Returns:
         PreparedAnimalData with all fields ready for INSERT
     """
-    description_text = f"{animal_data.get('name', '')} {animal_data.get('breed', '')} {animal_data.get('age_text', '')}"
+    # `or ''` throughout: a NULL column arrives present-and-None, so a get()
+    # default never fires and the literal "None" would be fed to langdetect.
+    description_text = f"{animal_data.get('name') or ''} {animal_data.get('breed') or ''} {animal_data.get('age_text') or ''}"
     language = _detect_language(description_text)
 
-    standardized_breed, breed_group, size_estimate = standardize_breed(animal_data.get("breed", ""))
+    standardized_breed, breed_group, size_estimate = standardize_breed(animal_data.get("breed") or "")
 
     if "age_min_months" in animal_data and "age_max_months" in animal_data:
         age_months_min = animal_data.get("age_min_months")

--- a/services/database_service.py
+++ b/services/database_service.py
@@ -316,7 +316,7 @@ class DatabaseService:
             new_properties_json = json.dumps(sanitize_for_postgres(animal_data.get("properties")), sort_keys=True) if animal_data.get("properties") else None
 
             # Apply standardization for new values - KEEP OLD LOGIC FOR BACKWARDS COMPATIBILITY
-            new_standardized_breed, new_breed_group, size_estimate = standardize_breed(animal_data.get("breed", ""))
+            new_standardized_breed, new_breed_group, size_estimate = standardize_breed(animal_data.get("breed") or "")
 
             # Use pre-calculated age values if available
             if "age_min_months" in animal_data and "age_max_months" in animal_data:

--- a/services/llm/dog_profiler.py
+++ b/services/llm/dog_profiler.py
@@ -159,7 +159,7 @@ class DogProfilerPipeline:
             Profiler data dictionary or None if failed
         """
         dog_id = dog_data.get("id", "unknown")
-        dog_name = dog_data.get("name", "Unknown")
+        dog_name = dog_data.get("name") or "Unknown"
 
         if not is_sufficiently_grounded(dog_data):
             logger.warning(f"Skipping dog {dog_id} ({dog_name}): only {source_text_length(dog_data)} chars of source text, below the grounding floor")
@@ -217,7 +217,7 @@ class DogProfilerPipeline:
             # Add source references if not present
             if "source_references" not in profile_data:
                 profile_data["source_references"] = {
-                    "description": str(dog_data.get("properties", {}).get("description", "")),
+                    "description": str((dog_data.get("properties") or {}).get("description") or ""),
                     "personality_traits": "inferred from description",
                 }
 
@@ -236,7 +236,7 @@ class DogProfilerPipeline:
             # Add original dog data fields that aren't in the schema
             result["dog_id"] = dog_id  # Database updater expects dog_id
             result["name"] = dog_name
-            result["breed"] = dog_data.get("breed", "Mixed Breed")
+            result["breed"] = dog_data.get("breed") or "Mixed Breed"
             result["external_id"] = dog_data.get("external_id")
 
             result["quality_score"] = self._calculate_quality_score(result, dog_data)

--- a/services/llm/prompt_builder.py
+++ b/services/llm/prompt_builder.py
@@ -75,8 +75,11 @@ class PromptBuilder:
         Returns:
             Formatted prompt string
         """
-        # Extract properties as JSON string
-        properties = dog_data.get("properties", {})
+        # `or {}` rather than a get() default: every row loaded for profiling
+        # carries these keys, so a NULL column arrives present-and-None and a
+        # default never fires. Without this the model is handed the word
+        # "None" as its source material.
+        properties = dog_data.get("properties") or {}
         if isinstance(properties, dict):
             properties_str = json.dumps(properties, ensure_ascii=False, indent=2)
         else:
@@ -84,8 +87,8 @@ class PromptBuilder:
 
         # Format the extraction prompt with dog data
         prompt = self.prompt_template["extraction_prompt"].format(
-            name=dog_data.get("name", "Unknown"),
-            breed=dog_data.get("breed", "Mixed Breed"),
+            name=dog_data.get("name") or "Unknown",
+            breed=dog_data.get("breed") or "Mixed Breed",
             age_text=dog_data.get("age_text") or "Unknown age",
             properties=properties_str,
         )

--- a/services/llm_data_service.py
+++ b/services/llm_data_service.py
@@ -350,9 +350,9 @@ Make it engaging, honest, and help potential adopters connect emotionally."""
 
         user_prompt = f"""Create a profile for:
 Name: {dog_data.get("name")}
-Breed: {dog_data.get("breed", "Mixed breed")}
+Breed: {dog_data.get("breed") or "Mixed breed"}
 Age: {dog_data.get("age_text") or "Unknown"}
-Description: {dog_data.get("description", "")}"""
+Description: {dog_data.get("description") or ""}"""
 
         temperature = get_model_temperature("dog_profiler", self.config.models)
 

--- a/tests/services/llm/test_null_source_fields.py
+++ b/tests/services/llm/test_null_source_fields.py
@@ -1,0 +1,78 @@
+"""A NULL column must not reach the model as the word "None".
+
+`dict.get(key, default)` returns the default only when the key is ABSENT. Every
+row loaded by management/llm_commands.py:261 carries `breed` and `properties`
+as keys, so a NULL column arrives present-and-None and the default never fires.
+Production holds 59 animals with a NULL breed and 125 with NULL properties.
+
+Same defect class as #344: a profile written against source text that is not
+there. #349 fixed this for `age_text` in build_prompt; the two lines around it
+had it too.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from services.llm.prompt_builder import PromptBuilder
+
+TEMPLATE = {
+    "extraction_prompt": "Name: {name}\nBreed: {breed}\nAge: {age_text}\nSource:\n{properties}",
+    "system_prompt": "s",
+}
+
+
+@pytest.fixture
+def builder():
+    with patch.object(PromptBuilder, "_load_prompt_template", return_value=TEMPLATE):
+        return PromptBuilder(organization_id=1)
+
+
+@pytest.mark.unit
+class TestNullColumnsDoNotReachTheModel:
+    def test_a_null_breed_does_not_become_the_word_none(self, builder):
+        prompt = builder.build_prompt({"name": "Bella", "breed": None, "age_text": "2 years", "properties": {"description": "x"}})
+
+        assert "Breed: None" not in prompt
+        assert "Breed: Mixed Breed" in prompt
+
+    def test_null_properties_do_not_become_the_word_none(self, builder):
+        prompt = builder.build_prompt({"name": "Bella", "breed": "Lab", "age_text": "2 years", "properties": None})
+
+        assert "None" not in prompt.split("Source:")[1]
+
+    def test_a_null_name_does_not_become_the_word_none(self, builder):
+        prompt = builder.build_prompt({"name": None, "breed": "Lab", "age_text": "2 years", "properties": {}})
+
+        assert "Name: None" not in prompt
+
+    def test_real_values_are_passed_through_untouched(self, builder):
+        prompt = builder.build_prompt({"name": "Bella", "breed": "Beagle", "age_text": "3 years", "properties": {"description": "Found in Sofia"}})
+
+        assert "Breed: Beagle" in prompt
+        assert "Name: Bella" in prompt
+        assert "Found in Sofia" in prompt
+
+
+@pytest.mark.unit
+class TestNullPropertiesDoNotCrashTheProfiler:
+    """`dog_data.get("properties", {}).get(...)` raised on a NULL column.
+
+    125 animals carry NULL properties. The chained get ran whenever the model
+    omitted `source_references`, so the failure was intermittent by response
+    shape rather than by row.
+    """
+
+    def test_source_reference_extraction_survives_null_properties(self):
+        dog_data = {"id": 1, "name": "Bella", "breed": None, "properties": None}
+
+        description = str((dog_data.get("properties") or {}).get("description") or "")
+
+        assert description == ""
+
+    def test_source_reference_extraction_reads_a_real_description(self):
+        dog_data = {"id": 1, "name": "Bella", "properties": {"description": "Found in Sofia"}}
+
+        description = str((dog_data.get("properties") or {}).get("description") or "")
+
+        assert description == "Found in Sofia"


### PR DESCRIPTION
`dict.get(key, default)` fires only when the key is **absent**. `management/llm_commands.py:261` selects `breed` and `properties` with no COALESCE and no filter, so a NULL column arrives *present-and-None* and every default below it is dead code.

Found while auditing #349's `age_text` fix. That PR fixed this defect on one line; the two lines around it had it too.

## Verified against production

| column | NULL rows | of which available |
|---|---|---|
| `properties` | 125 (all santerpaws) | 61 |
| `breed` | 59 (misisrescue 28, rean 31) | — |

## What the model actually saw

```python
name=dog_data.get("name", "Unknown"),
breed=dog_data.get("breed", "Mixed Breed"),
age_text=dog_data.get("age_text") or "Unknown age",   # <- #349 fixed only this one
properties=properties_str,
```

The prompt read `Breed: None`. And since a `None` properties value is not a dict, `properties_str = str(None)` — the **entire source-material block rendered as the word "None"**. The model was asked to write a grounded profile against nothing, which is the defect #344 set out to remove.

## The crash

`dog_profiler.py:220` chained `get("properties", {}).get("description", "")` — that raises `AttributeError` on a NULL column. It only runs when the model omits `source_references`, so it failed by *response shape* rather than by row, which is why it never surfaced as a reproducible crash. `--force` re-profiles dogs that already have a profile, so all 61 rows are reachable.

## Also fixed where it changes stored data or a decision

- `animal_data_preparation.py:47` fed the literal `"None"` to langdetect, and the result is written to `animals.language`.
- `animal_data_preparation.py:50` / `database_service.py:319` passed `"None"` to `standardize_breed` as a breed string.
- `animal_service.py:529` returned `None` where the API documents an object.

Left alone deliberately: `swipe.py:314` already has `or {}`, and the `"Unknown"` fallbacks in log lines and CLI output are cosmetic.

## No backfill needed

All 125 NULL-properties rows are already profiled and none is unprofiled-and-available, so no profile has been written from a "None" prompt yet. Fixing it now is what keeps that true.

## Tests

6 new tests; 3 failed against the old code and pass against the new. Full suite **2204 passed, 0 failed**.