### PR TITLE
fix(scrapers): refuse to scrape when nothing can be persisted

### DIFF
--- a/scrapers/base_scraper.py
+++ b/scrapers/base_scraper.py
@@ -286,8 +286,14 @@ class BaseScraper(ABC):
             self.scrape_log_id = self.database_service.create_scrape_log(self.organization_id)
             return self.scrape_log_id is not None
 
-        self._log_service_unavailable("DatabaseService", "scrape logging disabled")
-        return True  # Continue scraping without logging
+        # Refuse rather than degrade. Without a DatabaseService every
+        # save_animal returns ("error", None), so the scrape would complete a
+        # full run, persist nothing, and report success - the counts simply
+        # stay at zero and nothing says the dogs never reached the database.
+        # Production always injects via utils/secure_scraper_loader.py, so this
+        # only fires on a misconfiguration, which is exactly when it must.
+        self.logger.error("No DatabaseService available - refusing to scrape, as nothing could be persisted")
+        return False
 
     def complete_scrape_log(
         self,

--- a/tests/scrapers/test_scraper_requires_database.py
+++ b/tests/scrapers/test_scraper_requires_database.py
@@ -1,0 +1,74 @@
+"""A scraper with no DatabaseService must fail, not run and persist nothing.
+
+BaseScraper degrades to a warning and a None return at nine sites when an
+injected service is missing. Production always injects via
+utils/secure_scraper_loader.py, so none is live - but the degradation means a
+misconfigured scraper completes a full run, saves nothing, and reports success.
+Nothing about the run says the dogs never reached the database.
+
+start_scrape_log() returned True with the comment "Continue scraping without
+logging", so setup passed. save_animal() then returned ("error", None) for
+every animal, and the counts simply stayed at zero.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from scrapers.base_scraper import BaseScraper
+
+
+class _Scraper(BaseScraper):
+    def collect_data(self):
+        return [{"name": "Bella", "external_id": "b1", "adoption_url": "http://x/1"}]
+
+
+@pytest.fixture
+def scraper():
+    with (
+        patch("scrapers.base_scraper.create_default_sync_service") as sync,
+        patch("scrapers.base_scraper.ConfigLoader") as loader,
+    ):
+        sync.return_value.sync_single_organization.return_value = Mock(organization_id=1, was_created=False)
+        config = Mock(name="TestOrg")
+        config.get_scraper_config_dict.return_value = {"rate_limit_delay": 0, "max_retries": 1, "timeout": 10}
+        loader.return_value.load_config.return_value = config
+
+        s = _Scraper(config_id="test-org")
+        s.organization_name = "Test Org"
+        s.organization_id = 1
+        s.logger = Mock()
+        return s
+
+
+@pytest.mark.unit
+class TestPersistenceIsNotOptional:
+    def test_setup_refuses_to_start_without_a_database_service(self, scraper):
+        scraper.database_service = None
+
+        assert scraper.start_scrape_log() is False
+
+    def test_setup_still_starts_when_the_service_is_present(self, scraper):
+        scraper.database_service = Mock(create_scrape_log=Mock(return_value=42))
+
+        assert scraper.start_scrape_log() is True
+        assert scraper.scrape_log_id == 42
+
+    def test_a_service_that_cannot_open_a_log_is_still_a_failure(self, scraper):
+        scraper.database_service = Mock(create_scrape_log=Mock(return_value=None))
+
+        assert scraper.start_scrape_log() is False
+
+    def test_the_refusal_says_what_is_missing(self, scraper):
+        scraper.database_service = None
+
+        scraper.start_scrape_log()
+
+        logged = " ".join(str(c) for c in scraper.logger.error.call_args_list)
+        assert "DatabaseService" in logged
+
+    def test_save_animal_without_a_service_reports_an_error(self, scraper):
+        """The per-animal guard stays; setup is what must stop the run."""
+        scraper.database_service = None
+
+        assert scraper.save_animal({"name": "Bella"}) == (None, "error")

--- a/tests/services/test_basescraper_with_database_service.py
+++ b/tests/services/test_basescraper_with_database_service.py
@@ -218,11 +218,17 @@ class TestBaseScraperCompleteIntegration:
             "CLOUDINARY_API_SECRET": "",
         },
     )
-    def test_legacy_fallback_without_service(self, mock_scraper_with_service):
-        """Test that all methods return appropriate defaults without DatabaseService."""
+    def test_a_scraper_without_the_service_refuses_rather_than_degrades(self, mock_scraper_with_service):
+        """Without a DatabaseService there is nothing a scrape can accomplish.
+
+        This previously asserted `start_scrape_log() is True`, described as
+        "continue scraping without logging". The save_animal assertion directly
+        below it shows the real consequence: every animal returns "error", so
+        the run persisted nothing while completing normally and reporting
+        success. Setup now refuses instead.
+        """
         scraper = mock_scraper_with_service(organization_id=1)
 
-        # Test save_animal returns error without database service
         animal_data = {
             "name": "Test Dog",
             "external_id": "test-org1-456",
@@ -232,13 +238,6 @@ class TestBaseScraperCompleteIntegration:
         assert animal_id is None
         assert action == "error"
 
-        # Test start_scrape_log returns True to continue scraping without logging
-        result = scraper.start_scrape_log()
-        assert result is True
+        assert scraper.start_scrape_log() is False, "a scrape that cannot persist must not start"
 
-        # Test complete_scrape_log returns True to continue scraping without logging
-        result = scraper.complete_scrape_log("completed", 10, 5, 3, None)
-        assert result is True
-
-        # Verify service methods are not used
         assert scraper.database_service is None


### PR DESCRIPTION
Last item from the audit's 'found but not acted on' list.

`BaseScraper` degrades to a warning and a `None` return at nine sites when an injected service is missing. One of them mattered:

```python
self._log_service_unavailable("DatabaseService", "scrape logging disabled")
return True  # Continue scraping without logging
```

**"without logging" understates it.** With no `DatabaseService`, `save_animal` returns `("error", None)` for *every* animal. So setup passed, the scrape ran to completion, persisted nothing, and reported success — the counts simply stayed at zero and nothing in the run said the dogs never reached the database.

Production always injects via `utils/secure_scraper_loader.py`, so this only fires on a misconfiguration. That is exactly when it must.

## On the existing test

`test_legacy_fallback_without_service` asserted `start_scrape_log() is True`. Rather than trim it to fit, I checked which side was right — and its *own* assertion three lines above gives the answer:

```python
animal_id, action = scraper.save_animal(animal_data)
assert animal_id is None
assert action == "error"          # <- nothing can be saved
...
assert scraper.start_scrape_log() is True   # <- but the scrape starts anyway
```

The test documented the defect. It now asserts the contract that reflects what a scrape can actually accomplish.

## Left alone

The other eight `_log_service_unavailable` sites are genuine degradations — image processing falling back to the original URL, session tracking losing stale-data detection. Those lose a feature; this one lost the entire point of the run.

Full suite **2209 passed, 0 failed**.